### PR TITLE
fix(functions): make traps set -u safe

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -62,9 +62,10 @@ lint() {
     original_dir=$(pwd)
 
     # Cleanup function
+    # Use ${var:-} for set -u safety — locals are out of scope when EXIT trap fires
     cleanup_temp_repo() {
-      cd "${original_dir}" 2>/dev/null || true
-      rm -rf "${temp_dir}"
+      cd "${original_dir:-}" 2>/dev/null || true
+      rm -rf "${temp_dir:-}"
       trap - EXIT # Unset trap
     }
     trap cleanup_temp_repo EXIT
@@ -723,8 +724,8 @@ git() {
   fi
 
   # Trap to cleanup guard and restore directory
-  # Note: cd failure in trap is silently ignored - can't do much if original dir was deleted
-  trap 'unset _GIT_WRAPPER_ACTIVE; [[ -n "${original_dir}" ]] && cd "${original_dir}" 2>/dev/null || true' RETURN
+  # Use ${var:-} for set -u safety — locals may be out of scope in inherited contexts
+  trap 'unset _GIT_WRAPPER_ACTIVE; [[ -n "${original_dir:-}" ]] && cd "${original_dir:-}" 2>/dev/null || true' RETURN
 
   # If init created a repo in a different directory, cd there first
   # This makes git rev-parse work from inside the new repo


### PR DESCRIPTION
## Summary
- Use `${var:-}` instead of `${var}` in EXIT and RETURN trap handlers in `bash/functions.sh`
- Prevents `unbound variable` errors when traps fire after local variable scope ends
- Specifically fixes the `original_dir: unbound variable` crash in scripts that inherit the `git()` wrapper via `export -f` and use `set -u`

## Context
Discovered while debugging `mac-dev-server-setup`'s `dotfiles-setup.sh` — the exported `git()` wrapper's RETURN trap fired after `main()` returned, hitting `set -u` because `original_dir` was a local in the wrapper function.

## Test plan
- [ ] Run `lint` on files outside a git repo (exercises the EXIT trap path)
- [ ] Run `git init` from a script with `set -euo pipefail` (exercises the RETURN trap path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)