### PR TITLE
fix(functions): skip pre-merge review for gh --help/-h flags

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -768,6 +768,14 @@ export -f git # Exported - overrides system git command globally
 gh() {
   local review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
 
+  # Pass help requests directly to the real gh — no review needed.
+  for arg in "$@"; do
+    if [[ "${arg}" == "--help" || "${arg}" == "-h" ]]; then
+      command gh "$@"
+      return $?
+    fi
+  done
+
   # Intercept: gh pr merge [...]
   if [[ "$1" == "pr" && "$2" == "merge" ]]; then
     if [[ -x "${review_script}" ]]; then


### PR DESCRIPTION
## Summary

- `gh()` wrapper in `bash/functions.sh` now passes `--help`/`-h` directly to `command gh`, skipping the pre-merge review entirely
- Fixes silent timeout when `gh pr merge --help` was called from within Claude Code

## The bug

```bash
# BEFORE: triggered 120s Claude CLI analysis
gh pr merge --help

# AFTER: passes straight to real gh binary
gh pr merge --help
```

The `[[ "$1" == "pr" && "$2" == "merge" ]]` condition matched ALL `gh pr merge ...` calls including `--help`. Pre-merge-review.sh then ran a full 120s Claude CLI analysis for a help request. Under the Bash tool's 120s default timeout, this caused the entire command (including preceding `echo` output) to appear silently suppressed.

## Fix

```bash
# Pass help requests directly to the real gh — no review needed.
for arg in "$@"; do
  if [[ "${arg}" == "--help" || "${arg}" == "-h" ]]; then
    command gh "$@"
    return $?
  fi
done
```

## Test plan

- [x] shellcheck clean (pre-commit hook passed)
- [x] code-reviewer: PASS
- [x] adversarial-reviewer: PASS
- [x] Companion bats tests in smartwatermelon/claude-config (test_gh_wrapper.bats): 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)