### PR TITLE
fix(functions): prevent double pre-merge review via _GH_REVIEW_DONE guard

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -770,9 +770,10 @@ gh() {
   local review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
 
   # Pass help requests directly to the real gh — no review needed.
+  # Set _GH_REVIEW_DONE so ~/.local/bin/gh wrapper also skips review.
   for arg in "$@"; do
     if [[ "${arg}" == "--help" || "${arg}" == "-h" ]]; then
-      command gh "$@"
+      _GH_REVIEW_DONE=1 command gh "$@"
       return $?
     fi
   done
@@ -788,7 +789,8 @@ gh() {
     fi
   fi
 
-  # Run the real gh command
-  command gh "$@"
+  # Run the real gh command. Set _GH_REVIEW_DONE so ~/.local/bin/gh wrapper
+  # does not run the review a second time (prevents double review).
+  _GH_REVIEW_DONE=1 command gh "$@"
 }
 export -f gh # Exported - overrides system gh command globally


### PR DESCRIPTION
## Summary

- Root cause of double review on dotfiles PR #4: `~/.local/bin/gh` is a bash script that also intercepts `gh pr merge` — when `gh()` calls `command gh`, the binary wrapper fires the review a second time
- Fix: set `_GH_REVIEW_DONE=1` inline before every `command gh` call in `gh()` so the binary wrapper skips review when already done
- Covers both the normal pr-merge path and the `--help` bypass path

## Test plan

- [ ] `bats ~/.claude/tests/test_gh_binary_wrapper.bats` — new tests pass (3/3)
- [ ] `bats ~/.claude/tests/test_gh_wrapper.bats` — existing tests still pass (4/4)
- [ ] `bats ~/.claude/tests/test_pre_merge_fetch.bats` — unrelated tests still pass (4/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)