### PR TITLE
fix(gh-wrapper): block gh api REST merge endpoint bypass

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -769,6 +769,33 @@ export -f git # Exported - overrides system git command globally
 gh() {
   local review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
 
+  # Block: gh api .../pulls/{number}/merge (REST API merge bypass)
+  # Block: gh api graphql with mergePullRequest mutation (GraphQL bypass)
+  #
+  # IMPORTANT: These checks run BEFORE the --help early-return below so that
+  # `gh api .../pulls/NNN/merge --help` cannot bypass this defense by
+  # appending --help to the command.
+  #
+  # This is the shell-wrapper layer; the Claude Code PreToolUse hook
+  # (hook-block-api-merge.sh) is the primary layer.
+  #
+  # Suffix boundary prevents false positives on paths like pulls/NNN/merge_status.
+  # If gh pr merge fails: report the failure, ask the human to merge manually.
+  if [[ "$1" == "api" ]] && printf '%s\n' "$*" | grep -qE 'pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
+    echo "[gh] BLOCKED: Direct REST API PR merge bypasses pre-merge review and merge authorization." >&2
+    echo "[gh] This endpoint skips pre-merge-review.sh and the merge-lock check." >&2
+    echo "[gh] Use 'gh pr merge <number>' instead." >&2
+    echo "[gh] If gh pr merge fails, report the failure and ask the human to merge manually." >&2
+    return 1
+  fi
+
+  if [[ "$1" == "api" ]] && printf '%s\n' "$*" | grep -qE 'graphql.*mergePullRequest[[:space:]]*\('; then
+    echo "[gh] BLOCKED: GraphQL mergePullRequest mutation bypasses pre-merge review and merge authorization." >&2
+    echo "[gh] Use 'gh pr merge <number>' instead." >&2
+    echo "[gh] If gh pr merge fails, report the failure and ask the human to merge manually." >&2
+    return 1
+  fi
+
   # Pass help requests directly to the real gh — no review needed.
   # Set _GH_REVIEW_DONE so ~/.local/bin/gh wrapper also skips review.
   for arg in "$@"; do
@@ -777,22 +804,6 @@ gh() {
       return $?
     fi
   done
-
-  # Block: gh api .../pulls/{number}/merge (REST API merge bypass)
-  #
-  # `gh api .../pulls/NNN/merge --method PUT` bypasses the gh pr merge
-  # interception below, circumventing pre-merge-review.sh and merge-lock.
-  # This block is the shell-wrapper layer of defense; the Claude Code
-  # PreToolUse hook (hook-block-api-merge.sh) is the primary layer.
-  #
-  # If gh pr merge fails: report the failure, ask the human to merge manually.
-  if [[ "$1" == "api" ]] && printf '%s\n' "$*" | grep -qE 'pulls/[0-9]+/merge'; then
-    echo "[gh] BLOCKED: Direct REST API PR merge bypasses pre-merge review and merge authorization." >&2
-    echo "[gh] This endpoint skips pre-merge-review.sh and the merge-lock check." >&2
-    echo "[gh] Use 'gh pr merge <number>' instead." >&2
-    echo "[gh] If gh pr merge fails, report the failure and ask the human to merge manually." >&2
-    return 1
-  fi
 
   # Intercept: gh pr merge [...]
   if [[ "$1" == "pr" && "$2" == "merge" ]]; then


### PR DESCRIPTION
## Summary

- Extends the `gh()` bash wrapper in `functions.sh` to also intercept `gh api .../pulls/NNN/merge` calls
- This is the **second layer** of defense; the primary layer is `hook-block-api-merge.sh` in the companion claude-config PR
- Covers direct terminal use and any context where the Claude Code PreToolUse hook isn't active

## Root cause

`gh api repos/.../pulls/NNN/merge --method PUT` skips the `gh pr merge` interception entirely (different `$1` value). Used as an emergency workaround in the PR #813 incident, then reused in v1.11.0 causing an unauthorized 9-second production merge.

## Test plan

- [x] 7 new bats tests in `~/.claude/tests/test_gh_wrapper_api_merge.bats` (in companion claude-config PR)
- [x] Full suite: 30/30 tests pass
- [x] Pre-commit: shell-lint, code-reviewer, adversarial-reviewer all pass

## Related

- Companion PR: `smartwatermelon/claude-config#59`
- v1.11.0 post-mortem: `post-mortem-release-1.11.0-unauthorized-merge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)