### PR TITLE
fix(security): parse global flags in gh() to catch merge bypass

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -805,8 +805,33 @@ gh() {
     fi
   done
 
-  # Intercept: gh pr merge [...]
-  if [[ "$1" == "pr" && "$2" == "merge" ]]; then
+  # Intercept: gh [global-flags] pr merge [...]
+  # Parse past known two-token global flags (flag + separate value) to find the
+  # actual positional subcommand. This handles both the standard form:
+  #   gh pr merge NNN
+  # and the global-flag bypass form:
+  #   gh -R owner/repo pr merge NNN
+  local _gh_sub="" _gh_subsub="" _gh_skip_next=0
+  for _gh_arg in "$@"; do
+    if [[ "${_gh_skip_next}" == "1" ]]; then
+      _gh_skip_next=0
+      continue
+    fi
+    case "${_gh_arg}" in
+      -R | --repo | --hostname | --config-dir | --token) _gh_skip_next=1 ;;
+      --*=*) ;; # --flag=value: single token, no separate value to skip
+      -*) ;;    # other single-token flags: skip
+      *)
+        if [[ -z "${_gh_sub}" ]]; then
+          _gh_sub="${_gh_arg}"
+        else
+          _gh_subsub="${_gh_arg}"
+          break
+        fi
+        ;;
+    esac
+  done
+  if [[ "${_gh_sub}" == "pr" && "${_gh_subsub}" == "merge" ]]; then
     if [[ -x "${review_script}" ]]; then
       "${review_script}" "$@" || return 1
     else


### PR DESCRIPTION
## Summary

- The `gh()` bash wrapper only checked `$1=='pr' && $2=='merge'`, so `gh -R owner/repo pr merge NNN` (global flag before subcommand) bypassed review routing entirely
- Fix: iterate over args, skipping known two-token global flags, to find the actual positional subcommand
- Companion PR: smartwatermelon/claude-config (hook + tests)

## Changes

**`bash/functions.sh`** — `gh()` wrapper:
- Replaces positional `$1`/`$2` check with a parsing loop that skips `-R`/`--repo`/`--hostname`/`--config-dir`/`--token` (and their values) before identifying the subcommand
- Same fix applies to `~/.local/bin/gh` binary wrapper (not tracked in git)

## Test plan

- [x] `bats ~/.claude/tests/test_gh_wrapper.bats` — 7/7 pass (3 new global-flag tests)
- [x] code-reviewer: PASS
- [x] adversarial-reviewer: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)