### PR TITLE
feat(pre-push): add POSTPUSH_LOOP=1 bypass in Protocol 4 checkpoint

### DIFF
--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -107,6 +107,12 @@ check_pr_review_iteration() {
       log "THE CYCLE: fix → local review → commit → push → CI → remote review → repeat"
       log ""
 
+      # Allow post-push loop to bypass interactive prompt (it manages review externally)
+      if [[ "${POSTPUSH_LOOP:-}" == "1" ]]; then
+        log "Post-push loop active — skipping interactive Protocol 4 prompt"
+        return 0
+      fi
+
       # Check for interactive terminal before prompting
       if [[ -t 0 ]]; then
         read -p "[PRE-PUSH] Local review clean? (y/N): " -n 1 -r


### PR DESCRIPTION
When the post-push monitoring loop pushes fixes autonomously, the
pre-push hook's Protocol 4 checkpoint would attempt to read from
stdin (no TTY available in the loop context). The existing non-
interactive fallback already returns 0, but this explicit bypass
makes the intent clear and logs why the prompt is being skipped.

The bypass is placed before the tty check so POSTPUSH_LOOP=1
takes precedence regardless of whether a TTY is attached.
