### PR TITLE
feat(pre-commit): add luacheck hook for Lua files

### DIFF
--- a/pre-commit/config.yaml
+++ b/pre-commit/config.yaml
@@ -61,6 +61,18 @@ repos:
         verbose: true
         args: ["--config", "~/.config/markdownlint-cli/.markdownlint.json"]
 
+  # Lua linting
+  - repo: local
+    hooks:
+      - id: luacheck
+        name: "Lua Lint (luacheck)"
+        entry: luacheck
+        language: system
+        types: [lua]
+        args: [--no-color, --ranges, --codes]
+        pass_filenames: true
+        verbose: true
+
   # Prettier formatting for JavaScript/TypeScript/JSON/CSS
   # Note: Markdown excluded - handled by markdownlint above
   - repo: local


### PR DESCRIPTION
## Summary
- Adds a local pre-commit hook that runs `luacheck` on staged `.lua` files
- Uses `--no-color`, `--ranges`, and `--codes` flags for clean, informative output
- Follows the existing `repo: local` / `language: system` pattern used by other linters

## Test plan
- [x] Verified `luacheck` is installed (`/opt/homebrew/bin/luacheck`)
- [x] Hook appeared in pre-commit run (correctly skipped when no `.lua` files staged)
- [x] Synced repo copy and live `~/.config/pre-commit/config.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)