### PR TITLE
feat(updates): run update-tools.sh after claude binary update

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -531,7 +531,23 @@ _claude_update() {
     _notif "claude update completed"
   else
     _notif "claude update failed (exit ${result})"
+    return "${result}"
   fi
+
+  # Update git-sourced Claude Code components (skills, hooks, etc.)
+  local tools_script="${HOME}/.claude/scripts/update-tools.sh"
+  if [[ -x "${tools_script}" ]]; then
+    _notif "Updating Claude Code tools..."
+    output=$("${tools_script}" 2>&1)
+    result=$?
+    echo "${output}" | _update_log
+    if [[ "${result}" -eq 0 ]]; then
+      _notif "claude tools update completed"
+    else
+      _notif "claude tools update failed (exit ${result})"
+    fi
+  fi
+
   return "${result}"
 }
 # Not exported - internal helper


### PR DESCRIPTION
## Summary
- Adds a stanza to `_claude_update()` in `bash/functions.sh` that runs `~/.claude/scripts/update-tools.sh` after a successful `claude update`
- Pulls latest for git-sourced Claude Code components (skills, hooks, agents) as part of the regular update flow
- Respects the existing `DISABLE_AUTOUPDATER` gate and logs output through `_update_log`

## Test plan
- [ ] Run `_claude_update` with `update-tools.sh` present and executable — verify it runs and logs
- [ ] Run `_claude_update` without `update-tools.sh` — verify graceful skip
- [ ] Run with `DISABLE_AUTOUPDATER=1` — verify entire function skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)