### PR TITLE
fix(lint-shell): fix .bats crash + symlink migration from ~/.config

### DIFF
--- a/git/hooks/lint-shell.sh
+++ b/git/hooks/lint-shell.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Track which files were modified and which have remaining issues
-declare -A fixed_by_shellcheck fixed_by_shfmt failed_files
+declare -A fixed_by_shellcheck=() fixed_by_shfmt=() failed_files=()
 temp_files=()
 
 # Cleanup temporary files on exit
@@ -82,9 +82,10 @@ for f in "$@"; do
           issues_remaining+="ShellCheck:\n${remaining}\n"
         fi
       else
-        # Patch failed - report original shellcheck output as issues
+        # Patch failed (e.g. issues not auto-fixable) - get human-readable output
         rm -f "${tmpfile}"
-        issues_remaining+="ShellCheck:\n${shellcheck_diff}\n"
+        remaining=$(shellcheck --severity=warning --exclude=SC2312 "${f}" 2>&1 || true)
+        issues_remaining+="ShellCheck:\n${remaining}\n"
       fi
     fi
   else
@@ -133,11 +134,11 @@ echo "----------------------------------------"
 
 # Show files fixed by each tool (deduplicated)
 all_fixed=()
-for f in "${!fixed_by_shellcheck[@]+"${!fixed_by_shellcheck[@]}"}"; do
-  [[ -n "${f}" ]] && all_fixed+=("${f} (shellcheck)")
+for f in "${!fixed_by_shellcheck[@]}"; do
+  all_fixed+=("${f} (shellcheck)")
 done
-for f in "${!fixed_by_shfmt[@]+"${!fixed_by_shfmt[@]}"}"; do
-  [[ -n "${f}" ]] && all_fixed+=("${f} (shfmt)")
+for f in "${!fixed_by_shfmt[@]}"; do
+  all_fixed+=("${f} (shfmt)")
 done
 
 if [[ ${#all_fixed[@]} -gt 0 ]]; then
@@ -147,15 +148,13 @@ fi
 
 # Check for failed files
 has_failures=false
-for f in "${!failed_files[@]+"${!failed_files[@]}"}"; do
-  if [[ -n "${f}" ]]; then
-    if ! ${has_failures}; then
-      echo "❌ Files with remaining issues:"
-      has_failures=true
-    fi
-    printf "  %s\n" "${f}"
-    printf "%b" "${failed_files[${f}]}" | sed 's/^/    /'
+for f in "${!failed_files[@]}"; do
+  if ! ${has_failures}; then
+    echo "❌ Files with remaining issues:"
+    has_failures=true
   fi
+  printf "  %s\n" "${f}"
+  printf "%b" "${failed_files[${f}]}" | sed 's/^/    /'
 done
 
 if ${has_failures}; then


### PR DESCRIPTION
## Summary

- Fixes the `invalid variable name` crash in `lint-shell.sh` when committing `.bats` files (issue #18)
- Migrates dotfiles deployment model from "repo cloned to ~/.config" to "repo at ~/Developer/dotfiles with per-file symlinks into ~/.config"
- Two-way syncs diverged files between repo and live config before migration

## Changes

**Bug fix (issue #18):**
- Initialize associative arrays explicitly (`declare -A arr=()`) for `set -u` safety
- Replace fragile `${!arr[@]+"${!arr[@]}"}` iteration with plain `${!arr[@]}`
- Re-run shellcheck in default format when `--format=diff` can't produce a patch

**Two-way sync:**
- Pull semgrep integration and `-U10` diff context from live pre-commit hook
- Pull full-diff review and project extensions from live pre-push hook
- Move bun PATH from `.bash_profile` to `path.sh` at priority 2

**Symlink migration:**
- Rewrite `install.sh` — runs from repo root, discovers files via `git ls-files`, creates per-file symlinks, `--dry-run` flag, backs up replaced files
- Update README setup instructions for new clone path
- Design and implementation plan documents

## Test plan

- [x] `.bats` file with unfixable warnings: exits 1 with readable output (no crash)
- [x] Clean `.bats` file: exits 0
- [x] `install.sh --dry-run` shows correct output, no excluded files leak
- [x] `install.sh` run: 35 symlinks created, backups in `~/.config/backup/`
- [x] Non-tracked files untouched (karabiner, gh/hosts.yml, secrets.sh)
- [x] `source ~/.bash_profile` works, bun in PATH
- [x] Git hooks fire via symlinks
- [x] Architecture review: PASS (no blocking issues)
- [x] Security audit: PASS (backup collision fix applied)

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)