### PR TITLE
fix: remove PII before making repo public

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -158,7 +158,7 @@ Check that `core.hooksPath` points to this directory:
 
 ```bash
 git config --get core.hooksPath
-# Should output: /Users/andrewrich/.config/git/hooks
+# Should output: ~/.config/git/hooks
 ```
 
 ### Pre-commit hook fails

--- a/git/config
+++ b/git/config
@@ -1,7 +1,7 @@
 # This is Git's per-user configuration file.
 # https://blog.gitbutler.com/how-git-core-devs-configure-git/
 [user]
-	email = andrew.rich@gmail.com
+	email = 676392+smartwatermelon@users.noreply.github.com
 	name = Andrew Rich
 [column]
 	ui = auto

--- a/yt-dlp/config
+++ b/yt-dlp/config
@@ -2,7 +2,6 @@
 
 # Output location
 --paths "temp:/tmp"
-# --paths "home:/Volumes/DSMedia/Media/Torrents"
 
 # Process metadata first
 --parse-metadata "title:%(title)s"


### PR DESCRIPTION
## Summary

- Replace personal email with GitHub noreply address in `git/config`
- Replace hardcoded `/Users/andrewrich` path with `~` in `git/README.md`
- Remove commented-out private volume path from `yt-dlp/config`

## Context

Pre-public security audit found these three items. No secrets or tokens were found — just PII and private paths that should be cleaned before making the repo public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)