### PR TITLE
fix(hooks): add post-commit hook to correct review log commit hash

### DIFF
--- a/git/hooks/post-commit
+++ b/git/hooks/post-commit
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =========================================================
+# POST-COMMIT — Patch review log with actual commit hash
+# =========================================================
+#
+# Pre-commit review runs before the commit object exists, so
+# run-review.sh logs the PARENT commit hash. This hook
+# overwrites the stale "commit:" line with the real hash in
+# both the per-repo and global review logs.
+#
+
+_real_hash=$(git rev-parse --short HEAD 2>/dev/null) || exit 0
+
+# Per-repo log
+_repo_log="$(git rev-parse --git-dir 2>/dev/null)/last-review-result.log"
+if [[ -f "${_repo_log}" ]]; then
+  sed -i '' "s/^commit: .*/commit: ${_real_hash}/" "${_repo_log}"
+fi
+
+# Global pointer
+_global_log="${HOME}/.claude/last-review-result.log"
+if [[ -f "${_global_log}" ]]; then
+  sed -i '' "s/^commit: .*/commit: ${_real_hash}/" "${_global_log}"
+fi


### PR DESCRIPTION
## Summary
- Adds `post-commit` hook that patches the `commit:` line in both per-repo and global review logs with the actual new commit hash
- Fixes a bug where `run-review.sh` logged the parent commit hash (because pre-commit runs before the commit object exists)
- Verified: the hook corrected its own commit hash on first run

## Test plan
- [x] shellcheck clean
- [x] `sed` pattern tested against sample review log
- [x] Hook self-verified: `commit:` field in log matches `git rev-parse --short HEAD` after commit
- [x] Both code-reviewer and adversarial-reviewer passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)