### PR TITLE
chore(hooks): move Semgrep static analysis from pre-commit to pre-push

### DIFF
--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -57,21 +57,6 @@ else
 fi
 
 # =========================================================
-# SEMGREP STATIC ANALYSIS (fetches rules from registry on first run)
-# =========================================================
-if command -v semgrep &>/dev/null; then
-  echo "[pre-commit] Running Semgrep static analysis..."
-  if ! semgrep scan --config auto --error --quiet .; then
-    echo "" >&2
-    echo "🛑 Semgrep found issues. Fix them before committing." >&2
-    echo "" >&2
-    exit 1
-  fi
-else
-  echo "[pre-commit] Semgrep not installed — skipping static analysis" >&2
-fi
-
-# =========================================================
 # AUTOMATED CODE REVIEW (runs only if pre-commit passes)
 # =========================================================
 REVIEW_SCRIPT="${HOME}/.claude/hooks/run-review.sh"

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -129,6 +129,26 @@ run_supply_chain_scan() {
 run_supply_chain_scan
 
 # =========================================================
+# SEMGREP STATIC ANALYSIS (fetches rules from registry on first run)
+# =========================================================
+run_static_analysis() {
+  if ! command -v semgrep &>/dev/null; then
+    log_warning "Semgrep not installed — skipping static analysis"
+    return 0
+  fi
+
+  log "Running Semgrep static analysis..."
+  if ! semgrep scan --config auto --error --quiet .; then
+    echo "" >&2
+    log_warning "🛑 Semgrep found issues. Fix them before pushing."
+    echo "" >&2
+    exit 1
+  fi
+  log_success "Semgrep static analysis clean"
+}
+run_static_analysis
+
+# =========================================================
 # FULL-DIFF + CODEBASE REVIEW (parallel)
 # =========================================================
 # Runs two reviews in parallel on complete main...HEAD diff:


### PR DESCRIPTION
## Summary
- Moves Semgrep static analysis scan from the `pre-commit` hook to `pre-push`, so the `commit-msg` format check runs right after the fast linters instead of after a slow full-repo scan
- Semgrep block adopts pre-push conventions: wrapped in a function, uses `log`/`log_warning`/`log_success` helpers

## Test plan
- [ ] Commit with a bad message format — should fail at `commit-msg` without waiting for Semgrep
- [ ] Push with a Semgrep finding — should block at `pre-push`
- [ ] Push clean code — Semgrep passes, reviews pass, push succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)