### PR TITLE
feat(bash): add gpush function for push-to-merge workflow

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -876,3 +876,124 @@ gh() {
   _GH_REVIEW_DONE=1 command gh "$@"
 }
 export -f gh # Exported - overrides system gh command globally
+
+# ============================================================================
+# gpush — Push, create PR, wait for CI, merge, and clean up in one command
+# ============================================================================
+# Usage: gpush [--no-merge]
+#   --no-merge  Stop after CI passes (don't authorize or merge)
+#
+# Not exported — user-facing convenience function only
+
+gpush() {
+  # Validate arguments
+  case "${1:-}" in
+    --no-merge) ;;
+    "") ;;
+    *)
+      echo "Usage: gpush [--no-merge]" >&2
+      return 1
+      ;;
+  esac
+
+  local no_merge=false
+  if [[ "${1:-}" == "--no-merge" ]]; then
+    no_merge=true
+  fi
+
+  local GREEN='\033[0;32m'
+  local RED='\033[0;31m'
+  local BLUE='\033[0;34m'
+  local NC='\033[0m'
+
+  # Step 1: Guard — refuse to run on main/master
+  local branch
+  branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+  if [[ -z "${branch}" || "${branch}" == "main" || "${branch}" == "master" ]]; then
+    echo -e "${RED}[gpush]${NC} Refusing to run on ${branch:-detached HEAD}. Create a branch first." >&2
+    return 1
+  fi
+  echo -e "${BLUE}[gpush]${NC} Branch: ${branch}"
+
+  # Step 2: Push
+  echo -e "${BLUE}[gpush]${NC} Pushing to origin..."
+  if ! git push -u origin HEAD; then
+    echo -e "${RED}[gpush]${NC} Push failed." >&2
+    return 1
+  fi
+
+  # Step 3: Create PR (or detect existing one)
+  local pr_number=""
+  local pr_output
+  echo -e "${BLUE}[gpush]${NC} Creating PR..."
+  if pr_output=$(gh pr create --fill 2>&1); then
+    # Extract PR number from URL in output (last line is typically the URL)
+    pr_number=$(echo "${pr_output}" | grep -oE '/pull/[0-9]+' | tail -1 | grep -oE '[0-9]+')
+    echo -e "${GREEN}[gpush]${NC} Created PR #${pr_number}"
+  else
+    # PR may already exist
+    if echo "${pr_output}" | grep -qi "already exists"; then
+      pr_number=$(gh pr view --json number -q .number 2>/dev/null)
+      if [[ -n "${pr_number}" ]]; then
+        echo -e "${BLUE}[gpush]${NC} PR #${pr_number} already exists, continuing"
+      fi
+    fi
+    if [[ -z "${pr_number}" ]]; then
+      echo -e "${RED}[gpush]${NC} Failed to create PR:" >&2
+      echo "${pr_output}" >&2
+      return 1
+    fi
+  fi
+
+  # Step 4: Watch CI (use gh run watch — gh pr checks fails with PAT errors)
+  echo -e "${BLUE}[gpush]${NC} Watching CI for PR #${pr_number}..."
+  if ! gh run watch --exit-status; then
+    echo -e "${RED}[gpush]${NC} CI failed. Fix and re-run gpush." >&2
+    return 1
+  fi
+  echo -e "${GREEN}[gpush]${NC} CI passed"
+
+  if [[ "${no_merge}" == true ]]; then
+    echo -e "${GREEN}[gpush]${NC} --no-merge: stopping after CI. PR #${pr_number} is ready."
+    return 0
+  fi
+
+  # Step 5: Confirm and authorize merge
+  local confirm
+  echo ""
+  read -r -p "[gpush] Merge PR #${pr_number}? [y/N] " confirm
+  if [[ ! "${confirm}" =~ ^[Yy]$ ]]; then
+    echo -e "${BLUE}[gpush]${NC} Merge cancelled. PR #${pr_number} is ready for manual merge."
+    return 0
+  fi
+
+  if ! command -v merge-lock &>/dev/null; then
+    echo -e "${RED}[gpush]${NC} merge-lock not found on PATH." >&2
+    return 1
+  fi
+  if ! merge-lock auth "${pr_number}" "gpush"; then
+    echo -e "${RED}[gpush]${NC} merge-lock authorization failed." >&2
+    return 1
+  fi
+
+  # Step 6: Merge (goes through gh wrapper → pre-merge-review.sh)
+  echo -e "${BLUE}[gpush]${NC} Merging PR #${pr_number}..."
+  if ! gh pr merge "${pr_number}" --squash --delete-branch; then
+    echo -e "${RED}[gpush]${NC} Merge failed. Check pre-merge review output above." >&2
+    return 1
+  fi
+  echo -e "${GREEN}[gpush]${NC} PR #${pr_number} merged"
+
+  # Step 7: Cleanup — handle each step independently
+  echo -e "${BLUE}[gpush]${NC} Cleaning up..."
+  if ! git switch main; then
+    echo -e "${RED}[gpush]${NC} Failed to switch to main." >&2
+    return 1
+  fi
+  if ! git pull; then
+    echo -e "${RED}[gpush]${NC} Failed to pull main. Run 'git pull' manually." >&2
+    return 1
+  fi
+  git branch -D "${branch}" 2>/dev/null || true
+  echo -e "${GREEN}[gpush]${NC} Done. Back on main."
+}

--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -929,6 +929,11 @@ gpush() {
   if pr_output=$(gh pr create --fill 2>&1); then
     # Extract PR number from URL in output (last line is typically the URL)
     pr_number=$(echo "${pr_output}" | grep -oE '/pull/[0-9]+' | tail -1 | grep -oE '[0-9]+')
+    if [[ -z "${pr_number}" ]]; then
+      echo -e "${RED}[gpush]${NC} Could not parse PR number from create output." >&2
+      echo "${pr_output}" >&2
+      return 1
+    fi
     echo -e "${GREEN}[gpush]${NC} Created PR #${pr_number}"
   else
     # PR may already exist
@@ -946,8 +951,23 @@ gpush() {
   fi
 
   # Step 4: Watch CI (use gh run watch — gh pr checks fails with PAT errors)
-  echo -e "${BLUE}[gpush]${NC} Watching CI for PR #${pr_number}..."
-  if ! gh run watch --exit-status; then
+  # Extract the specific run ID for this branch to avoid watching a stale run
+  echo -e "${BLUE}[gpush]${NC} Waiting for CI run to appear..."
+  local run_id=""
+  local attempts=0
+  while [[ -z "${run_id}" && ${attempts} -lt 10 ]]; do
+    run_id=$(gh run list --branch "${branch}" --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
+    if [[ -z "${run_id}" ]]; then
+      ((attempts += 1))
+      sleep 2
+    fi
+  done
+  if [[ -z "${run_id}" ]]; then
+    echo -e "${RED}[gpush]${NC} No CI run found after 20s. Check GitHub Actions." >&2
+    return 1
+  fi
+  echo -e "${BLUE}[gpush]${NC} Watching CI run ${run_id} for PR #${pr_number}..."
+  if ! gh run watch "${run_id}" --exit-status; then
     echo -e "${RED}[gpush]${NC} CI failed. Fix and re-run gpush." >&2
     return 1
   fi
@@ -985,15 +1005,18 @@ gpush() {
   echo -e "${GREEN}[gpush]${NC} PR #${pr_number} merged"
 
   # Step 7: Cleanup — handle each step independently
+  local default_branch
+  default_branch=$(git remote show origin 2>/dev/null | awk '/HEAD branch/ {print $NF}')
+  default_branch="${default_branch:-main}"
   echo -e "${BLUE}[gpush]${NC} Cleaning up..."
-  if ! git switch main; then
-    echo -e "${RED}[gpush]${NC} Failed to switch to main." >&2
+  if ! git switch "${default_branch}"; then
+    echo -e "${RED}[gpush]${NC} Failed to switch to ${default_branch}." >&2
     return 1
   fi
   if ! git pull; then
-    echo -e "${RED}[gpush]${NC} Failed to pull main. Run 'git pull' manually." >&2
+    echo -e "${RED}[gpush]${NC} Failed to pull ${default_branch}. Run 'git pull' manually." >&2
     return 1
   fi
   git branch -D "${branch}" 2>/dev/null || true
-  echo -e "${GREEN}[gpush]${NC} Done. Back on main."
+  echo -e "${GREEN}[gpush]${NC} Done. Back on ${default_branch}."
 }

--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -951,19 +951,21 @@ gpush() {
   fi
 
   # Step 4: Watch CI (use gh run watch — gh pr checks fails with PAT errors)
-  # Extract the specific run ID for this branch to avoid watching a stale run
-  echo -e "${BLUE}[gpush]${NC} Waiting for CI run to appear..."
+  # Anchor on the pushed commit SHA to avoid watching a stale run from a prior push
+  local head_sha
+  head_sha=$(git rev-parse HEAD)
+  echo -e "${BLUE}[gpush]${NC} Waiting for CI run on ${head_sha:0:7}..."
   local run_id=""
   local attempts=0
-  while [[ -z "${run_id}" && ${attempts} -lt 10 ]]; do
-    run_id=$(gh run list --branch "${branch}" --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
+  while [[ -z "${run_id}" && ${attempts} -lt 15 ]]; do
+    run_id=$(gh run list --branch "${branch}" --commit "${head_sha}" --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
     if [[ -z "${run_id}" ]]; then
       ((attempts += 1))
       sleep 2
     fi
   done
   if [[ -z "${run_id}" ]]; then
-    echo -e "${RED}[gpush]${NC} No CI run found after 20s. Check GitHub Actions." >&2
+    echo -e "${RED}[gpush]${NC} No CI run found for ${head_sha:0:7} after 30s. Check GitHub Actions." >&2
     return 1
   fi
   echo -e "${BLUE}[gpush]${NC} Watching CI run ${run_id} for PR #${pr_number}..."


### PR DESCRIPTION
## Summary
- Adds `gpush` function to `bash/functions.sh` that automates the full push-to-merge cycle: push, create PR, watch CI, confirm merge, authorize merge-lock, squash-merge, and clean up
- Supports `--no-merge` flag to stop after CI passes
- Uses `gh run watch` instead of `gh pr checks` (avoids PAT errors)
- Prompts for confirmation before authorizing merge-lock and merging

## Test plan
- [ ] Run `gpush` on a feature branch — full cycle works
- [ ] Run `gpush --no-merge` — stops after CI
- [ ] Run `gpush` on `main` — refuses
- [ ] Run `gpush --typo` — prints usage and exits
- [ ] Decline the merge prompt — exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)