### PR TITLE
feat(bash): add 1Password CLI integration for non-interactive auth

### DIFF
--- a/bash/1password.sh
+++ b/bash/1password.sh
@@ -17,10 +17,18 @@ _OP_KEYCHAIN_SERVICE="op-service-account-claude-automation"
 # biometric prompts in non-interactive contexts (CCCLI, MCP).
 # Guard prevents redundant Keychain lookups if already set (e.g. CI).
 if [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
-  _op_token="$(security find-generic-password \
-    -a "$USER" \
-    -s "${_OP_KEYCHAIN_SERVICE}" \
-    -w 2>/dev/null || true)"
+  # Use timeout if available to guard against Keychain hangs;
+  # $(id -un) is more robust than $USER which can be unset/spoofed.
+  _op_cmd=(security find-generic-password
+    -a "$(id -un)"
+    -s "${_OP_KEYCHAIN_SERVICE}"
+    -w)
+  if command -v timeout &>/dev/null; then
+    _op_token="$(timeout 3 "${_op_cmd[@]}" 2>/dev/null || true)"
+  else
+    _op_token="$("${_op_cmd[@]}" 2>/dev/null || true)"
+  fi
+  unset _op_cmd
 
   if [[ -n "${_op_token}" ]]; then
     export OP_SERVICE_ACCOUNT_TOKEN="${_op_token}"

--- a/bash/1password.sh
+++ b/bash/1password.sh
@@ -1,0 +1,40 @@
+# ~/.config/bash/1password.sh
+#shellcheck shell=bash
+# 1Password CLI configuration
+# Provides non-interactive authentication for CCCLI, MCP server,
+# and gh shell plugin via a service account token stored in macOS Keychain.
+
+# =========================================================
+# CONFIGURATION
+# =========================================================
+# Keychain service name for the 1Password service account token
+_OP_KEYCHAIN_SERVICE="op-service-account-claude-automation"
+
+# =========================================================
+# SERVICE ACCOUNT AUTH
+# =========================================================
+# Fetch token from Keychain; enables op CLI to run without
+# biometric prompts in non-interactive contexts (CCCLI, MCP).
+# Guard prevents redundant Keychain lookups if already set (e.g. CI).
+if [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+  _op_token="$(security find-generic-password \
+    -a "$USER" \
+    -s "${_OP_KEYCHAIN_SERVICE}" \
+    -w 2>/dev/null || true)"
+
+  if [[ -n "${_op_token}" ]]; then
+    export OP_SERVICE_ACCOUNT_TOKEN="${_op_token}"
+  fi
+  unset _op_token
+fi
+unset _OP_KEYCHAIN_SERVICE
+
+# =========================================================
+# SHELL PLUGIN
+# =========================================================
+# Injects GH_TOKEN for all gh invocations from 1Password.
+# No-op until Phase 2 (op plugin init gh) creates this file.
+if [[ -f "${HOME}/.config/op/plugins.sh" ]]; then
+  #shellcheck source=/dev/null
+  source "${HOME}/.config/op/plugins.sh"
+fi

--- a/bash/env.sh
+++ b/bash/env.sh
@@ -9,6 +9,12 @@ if [[ -f "${BASH_CONFIG_DIR}/secrets.sh" ]]; then
   source "${BASH_CONFIG_DIR}/secrets.sh"
 fi
 
+# Load 1Password CLI configuration (service account + gh shell plugin)
+if [[ -f "${BASH_CONFIG_DIR}/1password.sh" ]]; then
+  #shellcheck source=/dev/null
+  source "${BASH_CONFIG_DIR}/1password.sh"
+fi
+
 # Silence macOS Bash deprecation warning
 export BASH_SILENCE_DEPRECATION_WARNING=1
 


### PR DESCRIPTION
## Summary
- Add `bash/1password.sh` to fetch a 1Password service account token from macOS Keychain, enabling non-interactive `op` CLI auth for CCCLI and MCP servers
- Source the new file from `bash/env.sh` alongside existing `secrets.sh`
- Wire up the `gh` shell plugin source for future GH_TOKEN injection (no-op until Phase 2)

## Test plan
- [ ] Open a new shell, confirm `echo $OP_SERVICE_ACCOUNT_TOKEN` is populated (requires Keychain entry)
- [ ] Confirm `op whoami` works without biometric prompt
- [ ] Verify shell startup time is not degraded (`time bash -l -c exit`)
- [ ] Confirm no regression on existing `secrets.sh` sourcing

🤖 Generated with [Claude Code](https://claude.com/claude-code)