### PR TITLE
feat(bash): inject GH_TOKEN directly, add opp() personal-vault helper

### DIFF
--- a/bash/1password.sh
+++ b/bash/1password.sh
@@ -38,11 +38,32 @@ fi
 unset _OP_KEYCHAIN_SERVICE
 
 # =========================================================
-# SHELL PLUGIN
+# GITHUB TOKEN
 # =========================================================
-# Injects GH_TOKEN for all gh invocations from 1Password.
-# No-op until Phase 2 (op plugin init gh) creates this file.
-if [[ -f "${HOME}/.config/op/plugins.sh" ]]; then
-  #shellcheck source=/dev/null
-  source "${HOME}/.config/op/plugins.sh"
+# Fetch GH_TOKEN from 1Password at shell startup.
+# Direct injection avoids the op shell plugin alias (alias gh="op plugin run -- gh")
+# which conflicts with the gh() function wrapper in functions.sh and bypasses
+# the pre-merge review enforcement it provides.
+if [[ -z "${GH_TOKEN:-}" ]] && [[ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+  _gh_token="$(op read "op://Automation/GitHub - CCCLI/Token" 2>/dev/null || true)"
+  if [[ -n "${_gh_token}" ]]; then
+    export GH_TOKEN="${_gh_token}"
+  fi
+  unset _gh_token
 fi
+
+# =========================================================
+# PERSONAL ACCOUNT HELPER
+# =========================================================
+# Unsets the service account token and signs in interactively.
+# Required for scripts that access the Personal vault (e.g. prep-airdrop.sh).
+# Usage: opp
+opp() {
+  (
+    unset OP_SERVICE_ACCOUNT_TOKEN
+    if ! op whoami &>/dev/null; then
+      op signin
+    fi
+    op "$@"
+  )
+}

--- a/git/gitignore_global
+++ b/git/gitignore_global
@@ -1,3 +1,4 @@
 .DS_Store
 .env
 claude-secrets.md
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Replace op shell plugin sourcing with direct `op read` injection of `GH_TOKEN`. The plugin aliases `gh` to `op plugin run -- gh`, which shadows the `gh()` function wrapper in `functions.sh` and bypasses its pre-merge review enforcement.
- Add `opp()` subshell wrapper that unsets `OP_SERVICE_ACCOUNT_TOKEN` and signs in interactively, for scripts that need the Personal vault (e.g. `prep-airdrop.sh`) without side effects on the parent shell.
- Ignore `.claude/scheduled_tasks.lock` in global gitignore.

## Test plan
- [ ] Open a new shell; confirm `echo \$GH_TOKEN` is populated and `gh auth status` works
- [ ] Confirm `type gh` still resolves to the function wrapper (not an alias)
- [ ] Run `opp whoami` — should prompt interactive signin, not use the service account
- [ ] Confirm parent shell's `OP_SERVICE_ACCOUNT_TOKEN` is unchanged after `opp` exits