### PR TITLE
docs(bash): note claude-wrapper dependency for 1Password tokens

### DIFF
--- a/bash/env.sh
+++ b/bash/env.sh
@@ -9,6 +9,11 @@ if [[ -f "${BASH_CONFIG_DIR}/secrets.sh" ]]; then
   source "${BASH_CONFIG_DIR}/secrets.sh"
 fi
 
+# 1Password CLI tokens (OP_SERVICE_ACCOUNT_TOKEN, GH_TOKEN) are injected
+# exclusively by claude-wrapper at CCCLI launch. Interactive shells started
+# outside claude-wrapper will have neither token set and must run `op signin`
+# (or use `opp` from functions.sh) for 1Password CLI auth.
+
 # Silence macOS Bash deprecation warning
 export BASH_SILENCE_DEPRECATION_WARNING=1
 


### PR DESCRIPTION
## Summary
Follow-up to #46. Adds a comment in `bash/env.sh` explaining that `OP_SERVICE_ACCOUNT_TOKEN` and `GH_TOKEN` are now injected exclusively by `claude-wrapper` at CCCLI launch, and pointing users who source these dotfiles outside CCCLI at `opp`/`op signin` for manual auth.

Closes #47

## Test plan
- [ ] `source ~/.config/bash/env.sh` in a fresh shell still works (comment-only change)
- [ ] Confirm issue #47 auto-closes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)