### PR TITLE
feat(pre-push): use semgrep ci --code to match remote CI ruleset

### DIFF
--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -170,8 +170,16 @@ run_static_analysis() {
 
   log "Running Semgrep static analysis (CI-equivalent code scan)..."
   local exit_code=0
-  SEMGREP_APP_TOKEN="${token}" SEMGREP_BASELINE_REF="origin/main" \
-    semgrep ci --code --dry-run --oss-only --quiet || exit_code=$?
+  # Only set SEMGREP_BASELINE_REF when origin/main is actually fetched —
+  # fresh clones / forks using different remotes would otherwise surface a
+  # confusing "network/auth" error from the exit-2 branch below.
+  (
+    export SEMGREP_APP_TOKEN="${token}"
+    if git rev-parse --verify --quiet origin/main >/dev/null; then
+      export SEMGREP_BASELINE_REF="origin/main"
+    fi
+    semgrep ci --code --dry-run --oss-only --quiet
+  ) || exit_code=$?
 
   case ${exit_code} in
     0)

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -129,22 +129,77 @@ run_supply_chain_scan() {
 run_supply_chain_scan
 
 # =========================================================
-# SEMGREP STATIC ANALYSIS (fetches rules from registry on first run)
+# SEMGREP STATIC ANALYSIS
 # =========================================================
+# With a Semgrep token: runs `semgrep ci --code` against the connected
+# Policies (same ruleset remote CI uses) — closes the local/CI coverage gap.
+# Without a token: falls back to `--config auto` (public Registry rules only).
+#
+# --dry-run: local run; do not upload findings (real CI uploads later).
+# --oss-only: Pro Engine local binary has a version-check issue; OSS engine
+#   still runs ~2866 rules (vs ~100 with --config auto). Remove this flag
+#   once the Pro binary installs cleanly locally.
+# SEMGREP_BASELINE_REF=origin/main: diff-aware scan, matches CI PR behavior.
 run_static_analysis() {
   if ! command -v semgrep &>/dev/null; then
     log_warning "Semgrep not installed — skipping static analysis"
     return 0
   fi
 
-  log "Running Semgrep static analysis..."
-  if ! semgrep scan --config auto --error --quiet .; then
-    echo "" >&2
-    log_warning "🛑 Semgrep found issues. Fix them before pushing."
-    echo "" >&2
-    exit 1
+  # Read token safely: anchor grep, strip quotes, tolerate missing file / pipefail.
+  local token=""
+  local settings="${HOME}/.semgrep/settings.yml"
+  if [[ -f "${settings}" ]]; then
+    token=$(grep -E '^[[:space:]]*api_token:' "${settings}" 2>/dev/null \
+      | head -n1 \
+      | awk '{print $2}' \
+      | tr -d "\"'" || true)
   fi
-  log_success "Semgrep static analysis clean"
+
+  if [[ -z "${token}" ]]; then
+    log_warning "No Semgrep API token — falling back to --config auto (narrower ruleset than CI)"
+    if ! semgrep scan --config auto --error --quiet .; then
+      echo "" >&2
+      log_warning "🛑 Semgrep found issues. Fix them before pushing."
+      echo "" >&2
+      exit 1
+    fi
+    log_success "Semgrep static analysis clean"
+    return 0
+  fi
+
+  log "Running Semgrep static analysis (CI-equivalent code scan)..."
+  local exit_code=0
+  SEMGREP_APP_TOKEN="${token}" SEMGREP_BASELINE_REF="origin/main" \
+    semgrep ci --code --dry-run --oss-only --quiet || exit_code=$?
+
+  case ${exit_code} in
+    0)
+      log_success "Semgrep static analysis clean (CI-equivalent)"
+      ;;
+    1)
+      echo "" >&2
+      log_warning "🛑 Semgrep found blocking issues. Fix them before pushing."
+      echo "" >&2
+      exit 1
+      ;;
+    *)
+      echo "" >&2
+      log_warning "⚠️  Semgrep failed to complete (exit ${exit_code}) — likely network/auth/rules issue, not findings."
+      log_warning "   Diagnose: SEMGREP_APP_TOKEN=<token> semgrep ci --code --dry-run --oss-only"
+      echo "" >&2
+      if [[ -t 0 ]]; then
+        local push_anyway
+        read -t 30 -p "[PRE-PUSH] Push without code scan? (y/N): " -n 1 -r push_anyway || true
+        echo
+        if [[ ! ${push_anyway} =~ ^[Yy]$ ]]; then
+          exit 1
+        fi
+      else
+        log_warning "Non-interactive mode — continuing despite scan infra error"
+      fi
+      ;;
+  esac
 }
 run_static_analysis
 


### PR DESCRIPTION
## Summary
- Local pre-push semgrep scan was running `semgrep scan --config auto` (~100 public Registry rules). Remote CI runs `semgrep ci --code` with our connected Policies (~2866 rules), so CI kept flagging issues the local hook silently passed over.
- This swaps the local invocation to `semgrep ci --code --dry-run --oss-only` when `SEMGREP_APP_TOKEN` is present, closing the coverage gap.
- `--dry-run` keeps local runs off the Semgrep dashboard; actual CI still uploads findings.
- `--oss-only` is a temporary workaround for a local Pro Engine binary version-check failure; ~2866 OSS rules still vastly outnumber the previous `--config auto` set. Remove when the Pro binary installs cleanly.
- `SEMGREP_BASELINE_REF=origin/main` makes the scan diff-aware against main, matching CI PR behavior.

## Behavior changes
- With token: scans against connected Policies — same ruleset as CI.
- Without token: falls back to `--config auto` (previous behavior).
- Exit 1 (blocking findings) → push blocked.
- Exit 2+ (network/auth/infra) → interactive prompt to override; non-interactive continues with warning (avoids false blocks on bad Wi-Fi).

## Security / portability
- Token read is now hardened: `[[ -f ... ]]` guard, anchored `grep -E '^[[:space:]]*api_token:'`, `head -n1`, quote strip, `|| true` for pipefail tolerance.

## Test plan
- [x] Manual isolated run of `run_static_analysis` — clean on current dotfiles repo
- [x] shellcheck -S info clean
- [x] Full pre-push hook exercised on this push itself (both full-diff + codebase review passed)
- [ ] Observe next few pushes for false-positive rate vs prior baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)