### PR TITLE
fix(commit-msg): accept conventional-commits breaking-change ! syntax

### DIFF
--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -46,7 +46,7 @@ if ! echo "${FIRST_LINE}" | grep -qE "${PATTERN}"; then
   echo "🛑 COMMIT MESSAGE VALIDATION FAILED" >&2
   echo "" >&2
   echo "Commit message must follow conventional commits format:" >&2
-  echo "  <type>(<scope>): <description>" >&2
+  echo "  <type>(<scope>)!?: <description>   (scope optional; ! marks breaking change)" >&2
   echo "" >&2
   echo "Valid types:" >&2
   echo "  feat     - New feature" >&2

--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -31,8 +31,13 @@ if [[ "${FIRST_LINE}" =~ ^Merge ]]; then
 fi
 
 # Conventional commits regex pattern
-# Format: type(optional-scope): description
-PATTERN='^(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert)(\([a-z0-9-]+\))?: .{1,}'
+# Format: type(optional-scope)!?: description
+# The optional `!` marks a breaking change per the conventional-commits spec
+# (https://www.conventionalcommits.org/en/v1.0.0/#summary). Examples:
+#   feat!: drop support for Node 10        (no scope, breaking)
+#   feat(api)!: rename authenticate()      (scoped breaking)
+#   fix: resolve null-check regression     (unchanged, non-breaking)
+PATTERN='^(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert)(\([a-z0-9-]+\))?!?: .{1,}'
 
 if ! echo "${FIRST_LINE}" | grep -qE "${PATTERN}"; then
   echo "" >&2
@@ -61,6 +66,8 @@ if ! echo "${FIRST_LINE}" | grep -qE "${PATTERN}"; then
   echo "  feat(auth): add JWT token refresh" >&2
   echo "  fix: resolve memory leak in parser" >&2
   echo "  docs(api): update authentication guide" >&2
+  echo "  feat!: drop support for Node 10 (breaking change)" >&2
+  echo "  feat(api)!: rename authenticate() (scoped breaking change)" >&2
   echo "" >&2
   echo "To bypass (emergency only):" >&2
   echo "  OBTAIN EXPLICIT PERMISSION and then git commit --no-verify" >&2

--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -6,16 +6,18 @@ set -euo pipefail
 # =========================================================
 #
 # Enforces conventional commits format:
-#   <type>(<scope>): <description>
+#   <type>(<scope>)!?: <description>
 #
 # Valid types: feat, fix, docs, style, refactor, test, chore, perf, ci, build, revert
-# Scope is optional
-# Description must be present and start with lowercase
+# Scope is optional; trailing ! marks a breaking change (spec v1.0.0).
+# Description must be present and start with lowercase.
 #
 # Examples:
 #   ✅ feat(auth): add JWT token refresh
 #   ✅ fix: resolve memory leak in parser
 #   ✅ docs(api): update authentication guide
+#   ✅ feat!: drop support for Node 10 (breaking change)
+#   ✅ feat(api)!: rename authenticate() (scoped breaking change)
 #   ❌ Add new feature (missing type)
 #   ❌ FEAT: new feature (type must be lowercase)
 #


### PR DESCRIPTION
## Summary

Batch E of the local-first-review strengthening work. One-file change to `git/hooks/commit-msg` that accepts the conventional-commits v1.0.0 breaking-change `!` marker.

The current validation regex required `<type>(<scope>)?: <description>` with no room for the `!`, so legitimate breaking-change commits (`feat!:`, `feat(api)!:`) were rejected with a format-failure message. One-char regex addition plus documentation updates.

### Changes

- **Regex**: `!?` added before the colon. Accepts `feat!:`, `feat(api)!:`, `chore(deps)!:`, etc. Non-breaking forms still pass unchanged.
- **Header comment** (lines 5-20): format and examples updated to include breaking-change variants.
- **Inline pattern comment** (line 34): notes `!` semantics.
- **Error output short format** (line 49): mirrors the expanded pattern.
- **Error output detailed examples** (lines 62-70): adds two breaking-change samples.

Three commits (the regex + examples, then the two intra-file consistency cleanups flagged by the pre-push codebase reviewer as non-blocking).

Closes #74.

### Test plan

- [x] `shellcheck -S info` clean
- [x] `bash` syntax parse clean
- [x] 11 manual regex cases pass: non-breaking (3), type-only breaking (2: `feat!:`, `fix!:`), scoped breaking (2: `feat(api)!:`, `chore(deps)!:`), uppercase rejection (`FEAT!:`), missing description rejection (`feat!`, `feat!: ` trailing-space empty body), non-conventional rejection
- [x] Pre-commit code-reviewer + adversarial-reviewer PASS on all three commits
- [x] Pre-push full-diff + codebase review PASS
- [ ] CI claude-blocking-review PASS

### Context

Comes after Batch D landed in `claude-config`. This repo (`dotfiles`) stands alone — only `git/hooks/commit-msg` owns the commit-message format contract, verified via grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)