### PR TITLE
feat(pre-commit): add .ralph/pre-commit extension point

### DIFF
--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -57,6 +57,39 @@ else
 fi
 
 # =========================================================
+# PROJECT-LOCAL PRE-COMMIT EXTENSIONS
+# =========================================================
+# Repos can add a .ralph/pre-commit script for project-specific checks
+# (e.g. typecheck-affected, test-affected, custom lints) that run after
+# the global lint pass but before the expensive AI review. Symmetric
+# with .ralph/pre-push — same trust model (if you cloned the repo and
+# are committing to it, you trust its build tooling) and same +x
+# activation requirement.
+#
+# Placed here deliberately so the cheaper project-local checks fail
+# fast before the 60-120s AI review cycle spends compute on a diff
+# the project already knows is broken.
+run_project_extensions() {
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+  if [[ -z "${repo_root}" ]]; then
+    return 0
+  fi
+
+  local ext="${repo_root}/.ralph/pre-commit"
+  if [[ -x "${ext}" ]]; then
+    echo "[pre-commit] Running project-local pre-commit extension: ${ext}"
+    if ! "${ext}"; then
+      echo "" >&2
+      echo "🛑 Project pre-commit extension failed — fix before committing." >&2
+      echo "" >&2
+      exit 1
+    fi
+  fi
+}
+run_project_extensions
+
+# =========================================================
 # AUTOMATED CODE REVIEW (runs only if pre-commit passes)
 # =========================================================
 REVIEW_SCRIPT="${HOME}/.claude/hooks/run-review.sh"


### PR DESCRIPTION
## Summary

Batch F. Adds a per-repo `.ralph/pre-commit` extension point to the global pre-commit hook, symmetric with the existing `.ralph/pre-push` extension (pre-push.sh lines 418-435). Projects can now add typecheck-affected, test-affected, or custom-lint hooks without editing the global file.

### Behavior

- Script at `<repo>/.ralph/pre-commit` with executable bit set runs after the global lint pass and before the automated AI review.
- Non-zero exit blocks the commit with a clear message pointing at the script path.
- Non-executable (or missing) script is silently skipped — activation is explicit via `chmod +x`.
- Trust model is identical to `.ralph/pre-push`: cloning the repo implies trusting its build tooling.

### Placement rationale

Between the global lint tool and the AI review. Project-local checks are typically cheaper fail-fast, so putting them before the 60-120s review saves review compute on diffs the project already knows are broken.

### Test plan

- [x] `shellcheck -S info` clean (only the pre-existing SC1091 on `source "${_REPAIR_LIB}"`)
- [x] `bash` syntax parse clean
- [x] End-to-end smoke test in a scratch repo on a feature branch: executable script runs, non-zero exit blocks commit, non-executable script is skipped — 3/3
- [x] Pre-commit code-reviewer + adversarial-reviewer PASS
- [x] Pre-push full-diff + codebase review PASS
- [ ] CI claude-blocking-review PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)