### PR TITLE
refactor(hooks): move AI code review from pre-commit to commit-msg

### DIFF
--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -2,10 +2,23 @@
 set -euo pipefail
 
 # =========================================================
-# COMMIT MESSAGE VALIDATION - Conventional Commits Format
+# COMMIT MESSAGE VALIDATION + AI CODE REVIEW
 # =========================================================
 #
-# Enforces conventional commits format:
+# This hook runs two checks in sequence:
+#   1. Conventional Commits format validation on the in-progress
+#      commit message ($1).
+#   2. AI code review of the staged diff, with the proposed commit
+#      message forwarded via run-review.sh's --message-file=PATH flag
+#      so the reviewer sees both the code change and the author's
+#      stated intent.
+#
+# AI review lives here (rather than in pre-commit) because git only
+# materializes the commit message on disk by the time commit-msg fires;
+# during pre-commit, COMMIT_EDITMSG still contains the PREVIOUS commit's
+# message (per `man githooks`).
+#
+# Conventional Commits format:
 #   <type>(<scope>)!?: <description>
 #
 # Valid types: feat, fix, docs, style, refactor, test, chore, perf, ci, build, revert
@@ -86,6 +99,30 @@ if [[ ${SUBJECT_LENGTH} -gt 72 ]]; then
   echo "Consider shortening your message or moving details to the body." >&2
   echo "" >&2
   # This is a warning, not an error - don't exit 1
+fi
+
+# =========================================================
+# AUTOMATED CODE REVIEW (runs only if message validation passes)
+# =========================================================
+# Forwards the in-progress commit message file to the reviewer via
+# --message-file=PATH so the AI sees both the diff and the author's
+# stated intent. Pre-commit cannot do this — see header.
+REVIEW_SCRIPT="${HOME}/.claude/hooks/run-review.sh"
+
+if [[ -x "${REVIEW_SCRIPT}" ]]; then
+  if ! git diff --cached -U10 | "${REVIEW_SCRIPT}" --message-file="${COMMIT_MSG_FILE}"; then
+    echo "" >&2
+    echo "🛑 Commit blocked by code review." >&2
+    echo "   Address the issues above and try again." >&2
+    echo "" >&2
+    echo "   To bypass (emergency only): git commit --no-verify" >&2
+    echo "" >&2
+    exit 1
+  fi
+else
+  echo "[commit-msg] Warning: Review script not found or not executable" >&2
+  echo "[commit-msg] Expected: ${REVIEW_SCRIPT}" >&2
+  echo "[commit-msg] Skipping automated review" >&2
 fi
 
 exit 0

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -2,6 +2,19 @@
 set -euo pipefail
 
 # =========================================================
+# RESPONSIBILITY SPLIT
+# =========================================================
+# This hook runs BEFORE git materializes the proposed commit message
+# anywhere on disk (per `man githooks`), so it cannot pass the message
+# to the AI reviewer. Keep deterministic, message-independent checks
+# here: branch protection, symlink repair, linters via the pre-commit
+# framework, and project-local .ralph/pre-commit extensions.
+#
+# AI code review now lives in the commit-msg hook, which receives the
+# in-progress commit message file as $1 and forwards it to the reviewer
+# via run-review.sh's --message-file=PATH flag.
+#
+# =========================================================
 # BRANCH PROTECTION - Do not commit directly to main/master
 # =========================================================
 protected_branch_check() {
@@ -89,26 +102,7 @@ run_project_extensions() {
 }
 run_project_extensions
 
-# =========================================================
-# AUTOMATED CODE REVIEW (runs only if pre-commit passes)
-# =========================================================
-REVIEW_SCRIPT="${HOME}/.claude/hooks/run-review.sh"
-
-if [[ -x "${REVIEW_SCRIPT}" ]]; then
-  # Get staged diff and pipe to review
-  if ! git diff --cached -U10 | "${REVIEW_SCRIPT}"; then
-    echo "" >&2
-    echo "🛑 Commit blocked by code review." >&2
-    echo "   Address the issues above and try again." >&2
-    echo "" >&2
-    echo "   To bypass (emergency only): git commit --no-verify" >&2
-    echo "" >&2
-    exit 1
-  fi
-else
-  echo "[pre-commit] Warning: Review script not found or not executable" >&2
-  echo "[pre-commit] Expected: ${REVIEW_SCRIPT}" >&2
-  echo "[pre-commit] Skipping automated review" >&2
-fi
+# AI code review runs in the commit-msg hook (where the in-progress
+# commit message is available as $1) — not here.
 
 exit 0


### PR DESCRIPTION
## Summary

Coordinates with [claude-config #152](https://github.com/smartwatermelon/claude-config/pull/152), which added `--message-file=PATH` to `~/.claude/hooks/run-review.sh`. This PR moves the AI code review invocation from the `pre-commit` hook to `commit-msg` so the in-progress commit message can be forwarded to the reviewer.

**Why:** Pre-commit runs *before* git materializes the proposed commit message (per `man githooks`: "invoked before obtaining the proposed commit log message"). Empirically, `COMMIT_EDITMSG` during pre-commit always contains the *previous* commit's message, so the reviewer was getting stale context for every commit. The commit-msg hook receives the in-progress message file as `$1`, which is what the new `--message-file=PATH` flag consumes.

**Amends ec50ca6** (Dec 26, 2025), which moved review *from* commit-msg *to* pre-commit citing "commit-msg should validate message format, not code changes." Reframing: AI review needs both code and message context, so commit-msg is the right home. Pre-commit retains all deterministic, message-independent checks (linters via the pre-commit framework, branch protection, symlink repair, project-local extensions).

## Changes

- `git/hooks/pre-commit`: removed the AI review block; updated header to document the new responsibility split.
- `git/hooks/commit-msg`: added the AI review invocation after the existing format-validation success path, passing `--message-file="${COMMIT_MSG_FILE}"`; updated header.

## Test plan

- [x] `bash -n` syntax check on both hooks
- [x] `shellcheck -S info` (no new findings; pre-existing SC1091 only)
- [x] Behavioral test in fresh `/tmp` repo with `core.hooksPath` pointing at this branch — pre-commit ran framework hooks (no review), commit-msg ran format check + review with the correct message
- [x] Self-hosted: this PR's own commit went through the new hooks (both reviewers PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)