### PR TITLE
fix(pipx): set PYO3 compat flag for headroom-ai builds

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -433,7 +433,9 @@ _pipx_update() {
   _notif "Updating pipx packages..."
   echo "=== pipx update ${timestamp} ===" | _update_log
 
-  output=$(pipx upgrade-all --verbose 2>&1)
+  # headroom-ai is installed as an editable local fork with a maturin (Rust)
+  # build backend; PyO3 needs this flag to build on Python > 3.13.
+  output=$(PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 pipx upgrade-all --verbose 2>&1)
   result=$?
   echo "${output}" | _update_log
 


### PR DESCRIPTION
## Summary

- Scope `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` to the `pipx upgrade-all` command in `_pipx_update()` so maturin/PyO3 builds succeed on Python 3.14+
- headroom-ai is now installed as an editable local fork (not from PyPI), and `pipx upgrade-all` will attempt to rebuild the Rust extension

## Test plan

- [x] `_pipx_update` succeeds with editable headroom-ai install on Python 3.14
- [x] Env var does not leak into parent shell (inline prefix, not `export`)
- [x] shellcheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)