### PR TITLE
fix(brew): skip homebrew update when current user doesn't own prefix

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -318,6 +318,13 @@ SHIM
 # Update Homebrew packages
 # Package managers provide their own network error diagnostics, so no pre-check needed
 _homebrew_update() {
+  local brew_prefix
+  brew_prefix="$(brew --prefix 2>/dev/null)" || { return 0; }
+  if [[ "$(id -u)" != "$(stat -f '%u' "${brew_prefix}" 2>/dev/null)" ]]; then
+    _notif "Skipping Homebrew update: ${brew_prefix} is not owned by $(whoami)"
+    return 0
+  fi
+
   mkdir -p "${HOME}/.local/state" || return $?
 
   local timestamp output result


### PR DESCRIPTION
## Summary
- Adds an ownership guard to `_homebrew_update` that compares the current user's UID against the owner of the Homebrew prefix directory
- Uses `brew --prefix` for runtime resolution instead of hardcoding `/opt/homebrew`
- Early-exits with `return 0` so the parent `updates()` function continues normally

## Test plan
- [ ] Run `_homebrew_update` as the user who owns `/opt/homebrew` — should proceed normally
- [ ] Run `_homebrew_update` as a different user — should print skip notification and return 0
- [ ] On a system without `brew` installed — should silently return 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)