### PR TITLE
fix(hooks): skip review for WIP/fixup commits + remove claude.yml issues trigger

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,8 +11,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 
@@ -21,8 +19,7 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
     uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -45,6 +45,12 @@ if [[ "${FIRST_LINE}" =~ ^Merge ]]; then
   exit 0
 fi
 
+# Skip validation + review for WIP/fixup/squash commits (will be squashed before merge)
+if [[ "${FIRST_LINE}" =~ ^(fixup!|squash!|wip:|WIP:|wip[[:space:]]|WIP[[:space:]]) ]]; then
+  echo "ℹ️  WIP/fixup commit — skipping review" >&2
+  exit 0
+fi
+
 # Conventional commits regex pattern
 # Format: type(optional-scope)!?: description
 # The optional `!` marks a breaking change per the conventional-commits spec


### PR DESCRIPTION
## Summary

- **WIP/fixup commit skip**: Adds early exit in `commit-msg` hook for `fixup!`, `squash!`, and `wip:` prefixed commits. These are temporary commits that will be squashed before merge, so running conventional commit validation and AI code review on them wastes time and API tokens. The final squashed commit still goes through `pre-merge-review.sh`.
- **Remove `issues` trigger from `claude.yml`**: Stops the Claude Code workflow from firing on issue open/assign events. This prevents cascading spend from Ralph burndown and Dependabot creating issues that trigger Claude sessions that accomplish nothing useful.

## Motivation

Part of Anthropic spend reduction initiative. Both changes eliminate unnecessary Claude API invocations that provide no value.

## Test plan

- [ ] Verify `fixup! some message` commits skip review and validation
- [ ] Verify `wip: something` commits skip review and validation  
- [ ] Verify normal conventional commits still go through full validation + review
- [ ] Verify `claude.yml` no longer triggers on issue events (confirm by opening a test issue)