### PR TITLE
ci: add Haiku A/B test to blocking review

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -17,3 +17,11 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+  claude-review-haiku:
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.0.0
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      model: "claude-haiku-4-5-20251001"
+    secrets:
+      claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Adds an advisory Haiku review job (`claude-review-haiku`) alongside the existing blocking Sonnet review job (`claude-review`). Both jobs run in parallel on every PR using the same reusable workflow at `smartwatermelon/github-workflows@v3.0.0`.

- **Sonnet (`claude-review`)** remains the required check via branch protection -- merges are still gated on its verdict.
- **Haiku (`claude-review-haiku`)** runs as an advisory/non-blocking check. Its verdict is visible on the PR but does not block merge.

After 2+ weeks of parallel runs, we'll compare verdicts between models to evaluate whether Haiku catches the same issues at lower cost/latency, or whether Sonnet's deeper reasoning finds issues Haiku misses.

## Test plan

- [ ] Verify both jobs appear as separate checks on a test PR
- [ ] Confirm Sonnet job remains required in branch protection
- [ ] Confirm Haiku job does not block merge
- [ ] After 2 weeks, compare verdict concordance across PRs