### PR TITLE
Beacon work laptop: git identity + fresh-machine bootstrap fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
 
       - name: Decide if PR is auto-mergeable
         id: policy

--- a/git/config
+++ b/git/config
@@ -50,3 +50,5 @@
 	conflictstyle = zdiff3
 [pull]
 	rebase = true
+[includeIf "gitdir:~/Developer/beacon/"]
+	path = ~/.gitconfig-beacon

--- a/pre-commit/config.yaml
+++ b/pre-commit/config.yaml
@@ -63,17 +63,17 @@ repos:
         pass_filenames: true
         verbose: true
 
-  # Markdown linting
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+  # Markdown linting (Homebrew binary — avoids pre-commit's node-lang npm
+  # bootstrap, which breaks on npm releases that dropped --ignore-prepublish)
+  - repo: local
     hooks:
       - id: markdownlint
-        name: markdownlint (fix)
-        entry: markdownlint --fix
-        language: node
+        name: "Markdown Lint (fix)"
+        entry: bash -c 'markdownlint --fix --config "$HOME/.config/markdownlint-cli/.markdownlint.json" "$@"' --
+        language: system
         types: [markdown]
+        pass_filenames: true
         verbose: true
-        args: ["--config", "~/.config/markdownlint-cli/.markdownlint.json"]
 
   # Lua linting
   - repo: local


### PR DESCRIPTION
## Summary
- Adds a Beacon-scoped git identity (`includeIf gitdir:~/Developer/beacon/` → `andrew.rich@beacon.bio`), leaving personal identity as the default everywhere else.
- Fixes the global markdownlint pre-commit hook, which was broken on any fresh machine: `language: node` tries to `npm install` its own copy and fails on npm releases that dropped `--ignore-prepublish`. Switched to `language: system` against the Homebrew binary, matching every other linter in this config.
- Fixes two pre-existing Semgrep findings unrelated to the above (surfaced because this machine has no Semgrep API token yet, so the pre-push scan falls back to whole-tree instead of diff-aware): missing Dependabot cooldown, and `dependabot/fetch-metadata` pinned by mutable tag instead of SHA.

## Context
New work laptop for Beacon Biosignals (Senior SRE role, provisioned 2026-07-12).

## Test plan
- [x] `bash -c 'type _notif'` confirms shared functions load
- [x] Verified `andrew.rich@beacon.bio` resolves for a test repo under `~/Developer/beacon/`, personal identity elsewhere
- [x] `git commit`/`git push` succeeded cleanly through pre-commit + pre-push hooks (code-reviewer/adversarial-reviewer PASS)
- [x] Filed [#103](https://github.com/smartwatermelon/dotfiles/issues/103) for a related gap the review caught: `~/.gitconfig-beacon` itself isn't tracked/templated