### PR TITLE
Track a work-identity gitconfig template, warn if missing

### DIFF
--- a/git/gitconfig-beacon.example
+++ b/git/gitconfig-beacon.example
@@ -1,0 +1,17 @@
+# Template for a per-machine work-identity override.
+#
+# Copy this file to ~/.gitconfig-beacon and fill in your work email:
+#
+#   cp ~/Developer/dotfiles/git/gitconfig-beacon.example ~/.gitconfig-beacon
+#
+# Referenced by an includeIf block in git/config:
+#
+#   [includeIf "gitdir:~/Developer/beacon/"]
+#       path = ~/.gitconfig-beacon
+#
+# ~/.gitconfig-beacon itself is intentionally NOT tracked by this repo —
+# only this template is. install.sh warns if it's missing while
+# ~/Developer/beacon/ exists.
+
+[user]
+	email = your-work-email@example.com

--- a/install.sh
+++ b/install.sh
@@ -375,6 +375,21 @@ else
   failures+=("git-hooksPath")
 fi
 
+# Check per-machine work-identity gitconfig — only relevant if a
+# ~/Developer/beacon/ (or similar) workdir exists but its includeIf target
+# is missing, which would silently fall back to the personal git identity.
+BEACON_WORKDIR="${HOME}/Developer/beacon"
+BEACON_GITCONFIG="${HOME}/.gitconfig-beacon"
+if [[ -d "${BEACON_WORKDIR}" ]]; then
+  if [[ -f "${BEACON_GITCONFIG}" ]]; then
+    _ok "Work-identity gitconfig present: ${BEACON_GITCONFIG}"
+  else
+    _warn "Missing ${BEACON_GITCONFIG} — ${BEACON_WORKDIR} repos will silently use your personal git identity"
+    _warn "  Fix: cp ${REPO_DIR}/git/gitconfig-beacon.example ${BEACON_GITCONFIG} && edit the email"
+    failures+=("beacon-gitconfig")
+  fi
+fi
+
 # Symlink health check — verify all config symlinks resolve
 if [[ "${DRY_RUN}" == true ]]; then
   _dry "Would verify config symlink health"

--- a/install.sh
+++ b/install.sh
@@ -190,6 +190,8 @@ _is_excluded() {
     *.bats) return 0 ;;
     tests/*) return 0 ;;
     test/*) return 0 ;;
+    # Copy-and-edit templates — meant to be copied by hand, not symlinked
+    *.example) return 0 ;;
     # Other repo-level files that may be added
     Makefile) return 0 ;;
     .editorconfig) return 0 ;;


### PR DESCRIPTION
## Summary
Closes #103. The Beacon `includeIf` block added in #104 points at `~/.gitconfig-beacon`, which isn't tracked by this repo (it may hold a real work email) — on a fresh machine that file is simply absent, so git silently falls back to the personal identity for every repo under `~/Developer/beacon/`, with no warning.

- Add `git/gitconfig-beacon.example`, a tracked template to copy.
- `install.sh`'s smoke-test pass now warns (with the fix command) when `~/Developer/beacon/` exists but `~/.gitconfig-beacon` doesn't.
- Exclude `*.example` from the symlink loop — caught by pre-push review: the template would otherwise get spuriously symlinked into `~/.config/git/`.

## Test plan
- [x] Renamed the real `~/.gitconfig-beacon` temporarily, confirmed the warning fires with the correct fix command, restored it and confirmed the OK path
- [x] Confirmed dry-run no longer symlinks the `.example` template after the exclusion fix
- [x] `git commit`/`git push` succeeded through pre-commit + pre-push hooks (code-reviewer/adversarial-reviewer PASS on both commits)