### PR TITLE
fix: avoid shadowing claude binary when claude-wrapper is not installed

### DIFF
--- a/bash/aliases.sh
+++ b/bash/aliases.sh
@@ -32,8 +32,10 @@ alias gp='git pull'
 alias gc='git commit -m'
 
 # Exciting ways of launching Claude Code
-alias claude='${HOME}/.local/bin/claude-wrapper'
-alias clauded="claude --dangerously-skip-permissions"
+if [[ -f "${HOME}/.local/bin/claude-wrapper" ]]; then
+  alias claude='${HOME}/.local/bin/claude-wrapper'
+  alias clauded="claude --dangerously-skip-permissions"
+fi
 alias suclaude='${HOME}/.local/bin/claude'
 alias suclauded="suclaude --dangerously-skip-permissions"
 


### PR DESCRIPTION
## Summary
- Guard the `claude` alias on `~/.local/bin/claude-wrapper` existing, so a missing wrapper falls through to PATH instead of aliasing to a broken path
- Gate the dependent `clauded` alias the same way, since it previously referenced `claude` unconditionally and would silently invoke the system binary with an unsupported flag

## Test plan
- [x] `bash/aliases.sh` guard verified locally with wrapper absent
- [x] Pre-commit code-reviewer + adversarial-reviewer both pass
- [x] Pre-push full-diff + codebase review both pass (filed non-blocking issue #107 for a follow-up: consider the same guard for `suclaude`/`suclauded`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)