### PR TITLE
Beacon work laptop: bash bootstrap fixes + gated work env vars

### DIFF
--- a/bash/.gitignore
+++ b/bash/.gitignore
@@ -3,6 +3,9 @@
 # Sensitive files that should not be committed
 secrets.sh
 
+# Machine-local work overrides (see beacon.sh.example)
+beacon.sh
+
 # Auto-created backups
 backups/
 *.bak.*

--- a/bash/aliases.sh
+++ b/bash/aliases.sh
@@ -37,7 +37,7 @@ if [[ -f "${HOME}/.local/bin/claude-wrapper" ]]; then
   alias clauded="claude --dangerously-skip-permissions"
 else
   alias claude='${HOME}/.local/bin/claude'
-  alias clauded="suclaude --dangerously-skip-permissions"
+  alias clauded="claude --dangerously-skip-permissions"
 fi
 alias suclaude='${HOME}/.local/bin/claude'
 alias suclauded="suclaude --dangerously-skip-permissions"

--- a/bash/aliases.sh
+++ b/bash/aliases.sh
@@ -35,6 +35,9 @@ alias gc='git commit -m'
 if [[ -f "${HOME}/.local/bin/claude-wrapper" ]]; then
   alias claude='${HOME}/.local/bin/claude-wrapper'
   alias clauded="claude --dangerously-skip-permissions"
+else
+  alias claude='${HOME}/.local/bin/claude'
+  alias clauded="suclaude --dangerously-skip-permissions"
 fi
 alias suclaude='${HOME}/.local/bin/claude'
 alias suclauded="suclaude --dangerously-skip-permissions"

--- a/bash/beacon.sh.example
+++ b/bash/beacon.sh.example
@@ -1,0 +1,24 @@
+# Template for per-machine work (Beacon) environment overrides.
+#
+# Copy this file to ~/.config/bash/beacon.sh and adjust as needed:
+#
+#   cp ~/Developer/dotfiles/bash/beacon.sh.example ~/.config/bash/beacon.sh
+#
+# Referenced by an existence check in bash/env.sh:
+#
+#   if [[ -f "${BASH_CONFIG_DIR}/beacon.sh" ]]; then
+#       source "${BASH_CONFIG_DIR}/beacon.sh"
+#   fi
+#
+# ~/.config/bash/beacon.sh itself is intentionally NOT tracked by this repo —
+# only this template is. install.sh warns if it's missing while
+# ~/Developer/beacon/ exists.
+
+#shellcheck shell=bash
+
+# AWS defaults (Beacon). Leave AWS_PROFILE unset when aws-vault is managing
+# the session so it doesn't fight with AWS_VAULT-scoped credentials.
+if [[ -z "${AWS_VAULT}" ]]; then
+  export AWS_PROFILE=arich
+fi
+export AWS_DEFAULT_REGION="us-east-2"

--- a/bash/env.sh
+++ b/bash/env.sh
@@ -9,6 +9,14 @@ if [[ -f "${BASH_CONFIG_DIR}/secrets.sh" ]]; then
   source "${BASH_CONFIG_DIR}/secrets.sh"
 fi
 
+# Load work-specific (Beacon) env vars — untracked, machine-local.
+# See bash/beacon.sh.example for the template; install.sh warns if
+# ~/Developer/beacon/ exists but this file doesn't.
+if [[ -f "${BASH_CONFIG_DIR}/beacon.sh" ]]; then
+  #shellcheck source=/dev/null
+  source "${BASH_CONFIG_DIR}/beacon.sh"
+fi
+
 # 1Password CLI tokens (OP_SERVICE_ACCOUNT_TOKEN, GH_TOKEN) are injected
 # exclusively by claude-wrapper at CCCLI launch. Interactive shells started
 # outside claude-wrapper will have neither token set and must run `op signin`
@@ -159,3 +167,5 @@ export CLAUDE_CONFIG_DIR="${HOME}/.claude"
 
 # mas update disable
 export MAS_UPDATE_DISABLE=true
+
+export PATH="$HOME/.local/bin:$PATH"

--- a/bash/main.sh
+++ b/bash/main.sh
@@ -58,6 +58,11 @@ shopt -s nocaseglob
 # Correct simple directory spelling errors when using cd
 shopt -s cdspell
 
+# direnv (must load after prompt.sh, since it wraps PROMPT_COMMAND)
+if command -v direnv &>/dev/null; then
+  eval "$(direnv hook bash)"
+fi
+
 # End of custom configuration
 
 # Print startup message (comment out if not desired)

--- a/bash/path.sh
+++ b/bash/path.sh
@@ -91,6 +91,11 @@ if [[ -d "${HOME}/.bun/bin" ]]; then
   _prepend_path_once "${HOME}/.bun/bin"
 fi
 
+# asdf shims (multiple runtime version manager)
+if [[ -d "${HOME}/.asdf/shims" ]]; then
+  _prepend_path_once "${HOME}/.asdf/shims"
+fi
+
 # ============================================================================
 # STEP 3: Prepend User Binaries (Priority 1 - Highest)
 # ============================================================================

--- a/git/hooks/lint-shell.sh
+++ b/git/hooks/lint-shell.sh
@@ -95,8 +95,27 @@ for f in "$@"; do
 
   # --- shfmt ---
   if command -v shfmt >/dev/null; then
+    # shfmt only consults .editorconfig when given no formatting flags; passing
+    # -i/-ci/-bn suppresses that lookup. Search upward from the file for a
+    # .editorconfig and defer to it when present; otherwise fall back to our
+    # own defaults so repos without one keep prior behavior.
+    shfmt_flags=()
+    editorconfig_dir="$(cd "$(dirname "${f}")" && pwd)"
+    has_editorconfig=false
+    while true; do
+      if [[ -f "${editorconfig_dir}/.editorconfig" ]]; then
+        has_editorconfig=true
+        break
+      fi
+      [[ "${editorconfig_dir}" == "/" ]] && break
+      editorconfig_dir="$(dirname "${editorconfig_dir}")"
+    done
+    if ! ${has_editorconfig}; then
+      shfmt_flags=(-i 2 -ci -bn)
+    fi
+
     # Check if formatting is needed (without modifying)
-    if shfmt -d -i 2 -ci -bn "${f}" >/dev/null 2>&1; then
+    if shfmt -d "${shfmt_flags[@]}" "${f}" >/dev/null 2>&1; then
       # Already formatted correctly
       :
     else
@@ -108,7 +127,7 @@ for f in "$@"; do
       tmpfile=$(mktemp "${f}.XXXXXX")
       temp_files+=("${tmpfile}")
 
-      if shfmt -i 2 -ci -bn "${f}" >"${tmpfile}"; then
+      if shfmt "${shfmt_flags[@]}" "${f}" >"${tmpfile}"; then
         # Restore original permissions before replacing file
         chmod "${original_perms}" "${tmpfile}"
         mv "${tmpfile}" "${f}"

--- a/install.sh
+++ b/install.sh
@@ -392,6 +392,21 @@ if [[ -d "${BEACON_WORKDIR}" ]]; then
   fi
 fi
 
+# Check per-machine work (Beacon) bash env overrides — only relevant if a
+# ~/Developer/beacon/ workdir exists but env.sh's sourced target is missing,
+# which would silently skip work-only env vars (e.g. AWS_PROFILE) with no
+# warning.
+BEACON_BASHENV="${HOME}/.config/bash/beacon.sh"
+if [[ -d "${BEACON_WORKDIR}" ]]; then
+  if [[ -f "${BEACON_BASHENV}" ]]; then
+    _ok "Work bash env overrides present: ${BEACON_BASHENV}"
+  else
+    _warn "Missing ${BEACON_BASHENV} — work-only env vars (e.g. AWS_PROFILE) won't be set"
+    _warn "  Fix: cp ${REPO_DIR}/bash/beacon.sh.example ${BEACON_BASHENV} && adjust as needed"
+    failures+=("beacon-bashenv")
+  fi
+fi
+
 # Symlink health check — verify all config symlinks resolve
 if [[ "${DRY_RUN}" == true ]]; then
   _dry "Would verify config symlink health"


### PR DESCRIPTION
## Summary
- Generic fresh-machine bootstrap improvements found while setting up this Beacon work laptop (claude-wrapper alias fallback, direnv hook, asdf shims) — safe on any machine, not work-specific.
- Gate the Beacon-only AWS env vars (`AWS_PROFILE`, `AWS_DEFAULT_REGION`) behind an untracked, machine-local `~/.config/bash/beacon.sh`, mirroring the existing `gitconfig-beacon` pattern (#106): tracked `.example` template, gitignored real file, `install.sh` warns if `~/Developer/beacon/` exists but the file is missing.
- Branch also carries the earlier shfmt/editorconfig fix (`4fffe16`), which was itself surfaced by Beacon-environment specifics — hence the branch rename to describe the whole scope of work.

## Test plan
- [x] `shellcheck -S info` clean on all touched files
- [x] `shfmt -d` clean on all touched files
- [x] `install.sh --dry-run` confirms both beacon-gated checks (`gitconfig`, `bash env`) report OK
- [x] Fresh login shell verified to still source `AWS_PROFILE`/`AWS_DEFAULT_REGION` via `beacon.sh`
- [x] Both local code-reviewer + adversarial-reviewer hooks passed on both commits