### PR TITLE
fix(services): remove Headroom proxy startup

### DIFF
--- a/bash/services.sh
+++ b/bash/services.sh
@@ -1,33 +1,3 @@
 #!/usr/bin/env bash
 # Service Management
-# Handles background service lifecycle (Headroom proxy, etc.)
-# Start Headroom proxy if not already running
-# Headroom compresses Claude Code context/token usage transparently
-# Uses macOS LaunchAgent for proper service lifecycle management
-_start_headroom_proxy() {
-  # Set port with default
-  export HEADROOM_PROXY_PORT="${HEADROOM_PROXY_PORT:-8787}"
-
-  # Graceful degradation: skip if tool not installed
-  if ! command -v headroom &>/dev/null; then
-    return 0
-  fi
-
-  # Fast path: check if already running
-  if lsof -ti:"${HEADROOM_PROXY_PORT}" &>/dev/null; then
-    export ANTHROPIC_BASE_URL="http://localhost:${HEADROOM_PROXY_PORT}"
-    return 0
-  fi
-
-  # Not running - load LaunchAgent (idempotent, won't error if already loaded)
-  local plist_path="${HOME}/Library/LaunchAgents/com.headroom.proxy.plist"
-  if [[ -f "${plist_path}" ]]; then
-    launchctl bootstrap "gui/$(id -u)" "${plist_path}" 2>/dev/null || true
-  fi
-
-  # Set environment variable
-  export ANTHROPIC_BASE_URL="http://localhost:${HEADROOM_PROXY_PORT}"
-}
-
-# Start Headroom proxy
-_start_headroom_proxy
+# Handles background service lifecycle

--- a/install.sh
+++ b/install.sh
@@ -463,9 +463,8 @@ fi
 echo ""
 echo "── Manual steps (cannot be automated) ──────────────"
 echo "  1. Claude Code setup (~/.claude/ infrastructure)"
-echo "  2. Headroom LaunchAgent configuration"
-echo "  3. iTerm2 shell integration (Install Shell Integration from menu)"
-echo "  4. source ~/.bash_profile   # activate the new shell config"
+echo "  2. iTerm2 shell integration (Install Shell Integration from menu)"
+echo "  3. source ~/.bash_profile   # activate the new shell config"
 
 if [[ ${#manual[@]} -gt 0 ]]; then
   for item in "${manual[@]}"; do


### PR DESCRIPTION
## Summary
- Removes `_start_headroom_proxy()` from `bash/services.sh` — it set `ANTHROPIC_BASE_URL` to a local proxy, which shrank Claude Code's context window (1M → 200k) and disabled deferred MCP tool loading, for marginal token savings.
- Drops the now-stale "Headroom LaunchAgent configuration" manual-step line from `install.sh` and renumbers the remaining steps.

## Test plan
- [x] `shellcheck -S info` clean on both touched files (pre-existing unrelated SC2312 infos only)
- [x] Local pre-commit hook: adversarial review PASS, code-reviewer non-blocking warnings only
- [x] Local pre-push hook: full-diff review PASS, codebase review PASS
- [x] Confirmed no other repo file references `_start_headroom_proxy`, `ANTHROPIC_BASE_URL`, or `HEADROOM_PROXY_PORT`
- [x] `bash/main.sh` still sources `services.sh` safely (now a harmless stub)

https://claude.ai/code/session_01JjGcPYMsJt2TdKNNxZ96cX