### PR TITLE
feat(updates): add --continue flag to resume after a failed step

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -672,7 +672,12 @@ updates() {
   )
   local start_index=0
 
-  if [[ "${1:-}" == "--continue" ]]; then
+  if [[ -n "${1:-}" ]]; then
+    if [[ "${1}" != "--continue" ]]; then
+      _notif "Unknown option '${1}'; only --continue is supported"
+      return 1
+    fi
+
     if [[ -f "${_UPDATES_STATE_FILE}" ]]; then
       local last_failed i found=false
       last_failed=$(<"${_UPDATES_STATE_FILE}")
@@ -690,6 +695,16 @@ updates() {
       fi
     else
       _notif "No previous failure recorded; running full updates"
+    fi
+
+    # _homebrew_update defers casks to the next interactive run when the
+    # prior invocation was non-interactive (e.g. the nightly LaunchAgent).
+    # Skipping straight to a later step on --continue would silently drop
+    # that catch-up forever, so always re-run it (idempotent, cheap) unless
+    # it's already covered by the normal loop below.
+    if ((start_index > 0)); then
+      _notif "Re-running Homebrew update to pick up any casks deferred by a non-interactive run..."
+      _homebrew_update || return $?
     fi
   fi
 
@@ -721,7 +736,7 @@ allup() {
   pull-my-repos || return $?
   "${HOME}/Developer/dotfiles/install.sh" --repair || return $?
   "${HOME}/Developer/claude-config/install.sh" --repair || return $?
-  updates
+  updates "$@"
 }
 # Not exported - interactive command only
 

--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -655,19 +655,61 @@ _claude_update() {
 
 # Orchestrate all system updates
 # Each updater function is self-sufficient and creates its own log directory
+# Records the failing step to a state file so `updates --continue` can resume
+# after the user fixes the underlying problem, instead of re-running steps
+# that already succeeded (e.g. brew update/upgrade before a broken gem dir).
+_UPDATES_STATE_FILE="${HOME}/.local/state/updates.progress"
+
 updates() {
+  local -a steps=(
+    _homebrew_update
+    _softwareupdate
+    _mas_update
+    _npm_update
+    _pipx_update
+    _gem_update
+    _claude_update
+  )
+  local start_index=0
+
+  if [[ "${1:-}" == "--continue" ]]; then
+    if [[ -f "${_UPDATES_STATE_FILE}" ]]; then
+      local last_failed i found=false
+      last_failed=$(<"${_UPDATES_STATE_FILE}")
+      for i in "${!steps[@]}"; do
+        if [[ "${steps[i]}" == "${last_failed}" ]]; then
+          start_index="${i}"
+          found=true
+          break
+        fi
+      done
+      if [[ "${found}" == "true" ]]; then
+        _notif "Resuming updates from ${last_failed}..."
+      else
+        _notif "State file references unknown step '${last_failed}'; running full updates"
+      fi
+    else
+      _notif "No previous failure recorded; running full updates"
+    fi
+  fi
+
   _notif "Starting system updates..."
 
-  # Run updates in order: Homebrew first (updates other package managers)
-  # Fail fast: stop on first failure
-  _homebrew_update || return $?
-  _softwareupdate || return $?
-  _mas_update || return $?
-  _npm_update || return $?
-  _pipx_update || return $?
-  _gem_update || return $?
-  _claude_update || return $?
+  local i step result
+  for ((i = start_index; i < ${#steps[@]}; i++)); do
+    step="${steps[i]}"
+    "${step}"
+    result=$?
+    if [[ "${result}" -ne 0 ]]; then
+      if ! mkdir -p "${HOME}/.local/state" || ! echo "${step}" >"${_UPDATES_STATE_FILE}"; then
+        _notif "Warning: could not save resume state; 'updates --continue' will run from the start"
+      fi
+      _notif "updates stopped at ${step} (exit ${result}); fix the issue and run 'updates --continue'"
+      return "${result}"
+    fi
+  done
 
+  rm -f "${_UPDATES_STATE_FILE}"
   _notif "All updates completed successfully"
   return 0
 }


### PR DESCRIPTION
## Summary
- `updates` now runs its sub-updaters through an indexed loop instead of a flat `||` chain, so it can resume mid-sequence.
- On failure, the failing step name is recorded in `~/.local/state/updates.progress`.
- `updates --continue` resumes from that step (re-running it, then continuing) instead of re-running everything from `_homebrew_update` onward.
- Falls back safely (with a warning) to a full run if the state file is missing, unreadable, references an unknown step, or can't be written.
- Follow-up fix: always re-run `_homebrew_update` on `--continue` when resuming past step 0, since it defers cask upgrades to "the next interactive run" in non-interactive (nightly) mode — skipping it on resume would silently drop that catch-up forever. Also rejects unrecognized flags instead of silently running a full update.

## Test plan
- [x] `shellcheck -S info bash/functions.sh` clean
- [x] Manual simulation: stub each sub-updater, fail `_gem_update`, confirm `updates` stops and records state, confirm `updates --continue` skips the already-succeeded steps and resumes at `_gem_update`
- [x] Manual simulation: corrupt/unknown step in state file falls back to full run with a warning
- [x] Manual simulation: confirmed `_homebrew_update` re-runs on `--continue` when resuming past index 0, and unknown flags are rejected
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer), both commits: PASS
- [x] Pre-push full-diff + codebase review, both pushes: PASS
- [x] Independent 4th-round adversarial review (separate agent, fresh context): found the cask-deferral bug above, fixed and re-verified: PASS

[skip-claude-review: CLAUDE_CODE_OAUTH_TOKEN is rate-limited until ~12:50pm today (2026-07-29), so the claude-review/claude-review-haiku CI checks fail with "Verdict file not found" / no verdict rendered rather than an actual finding — confirmed via job logs. Substituted four rounds of local review (code-reviewer + adversarial-reviewer x2, full-diff/codebase reviewer x2, plus an independent adversarial-reviewer fork) covering both commits, all PASS.]