### PR TITLE
PATH structure rationalization

### DIFF
--- a/bash/env.sh
+++ b/bash/env.sh
@@ -84,7 +84,7 @@ if command -v brew &>/dev/null; then
     echo "[ERROR] brew shellenv contains suspicious patterns, refusing to eval" >&2
     echo "[ERROR] Output: ${BREW_SHELLENV}" >&2
   else
-    eval "${BREW_SHELLENV}"
+    eval "$(grep -vE '^export (PATH|MANPATH|INFOPATH)=' <<<"${BREW_SHELLENV}")"
   fi
   if [[ $(type -t _profile_time) == "function" ]] && [[ "$-" == *i* ]]; then
     _pf_end=$(date +%s.%N)
@@ -167,5 +167,3 @@ export CLAUDE_CONFIG_DIR="${HOME}/.claude"
 
 # mas update disable
 export MAS_UPDATE_DISABLE=true
-
-export PATH="$HOME/.local/bin:$PATH"

--- a/bash/main.sh
+++ b/bash/main.sh
@@ -11,15 +11,14 @@ if [[ -f "${BASH_CONFIG_DIR}/functions.sh" ]]; then
 fi
 
 # Load environment variables (depends on functions only)
-# NOTE: env.sh runs 'brew shellenv' which modifies PATH. Must load BEFORE
-# path.sh so that path.sh can apply the correct priority ordering on top.
+# NOTE: env.sh no longer touches PATH — it filters PATH/MANPATH/INFOPATH
+# out of the brew shellenv eval. path.sh is the sole PATH owner and does
+# not depend on load order relative to env.sh.
 if [[ -f "${BASH_CONFIG_DIR}/env.sh" ]]; then
   source "${BASH_CONFIG_DIR}/env.sh"
 fi
 
-# Load PATH configuration (depends on functions and env)
-# Runs AFTER env.sh to override brew shellenv's PATH ordering
-# with user-preferred priorities (~/.local/bin first)
+# Load PATH configuration (depends on functions only)
 if [[ -f "${BASH_CONFIG_DIR}/path.sh" ]]; then
   source "${BASH_CONFIG_DIR}/path.sh"
 fi

--- a/bash/path.sh
+++ b/bash/path.sh
@@ -1,20 +1,11 @@
 # ~/.config/bash/path.sh
 #shellcheck shell=bash
-# Consolidated PATH management
+# Consolidated PATH management — this file is the ONLY place PATH priority
+# is decided. env.sh does not touch PATH.
 #
-# PATH Search Order (left-to-right, first match wins):
-# 1. User binaries (highest priority) - ~/.local/bin, maestro
-# 2. Language-specific tools - Ruby, Gem executables
-# 3. Homebrew system tools - sbin
-# 4. System defaults - /usr/local/bin, /usr/bin, /bin, /usr/sbin, /sbin
-# 5. Android SDK tools (lowest priority) - emulator, platform-tools
-#
-# Prepending adds to the BEGINNING (higher priority, searched first)
-# Appending adds to the END (lower priority, searched last)
-
-# ============================================================================
-# HELPER FUNCTIONS
-# ============================================================================
+# _path_tiers below is the final PATH order, highest priority first.
+# Read top-to-bottom: that IS the resulting search order. No mental
+# simulation of prepend calls required.
 
 # Prepend to PATH, ensuring it's at the front (moves existing entry if needed)
 # macOS path_helper pre-populates PATH from /etc/paths.d, often placing user
@@ -23,7 +14,6 @@ _prepend_path_once() {
   local dir="$1"
   [[ -d "${dir}" ]] || return 0
 
-  # Remove existing entry (if any) before prepending
   if [[ "${PATH}" == "${dir}" ]]; then
     export PATH="${dir}"
     return 0
@@ -44,30 +34,13 @@ _append_path_once() {
 }
 
 # ============================================================================
-# PREPEND ORDER (reverse of priority - lowest priority prepended first)
-# ============================================================================
-# When prepending to PATH, the LAST item prepended has HIGHEST priority.
-# Therefore, we must prepend in REVERSE order of desired priority.
-
-# ============================================================================
-# STEP 1: Prepend Homebrew System Tools (Priority 3 - Lower)
+# EXPLICIT PATH ORDER — highest priority first
 # ============================================================================
 
-# Homebrew sbin (for system tools like nginx, unbound, postgresql)
-# Note: brew shellenv may already add this via path_helper
 HOMEBREW_ROOT=$(_get_homebrew_root)
-_prepend_path_once "${HOMEBREW_ROOT}/sbin"
 
-# ============================================================================
-# STEP 2: Prepend Language-Specific Tools (Priority 2 - Medium)
-# ============================================================================
-
-# Ruby and Gem executables (only if Homebrew Ruby is installed)
+GEM_EXE_DIR=""
 if command -v ruby &>/dev/null; then
-  # Ruby bin directory (prepended first, so lower priority than gem executables)
-  _prepend_path_once "${HOMEBREW_ROOT}/opt/ruby/bin"
-
-  # Gem executables (prepended last, so higher priority than ruby bin)
   if [[ $(type -t _profile_time) == "function" ]] && [[ "$-" == *i* ]]; then
     _pf_start=$(date +%s.%N)
   fi
@@ -80,38 +53,44 @@ if command -v ruby &>/dev/null; then
     fi
     unset _pf_start _pf_end _pf_duration
   fi
-  _prepend_path_once "${GEM_EXE_DIR}"
-
-  # Cleanup temporary variable
-  unset GEM_EXE_DIR
 fi
 
-# Bun JavaScript runtime
-if [[ -d "${HOME}/.bun/bin" ]]; then
-  _prepend_path_once "${HOME}/.bun/bin"
-fi
+# Written highest-priority-first. The loop below does a single forward
+# pass, appending each existing directory to a new prefix in this exact
+# order, then puts that prefix in front of whatever's left of the old
+# PATH. Array order above IS the resulting PATH order — read top to
+# bottom, no need to simulate anything.
+_path_tiers=(
+  "${HOME}/.local/bin"
+  "${GEM_EXE_DIR}"
+  "${HOME}/.bun/bin"
+  "${HOME}/.asdf/shims"
+  "${HOMEBREW_ROOT}/opt/ruby/bin"
+  "${HOMEBREW_ROOT}/bin"
+  "${HOMEBREW_ROOT}/sbin"
+)
 
-# asdf shims (multiple runtime version manager)
-if [[ -d "${HOME}/.asdf/shims" ]]; then
-  _prepend_path_once "${HOME}/.asdf/shims"
-fi
+_new_path=""
+for _dir in "${_path_tiers[@]}"; do
+  [[ -n "${_dir}" && -d "${_dir}" ]] || continue
+  # Strip ALL existing occurrences first so it isn't duplicated below.
+  # Looped (not a single pass) so 3+ consecutive duplicate entries are
+  # fully collapsed, not just reduced by one.
+  while [[ ":${PATH}:" == *":${_dir}:"* ]]; do
+    PATH="${PATH//:${_dir}:/:}"
+    PATH="${PATH/#${_dir}:/}"
+    PATH="${PATH/%:${_dir}/}"
+    if [[ "${PATH}" == "${_dir}" ]]; then
+      export PATH=""
+    fi
+  done
+  _new_path="${_new_path:+${_new_path}:}${_dir}"
+done
+export PATH="${_new_path}${_new_path:+:}${PATH}"
+unset _path_tiers _dir _new_path GEM_EXE_DIR
 
 # ============================================================================
-# STEP 3: Prepend User Binaries (Priority 1 - Highest)
-# ============================================================================
-
-# User local binaries (prepended LAST, so HIGHEST priority)
-# Note: Maestro is symlinked from ~/.maestro/bin/maestro to ~/.local/bin/maestro
-_prepend_path_once "${HOME}/.local/bin"
-
-# ============================================================================
-# PRIORITY 4: System Defaults
-# ============================================================================
-# Already in PATH from system login (/usr/local/bin, /usr/bin, /bin, etc.)
-# No modifications needed
-
-# ============================================================================
-# PRIORITY 5: Android SDK Tools (Append - Lowest Priority)
+# LOWEST PRIORITY — appended, not prepended
 # ============================================================================
 
 # Android SDK (only if installed)

--- a/bash/path.sh
+++ b/bash/path.sh
@@ -10,6 +10,12 @@
 # Prepend to PATH, ensuring it's at the front (moves existing entry if needed)
 # macOS path_helper pre-populates PATH from /etc/paths.d, often placing user
 # directories after system ones. This function corrects that ordering.
+#
+# Not called by the tier construction below (that builds PATH directly via
+# _path_tiers so the whole order is visible in one place, not accumulated
+# via repeated prepend calls). Kept available for one-off/interactive use
+# (e.g. a tool installer script that needs to prepend its own bin dir after
+# path.sh has already run).
 _prepend_path_once() {
   local dir="$1"
   [[ -d "${dir}" ]] || return 0
@@ -86,7 +92,7 @@ for _dir in "${_path_tiers[@]}"; do
   done
   _new_path="${_new_path:+${_new_path}:}${_dir}"
 done
-export PATH="${_new_path}${_new_path:+:}${PATH}"
+export PATH="${_new_path}${_new_path:+${PATH:+:}}${PATH}"
 unset _path_tiers _dir _new_path GEM_EXE_DIR
 
 # ============================================================================

--- a/bash/tests/test-path-order.sh
+++ b/bash/tests/test-path-order.sh
@@ -17,7 +17,8 @@ export HOME="/tmp/path-order-test-home-$$"
 mkdir -p "${HOME}/.local/bin" "${HOME}/.bun/bin"
 trap 'rm -rf "${HOME}"' EXIT
 
-# functions.sh defines _get_homebrew_root, _prepend_path_once, etc.
+# functions.sh defines _get_homebrew_root, etc. (_prepend_path_once and
+# _append_path_once are defined in path.sh itself, sourced below.)
 #shellcheck source=/dev/null
 source "${BASH_CONFIG_DIR}/functions.sh"
 
@@ -77,5 +78,63 @@ case ":${PATH}:" in
     echo "PASS: no empty PATH segments"
     ;;
 esac
+
+# Run path.sh in a fresh subshell with a given starting PATH, printing the
+# resulting PATH. Used by the two regression checks below, each of which
+# needs its own starting PATH rather than the one already built up above.
+_run_with_path() {
+  local starting_path="$1"
+  (
+    #shellcheck source=/dev/null
+    source "${BASH_CONFIG_DIR}/functions.sh"
+    export PATH="${starting_path}"
+    #shellcheck source=/dev/null
+    source "${BASH_CONFIG_DIR}/path.sh"
+    printf '%s' "${PATH}"
+  )
+}
+
+assert_no_stray_colons() {
+  local label="$1" result_path="$2"
+  local ok=1
+  [[ "${result_path}" == :* ]] && ok=0
+  [[ "${result_path}" == *: ]] && ok=0
+  [[ "${result_path}" == *"::"* ]] && ok=0
+  if [[ "${ok}" -eq 1 ]]; then
+    echo "PASS: ${label} (no leading/trailing/double colon): ${result_path}"
+  else
+    echo "FAIL: ${label} — stray colon in PATH: ${result_path}"
+    fail=1
+  fi
+}
+
+# Regression: when every existing PATH entry is itself tier-managed (i.e.
+# the "remainder" left after stripping tiers is fully consumed), the final
+# assembly must not leave a trailing ":" — a trailing colon is read by
+# bash/POSIX as "include the current directory," a PATH-injection risk.
+homebrew_root="$(_get_homebrew_root)"
+if [[ -d "${homebrew_root}/bin" ]]; then
+  fully_consumed_path="${HOME}/.local/bin:${homebrew_root}/bin"
+  result="$(_run_with_path "${fully_consumed_path}")"
+  assert_no_stray_colons "fully-consumed remainder" "${result}"
+else
+  echo "SKIP: Homebrew not installed at ${homebrew_root}; skipping trailing-colon regression check"
+fi
+
+# Regression: a duplicate tier entry already present (twice) in the
+# starting PATH must not survive as a duplicate in the result.
+dup_start_path="${HOME}/.local/bin:${HOME}/.local/bin:/usr/bin"
+dup_result="$(_run_with_path "${dup_start_path}")"
+dup_count=0
+IFS=':' read -ra dup_parts <<<"${dup_result}"
+for p in "${dup_parts[@]}"; do
+  [[ "${p}" == "${HOME}/.local/bin" ]] && ((dup_count += 1))
+done
+if [[ "${dup_count}" -eq 1 ]]; then
+  echo "PASS: duplicate starting-PATH entry collapsed to one occurrence"
+else
+  echo "FAIL: expected exactly 1 occurrence of '${HOME}/.local/bin', found ${dup_count}: ${dup_result}"
+  fail=1
+fi
 
 exit "${fail}"

--- a/bash/tests/test-path-order.sh
+++ b/bash/tests/test-path-order.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#shellcheck shell=bash
+# Standalone verification for bash/path.sh PATH ordering.
+# Run directly: bash bash/tests/test-path-order.sh
+set -euo pipefail
+
+# Avoid CDPATH causing `cd` to echo the resolved directory to stdout, which
+# would corrupt the REPO_ROOT command substitution below.
+unset CDPATH
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export BASH_CONFIG_DIR="${REPO_ROOT}/bash"
+
+# Isolate from the real environment so the test is deterministic regardless
+# of what's actually installed on the machine running it.
+export HOME="/tmp/path-order-test-home-$$"
+mkdir -p "${HOME}/.local/bin" "${HOME}/.bun/bin"
+trap 'rm -rf "${HOME}"' EXIT
+
+# functions.sh defines _get_homebrew_root, _prepend_path_once, etc.
+#shellcheck source=/dev/null
+source "${BASH_CONFIG_DIR}/functions.sh"
+
+export PATH="/usr/bin:/bin"
+#shellcheck source=/dev/null
+source "${BASH_CONFIG_DIR}/path.sh"
+
+fail=0
+assert_before() {
+  local first="$1" second="$2"
+  local first_idx second_idx idx=0
+  first_idx=-1
+  second_idx=-1
+  IFS=':' read -ra parts <<<"${PATH}"
+  for p in "${parts[@]}"; do
+    [[ "${p}" == "${first}" ]] && first_idx=${idx}
+    [[ "${p}" == "${second}" ]] && second_idx=${idx}
+    ((idx += 1))
+  done
+  if [[ ${first_idx} -eq -1 || ${second_idx} -eq -1 ]]; then
+    echo "FAIL: expected both '${first}' and '${second}' in PATH: ${PATH}"
+    fail=1
+  elif [[ ${first_idx} -ge ${second_idx} ]]; then
+    echo "FAIL: expected '${first}' before '${second}' in PATH: ${PATH}"
+    fail=1
+  else
+    echo "PASS: '${first}' before '${second}'"
+  fi
+}
+
+assert_before "${HOME}/.local/bin" "${HOME}/.bun/bin"
+
+# Homebrew-dependent assertions: this is a personal, single-machine dotfiles
+# repo, but skip gracefully (instead of failing) on a machine where Homebrew
+# isn't installed at all, rather than asserting on a directory that can't
+# exist.
+homebrew_root="$(_get_homebrew_root)"
+if [[ -d "${homebrew_root}/bin" ]]; then
+  assert_before "${HOME}/.bun/bin" "${homebrew_root}/bin"
+  assert_before "${homebrew_root}/bin" "/usr/bin"
+else
+  echo "SKIP: Homebrew not installed at ${homebrew_root}; skipping Homebrew-bin ordering checks"
+fi
+
+# Structural sanity check: the tier array in path.sh always contains
+# GEM_EXE_DIR as an element, which is "" whenever ruby isn't resolvable on
+# the (intentionally minimal) PATH this test sources path.sh with. Confirm
+# that an empty tier doesn't leak into PATH as an empty segment (leading,
+# trailing, or doubled colon) -- that's the structural risk of the "always
+# include GEM_EXE_DIR in the array" approach.
+case ":${PATH}:" in
+  *"::"*)
+    echo "FAIL: PATH contains an empty segment (likely from an unset tier): ${PATH}"
+    fail=1
+    ;;
+  *)
+    echo "PASS: no empty PATH segments"
+    ;;
+esac
+
+exit "${fail}"

--- a/docs/plans/2026-07-29-path-rationalization-design.md
+++ b/docs/plans/2026-07-29-path-rationalization-design.md
@@ -1,0 +1,91 @@
+# PATH structure rationalization
+
+## Problem
+
+Investigating a `brew doctor` PATH-shadowing warning surfaced three separate issues:
+
+1. **Two files share PATH responsibility.** `env.sh` runs `brew shellenv` (which
+   mutates PATH) and `path.sh` re-layers priority on top via prepend/append
+   helpers. Reasoning about final PATH order requires reading both files plus
+   knowing `brew shellenv`'s behavior.
+2. **Implicit ordering.** `path.sh`'s "prepend in reverse priority order"
+   comment-documented convention means the final PATH order isn't visible in
+   one place — it must be mentally simulated by reading prepend calls
+   bottom-to-top.
+3. **Fragile dependency on `brew shellenv` succeeding.** If `brew shellenv`
+   times out or fails (observed once in `~/.local/state/updates.err`:
+   `brew shellenv timed out after 5s, skipping Homebrew setup`), `env.sh`
+   skips its whole Homebrew PATH block, and `path.sh` never prepends
+   `${HOMEBREW_ROOT}/bin` (only `sbin`) — so `/opt/homebrew/bin` stays wherever
+   macOS's `path_helper` put it (after `/usr/bin`), for the whole shell
+   session, with no fallback.
+
+Separately, the nightly `com.andrewrich.updates` LaunchAgent hardcodes
+`/bin/bash` (macOS system bash 3.2) in `ProgramArguments`, an absolute path
+that bypasses PATH resolution entirely. The interactive login shell is
+unaffected (`UserShell` is `/opt/homebrew/bin/bash` 5.3.15, invoked directly by
+absolute path), but the nightly automation runs its login-shell startup files
+(`functions.sh`, `path.sh`, etc.) under bash 3.2 regardless of any PATH fix.
+
+`com.andrewrich.headroom-learn.plist` has the same `/bin/bash` pattern but is
+out of scope here — Headroom has been removed from the stack; that plist (and
+any other Headroom leftovers, including the auto-generated section in
+`CLAUDE.md`) needs a separate cleanup spike.
+
+`install.sh`'s two `/bin/bash -c` installer invocations (Homebrew installer,
+NVM installer) are intentionally left alone: at the point they run, Homebrew
+bash may not exist yet.
+
+## Design
+
+### 1. `path.sh` becomes sole owner of PATH
+
+Replace the prepend-in-reverse-priority scheme with one explicit array, read
+top-to-bottom in actual final priority order:
+
+```bash
+_path_tiers=(
+  "${HOME}/.local/bin"
+  "${GEM_EXE_DIR:-}"
+  "${HOME}/.bun/bin"
+  "${HOME}/.asdf/shims"
+  "${HOMEBREW_ROOT}/opt/ruby/bin"
+  "${HOMEBREW_ROOT}/bin"
+  "${HOMEBREW_ROOT}/sbin"
+)
+for dir in "${_path_tiers[@]}"; do
+  _prepend_path_once "${dir}"
+done
+```
+
+Each iteration prepends further left, so array order *is* final PATH
+priority — no simulation needed. `HOMEBREW_ROOT` comes from
+`_get_homebrew_root` (`functions.sh`), a pure `[[ -d /opt/homebrew ]]` check —
+no `brew` invocation, cannot time out. The existing Android SDK append logic
+at the bottom of `path.sh` (lowest priority, appended not prepended) is
+unchanged.
+
+### 2. `env.sh` stops touching PATH
+
+Drop reliance on `brew shellenv`'s PATH mutation. Keep evaluating
+`brew shellenv` for the non-PATH exports it still usefully provides
+(`HOMEBREW_PREFIX`, `HOMEBREW_CELLAR`, `HOMEBREW_REPOSITORY`), but move this
+to run *after* `path.sh` sources, so it can never affect PATH order. If it
+times out or fails, only those secondary vars are missing — PATH is already
+correct and unaffected. This fully absorbs the "fallback" requirement: PATH
+correctness no longer depends on `brew shellenv` succeeding at all.
+
+### 3. Fix the `updates` LaunchAgent's bash
+
+Change `com.andrewrich.updates.plist`'s `ProgramArguments[0]` from
+`/bin/bash` to `/opt/homebrew/bin/bash`, matching `UserShell`. This is
+independent of the PATH changes above — no PATH fix can correct it, since
+launchd invokes the named executable directly without PATH resolution.
+
+## Testing
+
+- Script-level test sourcing `path.sh` with `HOMEBREW_ROOT` forced to a known
+  value, asserting final `PATH` array order matches the declared tier list.
+- `plutil -lint` on the edited plist.
+- `launchctl bootstrap`/`kickstart` the `updates` agent and confirm
+  `bash --version` in its log output reports 5.x.

--- a/docs/plans/2026-07-29-path-rationalization-design.md
+++ b/docs/plans/2026-07-29-path-rationalization-design.md
@@ -75,12 +75,27 @@ times out or fails, only those secondary vars are missing — PATH is already
 correct and unaffected. This fully absorbs the "fallback" requirement: PATH
 correctness no longer depends on `brew shellenv` succeeding at all.
 
-### 3. Fix the `updates` LaunchAgent's bash
+### 3. `updates` LaunchAgent's bash — rejected, stays on system bash
 
-Change `com.andrewrich.updates.plist`'s `ProgramArguments[0]` from
-`/bin/bash` to `/opt/homebrew/bin/bash`, matching `UserShell`. This is
-independent of the PATH changes above — no PATH fix can correct it, since
-launchd invokes the named executable directly without PATH resolution.
+Originally proposed changing `com.andrewrich.updates.plist`'s
+`ProgramArguments[0]` from `/bin/bash` to `/opt/homebrew/bin/bash`, matching
+`UserShell`. **Rejected** on reconsideration: Homebrew's `bash` binary's real
+path changes on every `brew upgrade bash` (a versioned Cellar target), and
+TCC/Full Disk Access grants for that binary don't survive the change — an
+unattended nightly job pinned to Homebrew bash would silently lose FDA after
+any bash upgrade and start re-triggering "bash wants to use local files" TCC
+prompts (deferred to next unlock, since the agent runs with no GUI session).
+`/bin/bash` is SIP-protected, permanent, and code-signed by Apple, making it
+the only stable FDA grantee available for this job. This is a deliberate,
+standing constraint (see `2026-07-10-nightly-updates-sudo-tcc-plan.md`), not
+an oversight to fix — do not revisit without a concrete plan for keeping FDA
+stable across Homebrew bash upgrades.
+
+This has no effect on fixes #1–#2 above: `path.sh`'s new tier-array logic is
+plain bash-3.2-compatible syntax (indexed arrays, parameter expansion; no
+`declare -A`, no bash-4-only globstar reliance), so the nightly job gets
+correct, deterministic PATH ordering under system bash without any plist
+change.
 
 ## Testing
 

--- a/docs/plans/2026-07-29-path-rationalization-plan.md
+++ b/docs/plans/2026-07-29-path-rationalization-plan.md
@@ -264,55 +264,23 @@ git commit -m "fix(env): stop env.sh from mutating PATH, remove stray duplicate 
 
 ---
 
-## Task 3: Fix the `updates` LaunchAgent's bash
+## Task 3: `updates` LaunchAgent's bash — REJECTED, not implemented
 
-**Files:**
+Originally planned to change `com.andrewrich.updates.plist`'s
+`ProgramArguments[0]` from `/bin/bash` to `/opt/homebrew/bin/bash`. **Do not
+do this.** Homebrew's `bash` binary's real path changes on every
+`brew upgrade bash` (versioned Cellar target), and TCC/Full Disk Access
+grants for that binary don't survive the change — pinning the unattended
+nightly job to Homebrew bash would silently lose FDA after any bash upgrade
+and reintroduce the "bash wants to use local files" TCC prompts documented in
+`2026-07-10-nightly-updates-sudo-tcc-plan.md`. `/bin/bash` (system bash 3.2,
+SIP-protected, permanent) is the only stable FDA grantee for this job. See
+the design doc's §3 for full rationale.
 
-- Modify: `~/Library/LaunchAgents/com.andrewrich.updates.plist` (not part of the dotfiles repo — lives outside version control; edit in place)
-
-**Step 1: Edit the plist**
-
-Change `ProgramArguments[0]` from `/bin/bash` to `/opt/homebrew/bin/bash`:
-
-```bash
-/usr/libexec/PlistBuddy -c "Set :ProgramArguments:0 /opt/homebrew/bin/bash" \
-  ~/Library/LaunchAgents/com.andrewrich.updates.plist
-```
-
-**Step 2: Lint the plist**
-
-Run: `plutil -lint ~/Library/LaunchAgents/com.andrewrich.updates.plist`
-Expected: `... OK`
-
-**Step 3: Reload the agent**
-
-```bash
-launchctl bootout gui/$(id -u)/com.andrewrich.updates 2>/dev/null
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.andrewrich.updates.plist
-```
-
-**Step 4: Verify it now runs under Homebrew bash**
-
-This agent's `StartCalendarInterval` is 03:55 daily, so triggering it for real
-isn't practical to verify interactively. Instead verify directly:
-
-```bash
-/opt/homebrew/bin/bash -l -c 'echo "BASH_VERSION=$BASH_VERSION"'
-```
-
-Expected: `BASH_VERSION=5.x...`
-
-Confirm the plist's first argument is the same absolute path used above:
-
-```bash
-/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" ~/Library/LaunchAgents/com.andrewrich.updates.plist
-```
-
-Expected: `/opt/homebrew/bin/bash`
-
-**Step 5: No commit** — this file lives outside the dotfiles repo
-(`~/Library/LaunchAgents/`), so there's nothing to commit here. Note in the
-PR description that this manual step was performed.
+This doesn't block the rest of the plan: Tasks 1–2 fix the actual reported
+symptom (the `brew doctor` PATH warning) using plain bash-3.2-compatible
+syntax, so the nightly job gets correct PATH ordering under system bash with
+no plist change needed.
 
 ---
 

--- a/docs/plans/2026-07-29-path-rationalization-plan.md
+++ b/docs/plans/2026-07-29-path-rationalization-plan.md
@@ -1,0 +1,330 @@
+# PATH Rationalization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `path.sh` the single, explicit-order owner of PATH construction (independent of `brew shellenv` succeeding), stop `env.sh` from mutating PATH, and fix the `updates` LaunchAgent to run under Homebrew bash instead of macOS system bash 3.2.
+
+**Architecture:** Replace `path.sh`'s prepend-in-reverse-priority convention with one literal array walked top-to-bottom (array order = final PATH order). Neutralize `env.sh`'s `brew shellenv` eval so it can never touch PATH (filter its output before eval), and delete a stray duplicate `export PATH=` line found at the end of `env.sh`. Point the `com.andrewrich.updates` LaunchAgent at `/opt/homebrew/bin/bash`.
+
+**Tech Stack:** Bash 5.x (`bash/*.sh`, sourced via `~/.config/bash/main.sh`), shellcheck, macOS `launchd` plist.
+
+**Background:** See `docs/plans/2026-07-29-path-rationalization-design.md` for the full investigation and rationale.
+
+---
+
+## Task 1: Rewrite `path.sh` to explicit-order tier array
+
+**Files:**
+
+- Modify: `bash/path.sh` (full rewrite of the prepend section, lines ~15–105)
+- Test: `bash/tests/test-path-order.sh` (new — no test framework exists in this repo; this is a standalone script run manually, matching the repo's existing shellcheck-only verification convention)
+
+**Step 1: Write the failing test**
+
+Create `bash/tests/test-path-order.sh`:
+
+```bash
+#!/usr/bin/env bash
+#shellcheck shell=bash
+# Standalone verification for bash/path.sh PATH ordering.
+# Run directly: bash bash/tests/test-path-order.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export BASH_CONFIG_DIR="${REPO_ROOT}/bash"
+
+# Isolate from the real environment so the test is deterministic regardless
+# of what's actually installed on the machine running it.
+export HOME="/tmp/path-order-test-home-$$"
+mkdir -p "${HOME}/.local/bin" "${HOME}/.bun/bin"
+trap 'rm -rf "${HOME}"' EXIT
+
+# functions.sh defines _get_homebrew_root, _prepend_path_once, etc.
+#shellcheck source=/dev/null
+source "${BASH_CONFIG_DIR}/functions.sh"
+
+export PATH="/usr/bin:/bin"
+#shellcheck source=/dev/null
+source "${BASH_CONFIG_DIR}/path.sh"
+
+fail=0
+assert_before() {
+  local first="$1" second="$2"
+  local first_idx second_idx idx=0
+  first_idx=-1
+  second_idx=-1
+  IFS=':' read -ra parts <<<"${PATH}"
+  for p in "${parts[@]}"; do
+    [[ "${p}" == "${first}" ]] && first_idx=${idx}
+    [[ "${p}" == "${second}" ]] && second_idx=${idx}
+    ((idx += 1))
+  done
+  if [[ ${first_idx} -eq -1 || ${second_idx} -eq -1 ]]; then
+    echo "FAIL: expected both '${first}' and '${second}' in PATH: ${PATH}"
+    fail=1
+  elif [[ ${first_idx} -ge ${second_idx} ]]; then
+    echo "FAIL: expected '${first}' before '${second}' in PATH: ${PATH}"
+    fail=1
+  else
+    echo "PASS: '${first}' before '${second}'"
+  fi
+}
+
+assert_before "${HOME}/.local/bin" "${HOME}/.bun/bin"
+assert_before "${HOME}/.bun/bin" "$(_get_homebrew_root)/bin"
+assert_before "$(_get_homebrew_root)/bin" "/usr/bin"
+
+exit "${fail}"
+```
+
+**Step 2: Run test to verify current behavior**
+
+Run: `bash bash/tests/test-path-order.sh`
+Expected: FAILs on the `"$(_get_homebrew_root)/bin" before "/usr/bin"` assertion, since current `path.sh` never prepends `${HOMEBREW_ROOT}/bin` (only `sbin`) — it relies entirely on `env.sh`'s `brew shellenv`, which this test deliberately doesn't source.
+
+**Step 3: Rewrite `path.sh`**
+
+Replace the body of `bash/path.sh` (keep the two helper functions `_prepend_path_once`/`_append_path_once` and the header comment) with:
+
+```bash
+# ~/.config/bash/path.sh
+#shellcheck shell=bash
+# Consolidated PATH management — this file is the ONLY place PATH priority
+# is decided. env.sh does not touch PATH.
+#
+# _path_tiers below is the final PATH order, highest priority first.
+# Read top-to-bottom: that IS the resulting search order. No mental
+# simulation of prepend calls required.
+
+# Prepend to PATH, ensuring it's at the front (moves existing entry if needed)
+# macOS path_helper pre-populates PATH from /etc/paths.d, often placing user
+# directories after system ones. This function corrects that ordering.
+_prepend_path_once() {
+  local dir="$1"
+  [[ -d "${dir}" ]] || return 0
+
+  if [[ "${PATH}" == "${dir}" ]]; then
+    export PATH="${dir}"
+    return 0
+  fi
+  PATH="${PATH/#${dir}:/}"
+  PATH="${PATH//:${dir}:/:}"
+  PATH="${PATH/%:${dir}/}"
+
+  export PATH="${dir}:${PATH}"
+}
+
+# Append to PATH only if not already present (prevents duplicates)
+_append_path_once() {
+  local dir="$1"
+  if [[ -d "${dir}" ]] && [[ ":${PATH}:" != *":${dir}:"* ]]; then
+    export PATH="${PATH}:${dir}"
+  fi
+}
+
+# ============================================================================
+# EXPLICIT PATH ORDER — highest priority first
+# ============================================================================
+
+HOMEBREW_ROOT=$(_get_homebrew_root)
+
+GEM_EXE_DIR=""
+if command -v ruby &>/dev/null; then
+  if [[ $(type -t _profile_time) == "function" ]] && [[ "$-" == *i* ]]; then
+    _pf_start=$(date +%s.%N)
+  fi
+  GEM_EXE_DIR="$(ruby -e 'puts Gem.bindir' 2>/dev/null)"
+  if [[ $(type -t _profile_time) == "function" ]] && [[ "$-" == *i* ]]; then
+    _pf_end=$(date +%s.%N)
+    _pf_duration=$(awk "BEGIN {printf \"%.3f\", ${_pf_end} - ${_pf_start}}")
+    if (($(awk "BEGIN {print (${_pf_duration} > 1.0)}"))); then
+      echo "[PROFILE] ruby Gem.bindir took ${_pf_duration}s" >&2
+    fi
+    unset _pf_start _pf_end _pf_duration
+  fi
+fi
+
+# Written highest-priority-first. The loop below does a single forward
+# pass, appending each existing directory to a new prefix in this exact
+# order, then puts that prefix in front of whatever's left of the old
+# PATH. Array order above IS the resulting PATH order — read top to
+# bottom, no need to simulate anything.
+_path_tiers=(
+  "${HOME}/.local/bin"
+  "${GEM_EXE_DIR}"
+  "${HOME}/.bun/bin"
+  "${HOME}/.asdf/shims"
+  "${HOMEBREW_ROOT}/opt/ruby/bin"
+  "${HOMEBREW_ROOT}/bin"
+  "${HOMEBREW_ROOT}/sbin"
+)
+
+_new_path=""
+for _dir in "${_path_tiers[@]}"; do
+  [[ -n "${_dir}" && -d "${_dir}" ]] || continue
+  # Strip any existing occurrence first so it isn't duplicated below.
+  PATH="${PATH//:${_dir}:/:}"
+  PATH="${PATH/#${_dir}:/}"
+  PATH="${PATH/%:${_dir}/}"
+  [[ "${PATH}" == "${_dir}" ]] && PATH=""
+  _new_path="${_new_path:+${_new_path}:}${_dir}"
+done
+export PATH="${_new_path}${_new_path:+:}${PATH}"
+unset _path_tiers _dir _new_path GEM_EXE_DIR
+
+# ============================================================================
+# LOWEST PRIORITY — appended, not prepended
+# ============================================================================
+
+# Android SDK (only if installed)
+if [[ -d "${HOME}/Library/Android/sdk" ]]; then
+  export ANDROID_HOME="${HOME}/Library/Android/sdk"
+  _append_path_once "${ANDROID_HOME}/emulator"
+  _append_path_once "${ANDROID_HOME}/platform-tools"
+fi
+```
+
+`_prepend_path_once`/`_append_path_once` are kept for the Android SDK
+low-priority append and for any future one-off caller, but the tier
+construction itself no longer uses `_prepend_path_once` — repeated prepend
+calls are exactly the "simulate the order in your head" pattern this
+rewrite removes.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bash bash/tests/test-path-order.sh`
+Expected: All three `PASS` lines, exit 0.
+
+**Step 5: Shellcheck**
+
+Run: `shellcheck -S info bash/path.sh bash/tests/test-path-order.sh`
+Expected: no issues.
+
+**Step 6: Commit**
+
+```bash
+git add bash/path.sh bash/tests/test-path-order.sh
+git commit -m "refactor(path): make path.sh the sole explicit-order PATH owner"
+```
+
+---
+
+## Task 2: Stop `env.sh` from touching PATH
+
+**Files:**
+
+- Modify: `bash/env.sh:56-97` (brew shellenv block), `bash/env.sh:171` (stray export)
+
+**Step 1: Filter PATH/MANPATH/INFOPATH out of the `brew shellenv` eval**
+
+In `bash/env.sh`, change the `eval "${BREW_SHELLENV}"` branch (around line 87)
+so it strips any line that assigns those three variables before eval'ing —
+`path.sh` already owns them and must not be re-mutated by whatever
+`brew shellenv` decides to emit:
+
+```bash
+  else
+    eval "$(grep -vE '^export (PATH|MANPATH|INFOPATH)=' <<<"${BREW_SHELLENV}")"
+  fi
+```
+
+**Step 2: Delete the stray duplicate PATH export**
+
+Remove line 171 entirely:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+This was a leftover direct PATH mutation that both duplicated and could
+reorder what `path.sh` already establishes — `path.sh` already prepends
+`${HOME}/.local/bin` at the correct (highest) priority.
+
+**Step 3: Verify no other PATH/MANPATH/INFOPATH references remain in `env.sh`**
+
+Run: `grep -n 'PATH=' bash/env.sh`
+Expected: no output (all removed/filtered).
+
+**Step 4: Shellcheck**
+
+Run: `shellcheck -S info bash/env.sh`
+Expected: no issues.
+
+**Step 5: Manual verification**
+
+Run: `bash -c 'source bash/functions.sh && source bash/env.sh && source bash/path.sh && echo "${PATH}" | tr ":" "\n" | head -10'`
+Expected: `${HOME}/.local/bin` first, `${HOMEBREW_ROOT}/bin` ahead of `/usr/bin`, no duplicate entries.
+
+**Step 6: Commit**
+
+```bash
+git add bash/env.sh
+git commit -m "fix(env): stop env.sh from mutating PATH, remove stray duplicate export"
+```
+
+---
+
+## Task 3: Fix the `updates` LaunchAgent's bash
+
+**Files:**
+
+- Modify: `~/Library/LaunchAgents/com.andrewrich.updates.plist` (not part of the dotfiles repo — lives outside version control; edit in place)
+
+**Step 1: Edit the plist**
+
+Change `ProgramArguments[0]` from `/bin/bash` to `/opt/homebrew/bin/bash`:
+
+```bash
+/usr/libexec/PlistBuddy -c "Set :ProgramArguments:0 /opt/homebrew/bin/bash" \
+  ~/Library/LaunchAgents/com.andrewrich.updates.plist
+```
+
+**Step 2: Lint the plist**
+
+Run: `plutil -lint ~/Library/LaunchAgents/com.andrewrich.updates.plist`
+Expected: `... OK`
+
+**Step 3: Reload the agent**
+
+```bash
+launchctl bootout gui/$(id -u)/com.andrewrich.updates 2>/dev/null
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.andrewrich.updates.plist
+```
+
+**Step 4: Verify it now runs under Homebrew bash**
+
+This agent's `StartCalendarInterval` is 03:55 daily, so triggering it for real
+isn't practical to verify interactively. Instead verify directly:
+
+```bash
+/opt/homebrew/bin/bash -l -c 'echo "BASH_VERSION=$BASH_VERSION"'
+```
+
+Expected: `BASH_VERSION=5.x...`
+
+Confirm the plist's first argument is the same absolute path used above:
+
+```bash
+/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" ~/Library/LaunchAgents/com.andrewrich.updates.plist
+```
+
+Expected: `/opt/homebrew/bin/bash`
+
+**Step 5: No commit** — this file lives outside the dotfiles repo
+(`~/Library/LaunchAgents/`), so there's nothing to commit here. Note in the
+PR description that this manual step was performed.
+
+---
+
+## Task 4: Full regression check
+
+**Step 1:** Run `shellcheck -S info bash/path.sh bash/env.sh bash/functions.sh bash/main.sh bash/tests/test-path-order.sh`
+Expected: no issues.
+
+**Step 2:** Run `bash bash/tests/test-path-order.sh`
+Expected: exit 0, all PASS.
+
+**Step 3:** Open a fresh interactive login shell (`/opt/homebrew/bin/bash -l`) and run `echo $PATH | tr ':' '\n' | head -5`
+Expected: `${HOME}/.local/bin`, then homebrew paths, before any `/usr/bin`.
+
+**Step 4:** Report results; do not push until this task's checks are clean (Protocol 4).


### PR DESCRIPTION
## Summary
- Make `path.sh` the sole, explicit-order owner of PATH construction (one literal tier array, top-to-bottom = final priority), replacing the old prepend-in-reverse-priority convention.
- Stop `env.sh` from touching PATH/MANPATH/INFOPATH at all — PATH correctness no longer depends on `brew shellenv` succeeding (the original triggering symptom: a `brew doctor` PATH-shadowing warning from a nightly run where `brew shellenv` timed out).
- Fix a trailing-colon PATH-injection edge case found during review, and a stray duplicate `~/.local/bin` export in `env.sh`.

## Rejected (documented, not implemented)
- Switching the `com.andrewrich.updates` LaunchAgent from system bash (`/bin/bash`) to Homebrew bash was in the original plan but is **rejected**: Homebrew bash's real path changes on every `brew upgrade bash`, and TCC/Full Disk Access grants don't survive that change, so pinning the unattended nightly job to Homebrew bash would silently break FDA and reintroduce TCC prompts. System bash is the only stable FDA grantee for this job. See `docs/plans/2026-07-29-path-rationalization-design.md` §3 for full rationale. This doesn't affect the fix above — `path.sh`'s new logic is plain bash-3.2-compatible.

## Test plan
- [x] `shellcheck -S info bash/path.sh bash/env.sh bash/functions.sh bash/main.sh bash/tests/test-path-order.sh` — no new issues
- [x] `bash bash/tests/test-path-order.sh` — all PASS
- [x] Fresh interactive login shell (`/opt/homebrew/bin/bash -l`) shows `~/.local/bin` → Homebrew bin/sbin → system paths, in that order
- [x] Local code-reviewer + adversarial-reviewer clean on every commit
- [x] Pre-push full-diff + codebase review: PASS (one non-blocking follow-up filed as #114)

https://claude.ai/code/session_015h6YYCUJMYH5kb9PyPfk9d