### PR TITLE
feat: add pull-beacon-repos to allup function

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -731,9 +731,10 @@ updates() {
 # Not exported - interactive command only
 
 # Update all local repos, repair local config symlinks, run software updates
-# pull-my-repos is from ~/Developer/scripts, symlinked into ~/.local/bin
+# pull-my-repos and pull-beacon-repos are from ~/Developer/scripts, symlinked into ~/.local/bin
 allup() {
-  pull-my-repos || return $?
+  command -v pull-my-repos && pull-my-repos || return $?
+  command -v pull-beacon-repos && pull-beacon-repos || return $?
   "${HOME}/Developer/dotfiles/install.sh" --repair || return $?
   "${HOME}/Developer/claude-config/install.sh" --repair || return $?
   updates "$@"

--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -733,8 +733,8 @@ updates() {
 # Update all local repos, repair local config symlinks, run software updates
 # pull-my-repos and pull-beacon-repos are from ~/Developer/scripts, symlinked into ~/.local/bin
 allup() {
-  command -v pull-my-repos && pull-my-repos || return $?
-  command -v pull-beacon-repos && pull-beacon-repos || return $?
+  if command -v pull-my-repos &>/dev/null; then pull-my-repos || return $?; fi
+  if command -v pull-beacon-repos &>/dev/null; then pull-beacon-repos || return $?; fi
   "${HOME}/Developer/dotfiles/install.sh" --repair || return $?
   "${HOME}/Developer/claude-config/install.sh" --repair || return $?
   updates "$@"


### PR DESCRIPTION
## Summary
- Adds `pull-beacon-repos` alongside the existing `pull-my-repos` call in `allup()`, both from `~/Developer/scripts` symlinked into `~/.local/bin`.
- Fixes an operator-precedence bug in the `command -v X && X || return $?` guards: this form returns 1 whenever X is absent instead of skipping it, and leaks `command -v`'s resolved path to stdout. Replaced with explicit `if command -v X &>/dev/null; then ...; fi` guards.

## Test plan
- [x] Ran locally with both commands present
- [x] shellcheck -S info clean
- [x] Local pre-commit/pre-push review hooks passed

[skip-claude-review: infra - CLAUDE_CODE_OAUTH_TOKEN failing instantly with is_error:true on both claude-review and claude-review-haiku across reruns (not related to this diff); local pre-commit/pre-push reviewers already passed]
