### PR TITLE
feat(gh): auto-switch gh CLI identity based on repo owner

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -971,7 +971,7 @@ export -f git # Exported - overrides system git command globally
 _gh_sync_identity() {
   local remote_url owner desired current
 
-  remote_url=$(git config --get remote.origin.url 2>/dev/null)
+  remote_url=$(command git config --get remote.origin.url 2>/dev/null)
   [[ -z "${remote_url}" ]] && return 0
 
   owner=$(printf '%s\n' "${remote_url}" | sed -E 's#^(git@[^:]+:|[a-zA-Z]+://[^/]+/)##; s#/.*##')
@@ -987,7 +987,8 @@ _gh_sync_identity() {
 
   if [[ -n "${current}" && "${current}" != "${desired}" ]]; then
     if ! command gh auth switch --hostname github.com --user "${desired}" >/dev/null 2>&1; then
-      echo "[gh] Warning: failed to switch identity to '${desired}' — commands may run as '${current}' instead" >&2
+      echo "[gh] ERROR: failed to switch identity to '${desired}' (repo owner: '${owner}') — refusing to run as '${current}' instead" >&2
+      return 1
     fi
   fi
 }
@@ -1004,7 +1005,7 @@ gh() {
 
   # Don't auto-switch identity while the user is managing accounts directly.
   if [[ "$1" != "auth" ]]; then
-    _gh_sync_identity
+    _gh_sync_identity || return 1
   fi
 
   # Block: gh api .../pulls/{number}/merge (REST API merge bypass)

--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -1003,8 +1003,13 @@ export -f _gh_sync_identity # Exported - used by the exported gh() wrapper
 gh() {
   local review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
 
-  # Don't auto-switch identity while the user is managing accounts directly.
-  if [[ "$1" != "auth" ]]; then
+  # Don't auto-switch identity while the user is managing accounts directly,
+  # or for --help/-h — informational calls shouldn't mutate global auth state.
+  local _gh_is_help=0 _gh_help_arg
+  for _gh_help_arg in "$@"; do
+    [[ "${_gh_help_arg}" == "--help" || "${_gh_help_arg}" == "-h" ]] && _gh_is_help=1 && break
+  done
+  if [[ "$1" != "auth" && "${_gh_is_help}" == "0" ]]; then
     _gh_sync_identity || return 1
   fi
 

--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -957,6 +957,42 @@ git() {
 export -f git # Exported - overrides system git command globally
 
 # ============================================================================
+# GitHub CLI identity auto-switch
+# ============================================================================
+# gh has one active account per host (not per repo), unlike git+SSH which
+# already resolves the right identity per remote via ~/.ssh/config host
+# aliases. This keeps gh in sync with that same per-repo intent: repos owned
+# by smartwatermelon use the smartwatermelon account; everything else
+# (Beacon repos, etc.) falls back to andrewmrich. Local-only (reads/writes
+# gh's config file, no network), so it's cheap to run on every invocation.
+# Caveat: this mutates global gh state, so concurrent shells working in
+# different-owner repos at the same time can race each other.
+_gh_sync_identity() {
+  local remote_url owner desired current
+
+  remote_url=$(git config --get remote.origin.url 2>/dev/null)
+  [[ -z "${remote_url}" ]] && return 0
+
+  owner=$(printf '%s\n' "${remote_url}" | sed -E 's#^(git@[^:]+:|[a-zA-Z]+://[^/]+/)##; s#/.*##')
+  [[ -z "${owner}" ]] && return 0
+
+  if [[ "${owner}" == "smartwatermelon" ]]; then
+    desired="smartwatermelon"
+  else
+    desired="andrewmrich"
+  fi
+
+  current=$(awk '/^github\.com:/{f=1} f && /^ *user:/{print $2; exit}' "${HOME}/.config/gh/hosts.yml" 2>/dev/null | tr -d "\"'")
+
+  if [[ -n "${current}" && "${current}" != "${desired}" ]]; then
+    if ! command gh auth switch --hostname github.com --user "${desired}" >/dev/null 2>&1; then
+      echo "[gh] Warning: failed to switch identity to '${desired}' — commands may run as '${current}' instead" >&2
+    fi
+  fi
+}
+export -f _gh_sync_identity # Exported - used by the exported gh() wrapper
+
+# ============================================================================
 # GitHub CLI Wrapper
 # ============================================================================
 # Intercepts `gh pr merge` to run pre-merge review
@@ -964,6 +1000,11 @@ export -f git # Exported - overrides system git command globally
 
 gh() {
   local review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
+
+  # Don't auto-switch identity while the user is managing accounts directly.
+  if [[ "$1" != "auth" ]]; then
+    _gh_sync_identity
+  fi
 
   # Block: gh api .../pulls/{number}/merge (REST API merge bypass)
   # Block: gh api graphql with mergePullRequest mutation (GraphQL bypass)


### PR DESCRIPTION
## Summary
- `gh` has a single active account per host, unlike git+SSH which already resolves the right identity per remote via `~/.ssh/config` host aliases. This caused `gh pr create` to fail with "must be a collaborator" when the active `gh` account didn't match the repo owner (hit this live on PR #120).
- Adds `_gh_sync_identity()`, wired into the front of the existing `gh()` wrapper in `bash/functions.sh`. Before any `gh` command runs, it checks the current repo's `origin` remote owner and switches `gh`'s active account to match: `smartwatermelon`-owned repos use the `smartwatermelon` account, everything else (Beacon repos, etc.) falls back to `andrewmrich`.
- Local-only (reads `git config`, reads/writes `gh`'s local config file) — no network calls, so it's cheap on every invocation.
- Skips the sync when the user is running `gh auth ...` directly, so it doesn't interfere with manual account management.

## Test plan
- [x] Verified in a real shell: forcing the wrong active account, then running `gh` inside this (smartwatermelon-owned) repo auto-switches to `smartwatermelon`
- [x] Verified fallback: running `gh` inside a scratch repo with a non-smartwatermelon remote auto-switches to `andrewmrich`
- [x] shellcheck -S info clean
- [x] Local pre-commit/pre-push review hooks passed

[skip-claude-review: infra - CLAUDE_CODE_OAUTH_TOKEN failing instantly with is_error:true on both claude-review and claude-review-haiku (same systemic issue seen on PR #120, not related to this diff); local pre-commit/pre-push reviewers already passed]
