### PR TITLE
refactor(gh): consolidate merge-guard wrapper into one canonical file

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -958,138 +958,17 @@ git() {
 export -f git # Exported - overrides system git command globally
 
 # ============================================================================
-# GitHub CLI identity auto-switch
-# ============================================================================
-# gh has one active account per host (not per repo), unlike git+SSH which
-# already resolves the right identity per remote via ~/.ssh/config host
-# aliases. This keeps gh in sync with that same per-repo intent: repos owned
-# by smartwatermelon use the smartwatermelon account; everything else
-# (Beacon repos, etc.) falls back to andrewmrich. Local-only (reads/writes
-# gh's config file, no network), so it's cheap to run on every invocation.
-# Caveat: this mutates global gh state, so concurrent shells working in
-# different-owner repos at the same time can race each other.
-_gh_sync_identity() {
-  local remote_url owner desired current
-
-  remote_url=$(command git config --get remote.origin.url 2>/dev/null)
-  [[ -z "${remote_url}" ]] && return 0
-
-  owner=$(printf '%s\n' "${remote_url}" | sed -E 's#^(git@[^:]+:|[a-zA-Z]+://[^/]+/)##; s#/.*##')
-  [[ -z "${owner}" ]] && return 0
-
-  if [[ "${owner}" == "smartwatermelon" ]]; then
-    desired="smartwatermelon"
-  else
-    desired="andrewmrich"
-  fi
-
-  current=$(awk '/^github\.com:/{f=1} f && /^ *user:/{print $2; exit}' "${HOME}/.config/gh/hosts.yml" 2>/dev/null | tr -d "\"'")
-
-  if [[ -n "${current}" && "${current}" != "${desired}" ]]; then
-    if ! command gh auth switch --hostname github.com --user "${desired}" >/dev/null 2>&1; then
-      echo "[gh] ERROR: failed to switch identity to '${desired}' (repo owner: '${owner}') — refusing to run as '${current}' instead" >&2
-      return 1
-    fi
-  fi
-}
-export -f _gh_sync_identity # Exported - used by the exported gh() wrapper
-
-# ============================================================================
 # GitHub CLI Wrapper
 # ============================================================================
-# Intercepts `gh pr merge` to run pre-merge review
-# All other gh commands pass through unchanged
+# Canonical implementation (including the identity auto-switch and the
+# pre-merge review + REST/GraphQL merge-bypass blocking) lives in
+# gh-wrapper.sh (sourced below), which also doubles as the standalone
+# ~/.local/bin/gh wrapper when symlinked and executed directly. See that
+# file for how the two modes interoperate.
 
-gh() {
-  local review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
-
-  # Don't auto-switch identity while the user is managing accounts directly,
-  # or for --help/-h — informational calls shouldn't mutate global auth state.
-  local _gh_is_help=0 _gh_help_arg
-  for _gh_help_arg in "$@"; do
-    [[ "${_gh_help_arg}" == "--help" || "${_gh_help_arg}" == "-h" ]] && _gh_is_help=1 && break
-  done
-  if [[ "$1" != "auth" && "${_gh_is_help}" == "0" ]]; then
-    _gh_sync_identity || return 1
-  fi
-
-  # Block: gh api .../pulls/{number}/merge (REST API merge bypass)
-  # Block: gh api graphql with mergePullRequest mutation (GraphQL bypass)
-  #
-  # IMPORTANT: These checks run BEFORE the --help early-return below so that
-  # `gh api .../pulls/NNN/merge --help` cannot bypass this defense by
-  # appending --help to the command.
-  #
-  # This is the shell-wrapper layer; the Claude Code PreToolUse hook
-  # (hook-block-api-merge.sh) is the primary layer.
-  #
-  # Suffix boundary prevents false positives on paths like pulls/NNN/merge_status.
-  # If gh pr merge fails: report the failure, ask the human to merge manually.
-  if [[ "$1" == "api" ]] && printf '%s\n' "$*" | grep -qE 'pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
-    echo "[gh] BLOCKED: Direct REST API PR merge bypasses pre-merge review and merge authorization." >&2
-    echo "[gh] This endpoint skips pre-merge-review.sh and the merge-lock check." >&2
-    echo "[gh] Use 'gh pr merge <number>' instead." >&2
-    echo "[gh] If gh pr merge fails, report the failure and ask the human to merge manually." >&2
-    return 1
-  fi
-
-  if [[ "$1" == "api" ]] && printf '%s\n' "$*" | grep -qE 'graphql.*mergePullRequest[[:space:]]*\('; then
-    echo "[gh] BLOCKED: GraphQL mergePullRequest mutation bypasses pre-merge review and merge authorization." >&2
-    echo "[gh] Use 'gh pr merge <number>' instead." >&2
-    echo "[gh] If gh pr merge fails, report the failure and ask the human to merge manually." >&2
-    return 1
-  fi
-
-  # Pass help requests directly to the real gh — no review needed.
-  # Set _GH_REVIEW_DONE so ~/.local/bin/gh wrapper also skips review.
-  for arg in "$@"; do
-    if [[ "${arg}" == "--help" || "${arg}" == "-h" ]]; then
-      _GH_REVIEW_DONE=1 command gh "$@"
-      return $?
-    fi
-  done
-
-  # Intercept: gh [global-flags] pr merge [...]
-  # Parse past known two-token global flags (flag + separate value) to find the
-  # actual positional subcommand. This handles both the standard form:
-  #   gh pr merge NNN
-  # and the global-flag bypass form:
-  #   gh -R owner/repo pr merge NNN
-  local _gh_sub="" _gh_subsub="" _gh_skip_next=0
-  for _gh_arg in "$@"; do
-    if [[ "${_gh_skip_next}" == "1" ]]; then
-      _gh_skip_next=0
-      continue
-    fi
-    case "${_gh_arg}" in
-      -R | --repo | --hostname | --config-dir | --token) _gh_skip_next=1 ;;
-      --*=*) ;; # --flag=value: single token, no separate value to skip
-      -*) ;;    # other single-token flags: skip
-      *)
-        if [[ -z "${_gh_sub}" ]]; then
-          _gh_sub="${_gh_arg}"
-        else
-          _gh_subsub="${_gh_arg}"
-          break
-        fi
-        ;;
-    esac
-  done
-  if [[ "${_gh_sub}" == "pr" && "${_gh_subsub}" == "merge" ]]; then
-    if [[ -x "${review_script}" ]]; then
-      "${review_script}" "$@" || return 1
-    else
-      echo "[gh] Warning: pre-merge review script not found or not executable" >&2
-      echo "[gh] Expected: ${review_script}" >&2
-      echo "[gh] Proceeding without review..." >&2
-    fi
-  fi
-
-  # Run the real gh command. Set _GH_REVIEW_DONE so ~/.local/bin/gh wrapper
-  # does not run the review a second time (prevents double review).
-  _GH_REVIEW_DONE=1 command gh "$@"
-}
-export -f gh # Exported - overrides system gh command globally
+if [[ -f "${HOME}/.config/bash/gh-wrapper.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "${HOME}/.config/bash/gh-wrapper.sh"
 
 # ============================================================================
 # gpush — Push, create PR, wait for CI, merge, and clean up in one command

--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -974,10 +974,13 @@ else
   # symlink-forest repair gone wrong) must not silently drop the
   # REST/GraphQL merge-bypass block and pre-merge review gate.
   echo "[gh] WARNING: ${HOME}/.config/bash/gh-wrapper.sh not found — gh merge guard is NOT active." >&2
-  echo "[gh] Run install.sh (or install.sh --repair) to restore it." >&2
+  # install.sh --repair only re-links files that already exist as plain
+  # copies; it skips paths that are missing entirely. A fully absent
+  # gh-wrapper.sh needs the plain (non-repair) install.sh run.
+  echo "[gh] Run install.sh to restore it." >&2
   gh() {
     echo "[gh] ERROR: gh-wrapper.sh is missing; refusing to run gh unguarded." >&2
-    echo "[gh] Run install.sh (or install.sh --repair) to restore ${HOME}/.config/bash/gh-wrapper.sh." >&2
+    echo "[gh] Run install.sh to restore ${HOME}/.config/bash/gh-wrapper.sh." >&2
     return 1
   }
   export -f gh

--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -969,6 +969,19 @@ export -f git # Exported - overrides system git command globally
 if [[ -f "${HOME}/.config/bash/gh-wrapper.sh" ]]; then
   # shellcheck source=/dev/null
   source "${HOME}/.config/bash/gh-wrapper.sh"
+else
+  # Fail closed: a missing/broken symlink here (e.g. mid-install, or a
+  # symlink-forest repair gone wrong) must not silently drop the
+  # REST/GraphQL merge-bypass block and pre-merge review gate.
+  echo "[gh] WARNING: ${HOME}/.config/bash/gh-wrapper.sh not found — gh merge guard is NOT active." >&2
+  echo "[gh] Run install.sh (or install.sh --repair) to restore it." >&2
+  gh() {
+    echo "[gh] ERROR: gh-wrapper.sh is missing; refusing to run gh unguarded." >&2
+    echo "[gh] Run install.sh (or install.sh --repair) to restore ${HOME}/.config/bash/gh-wrapper.sh." >&2
+    return 1
+  }
+  export -f gh
+fi
 
 # ============================================================================
 # gpush — Push, create PR, wait for CI, merge, and clean up in one command

--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -1,0 +1,183 @@
+# ~/.config/bash/gh-wrapper.sh
+#shellcheck shell=bash
+# Canonical implementation of the `gh` PR-merge guard (pre-merge review +
+# REST/GraphQL merge-bypass blocking). One file, two invocation modes:
+#
+#   1. Sourced from functions.sh: defines gh() as a bash function. This wins
+#      over PATH lookup for any bash process — interactive shells (via
+#      .bash_profile -> main.sh) and non-interactive ones too, since
+#      ~/.claude/settings.json sets BASH_ENV=~/.config/bash/functions.sh so
+#      Claude Code's own Bash tool sources it as well.
+#   2. Symlinked as ~/.local/bin/gh and executed directly: acts as a
+#      standalone wrapper. This is the fallback for anything that reaches
+#      `gh` without going through a bash process that has BASH_ENV in
+#      effect — GUI apps, LaunchAgents/cron with a stripped environment,
+#      editor git integrations, other language runtimes shelling out to
+#      `gh`, etc.
+#
+# _GH_REVIEW_DONE guards against running pre-merge-review.sh twice when both
+# layers fire in the same call chain: the bash function runs first, then
+# calls `command gh`, which (since ~/.local/bin is early in PATH) finds this
+# same file again in standalone-wrapper mode.
+
+_gh_wrapper_review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
+
+# Find the real `gh` binary, skipping ourselves. Only meaningful in
+# standalone-wrapper mode.
+_gh_wrapper_find_real_gh() {
+  local self
+  self="$(realpath "${BASH_SOURCE[0]}")"
+
+  local IFS=':'
+  local dir candidate candidate_real
+  for dir in ${PATH}; do
+    candidate="${dir}/gh"
+    if [[ -x "${candidate}" ]]; then
+      candidate_real="$(realpath "${candidate}" 2>/dev/null)"
+      if [[ "${candidate_real}" != "${self}" ]]; then
+        printf '%s\n' "${candidate}"
+        return 0
+      fi
+    fi
+  done
+
+  printf '[gh-wrapper] Error: Could not find real gh binary in PATH\n' >&2
+  return 1
+}
+
+# Blocks REST/GraphQL PR-merge bypass vectors that skip pre-merge-review.sh
+# and the merge-lock check entirely. Returns 1 if the call should be blocked.
+_gh_wrapper_block_bypass() {
+  if [[ "$1" == "api" ]] && printf '%s\n' "$*" | grep -qE 'pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
+    echo "[gh] BLOCKED: Direct REST API PR merge bypasses pre-merge review and merge authorization." >&2
+    echo "[gh] This endpoint skips pre-merge-review.sh and the merge-lock check." >&2
+    echo "[gh] Use 'gh pr merge <number>' instead." >&2
+    echo "[gh] If gh pr merge fails, report the failure and ask the human to merge manually." >&2
+    return 1
+  fi
+
+  if [[ "$1" == "api" ]] && printf '%s\n' "$*" | grep -qE 'graphql.*mergePullRequest[[:space:]]*\('; then
+    echo "[gh] BLOCKED: GraphQL mergePullRequest mutation bypasses pre-merge review and merge authorization." >&2
+    echo "[gh] Use 'gh pr merge <number>' instead." >&2
+    echo "[gh] If gh pr merge fails, report the failure and ask the human to merge manually." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+# Runs pre-merge-review.sh if this call is `gh pr merge`. Returns 1 to block.
+# Parses args past known two-token global flags to find the actual
+# subcommand, handling both `gh pr merge NNN` and `gh -R owner/repo pr merge
+# NNN`.
+#
+# $1: "strict" or "warn" — how to react if the review script is missing.
+# "strict" (standalone-wrapper mode) fails closed, since that mode is the
+# fallback safety net for callers with no other guard layer. "warn"
+# (function mode) matches the original bash-function behavior of warning
+# and proceeding, since a bash session has other opportunities to catch a
+# misconfigured review script.
+_gh_wrapper_maybe_review() {
+  local missing_script_mode="$1"
+  shift
+
+  local sub="" subsub="" skip_next=0 arg
+  for arg in "$@"; do
+    if [[ "${skip_next}" == "1" ]]; then
+      skip_next=0
+      continue
+    fi
+    case "${arg}" in
+      -R | --repo | --hostname | --config-dir | --token) skip_next=1 ;;
+      --*=*) ;; # --flag=value: single token, no separate value to skip
+      -*) ;;    # other single-token flags: skip
+      *)
+        if [[ -z "${sub}" ]]; then
+          sub="${arg}"
+        else
+          subsub="${arg}"
+          break
+        fi
+        ;;
+    esac
+  done
+
+  if [[ "${sub}" == "pr" && "${subsub}" == "merge" ]]; then
+    if [[ -x "${_gh_wrapper_review_script}" ]]; then
+      "${_gh_wrapper_review_script}" "$@" || return 1
+    elif [[ "${missing_script_mode}" == "strict" ]]; then
+      echo "[gh] ERROR: pre-merge review script not found or not executable: ${_gh_wrapper_review_script}" >&2
+      echo "[gh] Refusing to proceed with an unguarded merge." >&2
+      return 1
+    else
+      echo "[gh] Warning: pre-merge review script not found or not executable" >&2
+      echo "[gh] Expected: ${_gh_wrapper_review_script}" >&2
+      echo "[gh] Proceeding without review..." >&2
+    fi
+  fi
+  return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  # --- Standalone-wrapper mode (executed directly, e.g. via the
+  # ~/.local/bin/gh symlink) ---
+  set -euo pipefail
+
+  REAL_GH="$(_gh_wrapper_find_real_gh)"
+
+  # Note whether this is a help request, but the REST/GraphQL bypass block
+  # below must run regardless — `gh api pulls/123/merge --help` must not
+  # escape it by appending --help.
+  _gh_wrapper_help=0
+  for _gh_wrapper_arg in "$@"; do
+    if [[ "${_gh_wrapper_arg}" == "--help" || "${_gh_wrapper_arg}" == "-h" ]]; then
+      _gh_wrapper_help=1
+      break
+    fi
+  done
+
+  if [[ -z "${_GH_REVIEW_DONE:-}" ]]; then
+    _gh_wrapper_block_bypass "$@" || exit 1
+    if [[ "${_gh_wrapper_help}" != "1" ]]; then
+      _gh_wrapper_maybe_review strict "$@" || exit 1
+    fi
+  fi
+
+  # Token routing for claude-wrapper multi-org support
+  if [[ -n "${CLAUDE_GH_TOKEN_ROUTER:-}" ]] && [[ -f "${CLAUDE_GH_TOKEN_ROUTER}" ]]; then
+    # shellcheck source=/dev/null
+    source "${CLAUDE_GH_TOKEN_ROUTER}" "$@"
+  fi
+
+  exec "${REAL_GH}" "$@"
+else
+  # --- Function-definition mode (sourced from functions.sh) ---
+  gh() {
+    # Note whether this is a help request, but the REST/GraphQL bypass block
+    # below must run regardless — `gh api pulls/123/merge --help` must not
+    # escape it by appending --help.
+    local help=0 arg
+    for arg in "$@"; do
+      if [[ "${arg}" == "--help" || "${arg}" == "-h" ]]; then
+        help=1
+        break
+      fi
+    done
+
+    _gh_wrapper_block_bypass "$@" || return 1
+
+    if [[ "${help}" == "1" ]]; then
+      # Set _GH_REVIEW_DONE so the ~/.local/bin/gh wrapper also skips review.
+      _GH_REVIEW_DONE=1 command gh "$@"
+      return $?
+    fi
+
+    _gh_wrapper_maybe_review warn "$@" || return 1
+
+    # Run the real gh command. Set _GH_REVIEW_DONE so the ~/.local/bin/gh
+    # wrapper (found again via `command gh`, since ~/.local/bin is early in
+    # PATH) does not run the review a second time.
+    _GH_REVIEW_DONE=1 command gh "$@"
+  }
+  export -f gh # Exported - overrides system gh command globally
+fi

--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # ~/.config/bash/gh-wrapper.sh
 #shellcheck shell=bash
-# Canonical implementation of the `gh` PR-merge guard (pre-merge review +
-# REST/GraphQL merge-bypass blocking). One file, two invocation modes:
+# Canonical implementation of the `gh` identity auto-switch and PR-merge
+# guard (pre-merge review + REST/GraphQL merge-bypass blocking). One file,
+# two invocation modes:
 #
 #   1. Sourced from functions.sh: defines gh() as a bash function. This wins
 #      over PATH lookup for any bash process — interactive shells (via
@@ -22,6 +23,39 @@
 # same file again in standalone-wrapper mode.
 
 _gh_wrapper_review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
+
+# gh has one active account per host (not per repo), unlike git+SSH which
+# already resolves the right identity per remote via ~/.ssh/config host
+# aliases. This keeps gh in sync with that same per-repo intent: repos owned
+# by smartwatermelon use the smartwatermelon account; everything else
+# (Beacon repos, etc.) falls back to andrewmrich. Local-only (reads/writes
+# gh's config file, no network), so it's cheap to run on every invocation.
+# Caveat: this mutates global gh state, so concurrent shells working in
+# different-owner repos at the same time can race each other.
+_gh_wrapper_sync_identity() {
+  local remote_url owner desired current
+
+  remote_url=$(command git config --get remote.origin.url 2>/dev/null)
+  [[ -z "${remote_url}" ]] && return 0
+
+  owner=$(printf '%s\n' "${remote_url}" | sed -E 's#^(git@[^:]+:|[a-zA-Z]+://[^/]+/)##; s#/.*##')
+  [[ -z "${owner}" ]] && return 0
+
+  if [[ "${owner}" == "smartwatermelon" ]]; then
+    desired="smartwatermelon"
+  else
+    desired="andrewmrich"
+  fi
+
+  current=$(awk '/^github\.com:/{f=1} f && /^ *user:/{print $2; exit}' "${HOME}/.config/gh/hosts.yml" 2>/dev/null | tr -d "\"'")
+
+  if [[ -n "${current}" && "${current}" != "${desired}" ]]; then
+    if ! command gh auth switch --hostname github.com --user "${desired}" >/dev/null 2>&1; then
+      echo "[gh] ERROR: failed to switch identity to '${desired}' (repo owner: '${owner}') — refusing to run as '${current}' instead" >&2
+      return 1
+    fi
+  fi
+}
 
 # Find the real `gh` binary, skipping ourselves. Only meaningful in
 # standalone-wrapper mode.
@@ -49,7 +83,7 @@ _gh_wrapper_find_real_gh() {
 # Blocks REST/GraphQL PR-merge bypass vectors that skip pre-merge-review.sh
 # and the merge-lock check entirely. Returns 1 if the call should be blocked.
 _gh_wrapper_block_bypass() {
-  if [[ "$1" == "api" ]] && printf '%s\n' "$*" | grep -qE 'pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
+  if [[ "${1:-}" == "api" ]] && printf '%s\n' "$*" | grep -qE 'pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
     echo "[gh] BLOCKED: Direct REST API PR merge bypasses pre-merge review and merge authorization." >&2
     echo "[gh] This endpoint skips pre-merge-review.sh and the merge-lock check." >&2
     echo "[gh] Use 'gh pr merge <number>' instead." >&2
@@ -57,7 +91,7 @@ _gh_wrapper_block_bypass() {
     return 1
   fi
 
-  if [[ "$1" == "api" ]] && printf '%s\n' "$*" | grep -qE 'graphql.*mergePullRequest[[:space:]]*\('; then
+  if [[ "${1:-}" == "api" ]] && printf '%s\n' "$*" | grep -qE 'graphql.*mergePullRequest[[:space:]]*\('; then
     echo "[gh] BLOCKED: GraphQL mergePullRequest mutation bypasses pre-merge review and merge authorization." >&2
     echo "[gh] Use 'gh pr merge <number>' instead." >&2
     echo "[gh] If gh pr merge fails, report the failure and ask the human to merge manually." >&2
@@ -137,12 +171,18 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     fi
   done
 
-  # Safe to skip both checks when _GH_REVIEW_DONE is set: that only happens
-  # when function mode already ran _gh_wrapper_block_bypass and
-  # _gh_wrapper_maybe_review before calling `command gh` (which lands here).
-  # If a future change ever sets _GH_REVIEW_DONE before running those checks
-  # in function mode, this skip becomes unsafe — keep the two in lockstep.
+  # Safe to skip all three checks when _GH_REVIEW_DONE is set: that only
+  # happens when function mode already ran them before calling `command gh`
+  # (which lands here). If a future change ever sets _GH_REVIEW_DONE before
+  # running those checks in function mode, this skip becomes unsafe — keep
+  # the two in lockstep.
   if [[ -z "${_GH_REVIEW_DONE:-}" ]]; then
+    # Don't auto-switch identity while the user is managing accounts
+    # directly, or for --help/-h — informational calls shouldn't mutate
+    # global auth state.
+    if [[ "${1:-}" != "auth" && "${_gh_wrapper_help}" != "1" ]]; then
+      _gh_wrapper_sync_identity || exit 1
+    fi
     _gh_wrapper_block_bypass "$@" || exit 1
     if [[ "${_gh_wrapper_help}" != "1" ]]; then
       _gh_wrapper_maybe_review strict "$@" || exit 1
@@ -170,6 +210,13 @@ else
       fi
     done
 
+    # Don't auto-switch identity while the user is managing accounts
+    # directly, or for --help/-h — informational calls shouldn't mutate
+    # global auth state.
+    if [[ "${1:-}" != "auth" && "${help}" != "1" ]]; then
+      _gh_wrapper_sync_identity || return 1
+    fi
+
     _gh_wrapper_block_bypass "$@" || return 1
 
     if [[ "${help}" == "1" ]]; then
@@ -189,6 +236,6 @@ else
   # its own body into subshells, not functions it calls. Without exporting
   # these too, gh() would break in any subshell that inherits the exported
   # gh but didn't source this file (e.g. BASH_ENV unset/overridden there).
-  export -f gh _gh_wrapper_block_bypass _gh_wrapper_maybe_review
+  export -f gh _gh_wrapper_block_bypass _gh_wrapper_maybe_review _gh_wrapper_sync_identity
   export _gh_wrapper_review_script
 fi

--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -179,5 +179,10 @@ else
     # PATH) does not run the review a second time.
     _GH_REVIEW_DONE=1 command gh "$@"
   }
-  export -f gh # Exported - overrides system gh command globally
+  # Export gh AND the helpers it calls: an exported function only carries
+  # its own body into subshells, not functions it calls. Without exporting
+  # these too, gh() would break in any subshell that inherits the exported
+  # gh but didn't source this file (e.g. BASH_ENV unset/overridden there).
+  export -f gh _gh_wrapper_block_bypass _gh_wrapper_maybe_review
+  export _gh_wrapper_review_script
 fi

--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -33,8 +33,8 @@ _gh_wrapper_find_real_gh() {
   for dir in ${PATH}; do
     candidate="${dir}/gh"
     if [[ -x "${candidate}" ]]; then
-      candidate_real="$(realpath "${candidate}" 2>/dev/null)"
-      if [[ "${candidate_real}" != "${self}" ]]; then
+      candidate_real="$(realpath "${candidate}" 2>/dev/null || true)"
+      if [[ -n "${candidate_real}" ]] && [[ "${candidate_real}" != "${self}" ]]; then
         printf '%s\n' "${candidate}"
         return 0
       fi

--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # ~/.config/bash/gh-wrapper.sh
 #shellcheck shell=bash
 # Canonical implementation of the `gh` PR-merge guard (pre-merge review +
@@ -136,6 +137,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     fi
   done
 
+  # Safe to skip both checks when _GH_REVIEW_DONE is set: that only happens
+  # when function mode already ran _gh_wrapper_block_bypass and
+  # _gh_wrapper_maybe_review before calling `command gh` (which lands here).
+  # If a future change ever sets _GH_REVIEW_DONE before running those checks
+  # in function mode, this skip becomes unsafe — keep the two in lockstep.
   if [[ -z "${_GH_REVIEW_DONE:-}" ]]; then
     _gh_wrapper_block_bypass "$@" || exit 1
     if [[ "${_gh_wrapper_help}" != "1" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -256,11 +256,14 @@ if [[ "${DRY_RUN}" == true ]]; then
   _dry "Would symlink: ~/.digrc -> ~/.config/dig/digrc"
   _dry "Would symlink: ~/.shellcheckrc -> ~/.config/shellcheck/.shellcheckrc"
   _dry "Would symlink: ~/.markdownlint.json -> ~/.config/markdownlint-cli/.markdownlint.json"
+  _dry "Would symlink: ~/.local/bin/gh -> ~/.config/bash/gh-wrapper.sh"
 else
   _ensure_symlink "${HOME}/.config/bash/.bash_profile" "${HOME}/.bash_profile"
   _ensure_symlink "${HOME}/.config/dig/digrc" "${HOME}/.digrc"
   _ensure_symlink "${HOME}/.config/shellcheck/.shellcheckrc" "${HOME}/.shellcheckrc"
   _ensure_symlink "${HOME}/.config/markdownlint-cli/.markdownlint.json" "${HOME}/.markdownlint.json"
+  mkdir -p "${HOME}/.local/bin"
+  _ensure_symlink "${HOME}/.config/bash/gh-wrapper.sh" "${HOME}/.local/bin/gh"
 fi
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Consolidates the `gh()` bash function (functions.sh) and the `~/.local/bin/gh` standalone wrapper into one canonical file, `bash/gh-wrapper.sh`, which behaves as a function-definition library when sourced and as a standalone PATH shim when executed directly (`[[ "${BASH_SOURCE[0]}" == "${0}" ]]`).
- Both invocation modes now share identical REST/GraphQL merge-bypass blocking and pre-merge review gating (previously only the bash function had the REST/GraphQL checks).
- `install.sh` now manages `~/.local/bin/gh` as a real symlink to `~/.config/bash/gh-wrapper.sh`, matching the convention used by every other entry in `~/.local/bin`.
- Fail-closed stub in `functions.sh` if `gh-wrapper.sh` is missing (e.g. broken symlink), rather than silently dropping the merge guard.
- Fixed a `set -e`/`realpath` bug in the real-`gh`-binary PATH scan, and added the shebang the standalone wrapper needs to work for non-bash callers.

## Test plan
- [x] shellcheck clean at `-S info`
- [x] Full local shell test suite passes
- [x] Both invocation modes verified (function mode, standalone mode, `--help` passthrough, REST/GraphQL bypass block in both)
- [x] Fail-closed stub verified when `gh-wrapper.sh` is missing
- [x] Non-bash caller (direct execve, not `bash script.sh`) verified to hit the shebang and work correctly
- [x] Pre-push Semgrep + adversarial-reviewer + codebase-reviewer all passed (3 non-blocking follow-up issues filed: #123, #124, #125)

https://claude.ai/code/session_01DRXBxWxYKyZUtb9dtsA294