### PR TITLE
chore: remove headroom-ai remnants from pipx update helper

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -449,9 +449,7 @@ _pipx_update() {
   _notif "Updating pipx packages..."
   echo "=== pipx update ${timestamp} ===" | _update_log
 
-  # headroom-ai is installed as an editable local fork with a maturin (Rust)
-  # build backend; PyO3 needs this flag to build on Python > 3.13.
-  output=$(PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 pipx upgrade-all --verbose 2>&1)
+  output=$(pipx upgrade-all --verbose 2>&1)
   result=$?
   echo "${output}" | _update_log
 


### PR DESCRIPTION
## Summary
- Headroom has been fully decommissioned. Removes the deleted headroom:learn-generated CLAUDE.md and the stale headroom-ai comment in bash/functions.sh's _pipx_update.

https://claude.ai/code/session_215f11d6-fd80-488b-9ae8-2e0fc0f51f9d