### PR TITLE
feat(pre-commit): add zizmor GitHub Actions security lint

### DIFF
--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -94,6 +94,21 @@ pre-commit/
   - MD024 siblings_only (allows duplicate headings in different sections)
   - Other rules disabled for documentation flexibility
 
+### GitHub Actions Workflows
+
+**zizmor**
+
+- **Type**: System tool
+- **Entry**: `zizmor`
+- **Purpose**: Security lints `.github/workflows/*` for dangerous triggers,
+  cache poisoning, unpinned actions, template injection, and excessive
+  permissions
+- **When**: Runs only on `.github/workflows/*.yml`/`*.yaml` files
+  (`files: ^\.github/workflows/.*\.ya?ml$`)
+- **Context**: Adopted as a Tier 3 follow-up to the 2026-04-29 GitHub Actions
+  security audit — see
+  [smartwatermelon/dev-env#19](https://github.com/smartwatermelon/dev-env/issues/19)
+
 ## Usage
 
 ### In a New Project
@@ -161,6 +176,12 @@ brew install yamllint
 
 ```bash
 brew install tidy-html5
+```
+
+**For GitHub Actions security linting**:
+
+```bash
+brew install zizmor
 ```
 
 ### Framework Installation
@@ -266,6 +287,9 @@ brew install yamllint
 
 # For tidy issues
 brew install tidy-html5
+
+# For zizmor issues
+brew install zizmor
 ```
 
 ### Hooks not running
@@ -310,3 +334,4 @@ pre-commit install --install-hooks
 - [ShellCheck Wiki](https://www.shellcheck.net/wiki/)
 - [yamllint Docs](https://yamllint.readthedocs.io/)
 - [markdownlint Rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)
+- [zizmor Docs](https://docs.zizmor.sh/)

--- a/pre-commit/config.yaml
+++ b/pre-commit/config.yaml
@@ -98,3 +98,19 @@ repos:
         files: \.(js|jsx|ts|tsx|json|css)$
         pass_filenames: true
         verbose: true
+
+  # GitHub Actions workflow security linting (zizmor). Catches dangerous
+  # triggers, cache poisoning, unpinned actions, template injection, and
+  # excessive permissions in .github/workflows/*. Tier 3 follow-up to the
+  # 2026-04-29 GitHub Actions security audit — see
+  # smartwatermelon/dev-env#19. Requires `brew install zizmor` once locally
+  # (language: system expects the binary already on PATH).
+  - repo: local
+    hooks:
+      - id: zizmor
+        name: "GitHub Actions Security Lint (zizmor)"
+        entry: zizmor
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: true
+        verbose: true


### PR DESCRIPTION
## Summary

- Adds `zizmor` as a `repo: local` pre-commit hook, scoped to `.github/workflows/*.yml`/`*.yaml` via `files: ^\.github/workflows/.*\.ya?ml$`
- Follows the existing `language: system` convention used by `yamllint`/`markdownlint`/`luacheck` in this config — shells out to a Homebrew-installed binary rather than a hosted pre-commit-hooks repo
- Documents the new hook in `pre-commit/README.md` (Configured Linters, Required System Tools, troubleshooting, references)

This is the pre-commit integration path (path 1 of 3) proposed in [smartwatermelon/dev-env#19](https://github.com/smartwatermelon/dev-env/issues/19), a Tier 3 follow-up to the 2026-04-29 GitHub Actions security audit. The companion documentation PR is smartwatermelon/dev-env#34.

**Out of scope**: CI-side enforcement (a reusable `zizmor.yml` in `smartwatermelon/github-workflows`) is a separate, not-yet-started follow-up — not touched by this PR.

## Test plan

- [x] Installed `zizmor` locally via `brew install zizmor` and confirmed the binary runs and produces findings against real workflow files
- [x] Ran the hook via `pre-commit run --config <config> zizmor` against a scratch repo containing a copied workflow file — hook fired, correctly reported findings, exited non-zero
- [x] Verified scoping: hook reports "(no files to check)" / skips when only non-workflow files are staged
- [x] Both `code-reviewer` and `adversarial-reviewer` passed locally on both commits in this branch (see git hook output)

Claude-Session: https://claude.ai/code/session_01SsnvQEpWgMxcRocq8bBVSE