### PR TITLE
fix(ci): harden dependabot bot check and drop dangling doc reference

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,8 +1,9 @@
 name: Dependabot Auto-Merge
 
 # Safely auto-merges Dependabot PRs after CI passes. Scope is narrow:
-#  - Only runs when github.actor == 'dependabot[bot]' (not spoofable;
-#    GitHub sets this from the authenticated user).
+#  - Only runs when the PR author is dependabot[bot], checked via
+#    github.event.pull_request.user.login (not github.actor, which
+#    zizmor flags as spoofable in other trigger contexts).
 #  - Patch/minor: always auto-merged.
 #  - Major: only auto-merged when EVERY listed dependency belongs to a
 #    trusted namespace (dependabot/, actions/, smartwatermelon/). One
@@ -21,10 +22,9 @@ name: Dependabot Auto-Merge
 # status checks pass; failing CI leaves the PR open indefinitely.
 #
 # Provisioned 2026-04-18 (v2.0.1 / Phase 5). Hardened 2026-04-28 with
-# the trusted-namespace allowlist + version-comparison defense. See
-# docs/plans/2026-04-28-dependabot-auto-merge-c2.md.
+# the trusted-namespace allowlist + version-comparison defense.
 
-on:
+on: # zizmor: ignore[dangerous-triggers] required so this runs from the base branch (see line 10); no PR code is ever executed
   pull_request_target:
     types: [opened, synchronize, reopened]
 
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata


### PR DESCRIPTION
## Summary
- Replace `github.actor` with `github.event.pull_request.user.login` for the dependabot[bot] gate in `dependabot-auto-merge.yml` — closes a zizmor `bot-conditions` finding where `github.actor` reflects whoever re-triggers the run, not the immutable PR author.
- Add a justified inline `zizmor: ignore[dangerous-triggers]` suppression for the `pull_request_target` trigger, which this workflow requires by design (base-branch execution so a PR can't alter its own auto-merge logic; no PR code is ever executed).
- Drop the header comment's pointer to `docs/plans/2026-04-28-dependabot-auto-merge-c2.md`, a planning doc that was never added to the repo.

Closes #80.

## Test plan
- [x] `zizmor` clean on the modified workflow (0 findings, 1 ignored/justified)
- [x] `yamllint` clean (pre-existing line-length warnings only, unrelated to this change)
- [x] Local code-reviewer + adversarial-reviewer: PASS
- [x] Pre-push full-diff + codebase review: PASS

https://claude.ai/code/session_018SBDDsRrkSzzDcWFbknGSj