### PR TITLE
fix(path): detect Android SDK at Homebrew cmdline-tools install path

### DIFF
--- a/bash/path.sh
+++ b/bash/path.sh
@@ -99,9 +99,17 @@ unset _path_tiers _dir _new_path GEM_EXE_DIR
 # LOWEST PRIORITY — appended, not prepended
 # ============================================================================
 
-# Android SDK (only if installed)
-if [[ -d "${HOME}/Library/Android/sdk" ]]; then
-  export ANDROID_HOME="${HOME}/Library/Android/sdk"
-  _append_path_once "${ANDROID_HOME}/emulator"
-  _append_path_once "${ANDROID_HOME}/platform-tools"
-fi
+# Android SDK (only if installed) — probe Android Studio's default location
+# first, then Homebrew cmdline-tools install paths.
+for _android_candidate in \
+  "${HOME}/Library/Android/sdk" \
+  "/opt/homebrew/share/android-commandlinetools" \
+  "/usr/local/share/android-commandlinetools"; do
+  if [[ -d "${_android_candidate}" ]]; then
+    export ANDROID_HOME="${_android_candidate}"
+    _append_path_once "${ANDROID_HOME}/emulator"
+    _append_path_once "${ANDROID_HOME}/platform-tools"
+    break
+  fi
+done
+unset _android_candidate


### PR DESCRIPTION
## Summary
- Android SDK detection in `bash/path.sh` only checked Android Studio's default install path (`~/Library/Android/sdk`), silently no-opping on systems where the SDK was installed via `brew install --cask android-commandlinetools` (which installs to `/opt/homebrew/share/android-commandlinetools` or `/usr/local/share/android-commandlinetools` on Intel).
- Now probes all three common install locations in priority order (Android Studio first), setting `ANDROID_HOME` and appending `emulator`/`platform-tools` from whichever is found first.

Closes #69

## Test plan
- [x] Read current file to confirm exact line numbers/context before editing
- [x] `shellcheck -S info bash/path.sh` — no new warnings vs. pre-change baseline (verified via git stash diff)
- [x] Local pre-commit hooks (shfmt auto-format, code-reviewer, adversarial-reviewer) passed
- [x] Local pre-push hooks (semgrep, full-diff review, codebase review) passed
- [ ] Manual verification on a machine with only Android Studio's SDK: behavior unchanged
- [ ] Manual verification on a machine with only Homebrew cmdline-tools: `ANDROID_HOME` resolves, `avdmanager`/`sdkmanager` on PATH via `cmdline-tools/latest/bin` (not covered by this change — see note below), `emulator`/`platform-tools` land on PATH once installed via `sdkmanager`
- [ ] Manual verification on a machine with neither: no export, no error

Note: Homebrew's `android-commandlinetools` cask installs only `cmdline-tools/latest/bin` (sdkmanager, avdmanager, etc.) by default — `emulator` and `platform-tools` are separate SDK packages installed afterward via `sdkmanager`, at which point they land directly under `${ANDROID_HOME}/emulator` and `${ANDROID_HOME}/platform-tools`, matching Android Studio's layout. This matches the fix as scoped in the issue.