### PR TITLE
fix(hooks): make post-commit sed invocation portable across BSD/GNU

### DIFF
--- a/git/hooks/post-commit
+++ b/git/hooks/post-commit
@@ -11,16 +11,29 @@ set -euo pipefail
 # both the per-repo and global review logs.
 #
 
+# Portable in-place sed: BSD sed (macOS) requires a backup-suffix arg after
+# -i (empty string for "no backup"); GNU sed (Linux) rejects that as an
+# invalid script. Detect via `sed --version` (GNU-only flag) and branch.
+_portable_sed_inplace() {
+  local _script="$1"
+  local _file="$2"
+  if sed --version >/dev/null 2>&1; then
+    sed -i "${_script}" "${_file}"
+  else
+    sed -i '' "${_script}" "${_file}"
+  fi
+}
+
 _real_hash=$(git rev-parse --short HEAD 2>/dev/null) || exit 0
 
 # Per-repo log
 _repo_log="$(git rev-parse --git-dir 2>/dev/null)/last-review-result.log"
 if [[ -f "${_repo_log}" ]]; then
-  sed -i '' "s/^commit: .*/commit: ${_real_hash}/" "${_repo_log}"
+  _portable_sed_inplace "s/^commit: .*/commit: ${_real_hash}/" "${_repo_log}"
 fi
 
 # Global pointer
 _global_log="${HOME}/.claude/last-review-result.log"
 if [[ -f "${_global_log}" ]]; then
-  sed -i '' "s/^commit: .*/commit: ${_real_hash}/" "${_global_log}"
+  _portable_sed_inplace "s/^commit: .*/commit: ${_real_hash}/" "${_global_log}"
 fi


### PR DESCRIPTION
## Summary
- `git/hooks/post-commit` used BSD-only `sed -i ''` syntax at both call sites (per-repo and global review log patching). GNU sed treats the empty string as the script itself rather than a backup-suffix argument, causing a hard failure on Linux.
- Adds a `_portable_sed_inplace()` helper that detects GNU vs BSD sed via `sed --version` (a GNU-only flag) and branches to the correct invocation, replacing both call sites with a single call.

Closes #30

## Test plan
- [x] `shellcheck -S info git/hooks/post-commit` — clean, no new warnings
- [x] `bash -n git/hooks/post-commit` — syntax valid
- [x] Verified locally on macOS (BSD sed) that the hook still patches `commit:` in both the per-repo and global review logs after a real commit
- [x] Pre-commit and pre-push review hooks (code-reviewer, adversarial-reviewer, full-diff/codebase review) ran clean on this change