### PR TITLE
fix(gh-wrapper): harden -R/--repo parsing and document identity mapping risk

### DIFF
--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ~/.config/bash/gh-wrapper.sh
-#shellcheck shell=bash
+# shellcheck shell=bash
 # Canonical implementation of the `gh` identity auto-switch and PR-merge
 # guard (pre-merge review + REST/GraphQL merge-bypass blocking). One file,
 # two invocation modes:
@@ -44,6 +44,7 @@ _gh_wrapper_sync_identity() {
 
   repo_flag_value=""
   for arg in "$@"; do
+    [[ "${arg}" == "--" ]] && break
     if [[ "${skip_next}" == "1" ]]; then
       repo_flag_value="${arg}"
       skip_next=0
@@ -53,6 +54,10 @@ _gh_wrapper_sync_identity() {
       -R | --repo) skip_next=1 ;;
       --repo=*)
         repo_flag_value="${arg#--repo=}"
+        break
+        ;;
+      -R*)
+        repo_flag_value="${arg#-R}"
         break
         ;;
       *) ;;
@@ -70,6 +75,12 @@ _gh_wrapper_sync_identity() {
   fi
   [[ -z "${owner}" ]] && return 0
 
+  # NOTE: the nightowlstudiollc -> smartwatermelon mapping below is asserted,
+  # not verified — nothing here confirms the smartwatermelon gh account is
+  # actually authorized against nightowlstudiollc repos. A `gh auth status`
+  # check (cross-referencing the authorized orgs for the current account)
+  # would be the way to confirm this mapping is still correct; that's left
+  # as a future enhancement rather than added here to avoid scope creep.
   case "${owner}" in
     smartwatermelon | nightowlstudiollc) desired="smartwatermelon" ;;
     *) desired="andrewmrich" ;;


### PR DESCRIPTION
## Summary
- Add support for combined short-form `-Rowner/repo` in `_gh_wrapper_sync_identity`'s argument parser (gh already accepts this alongside the space-separated `-R owner/repo` form).
- Add a `--` end-of-options sentinel guard so args after a literal `--` are treated as positional, not parsed as flags (e.g. `gh -- -R owner/repo subcommand`).
- Fix a missing-space ShellCheck directive (`#shellcheck` -> `# shellcheck`) that was silently ignored — no functional impact, the shebang already establishes shell type.
- Document (comment-only) that the `smartwatermelon <-> nightowlstudiollc` identity mapping is asserted, not verified, and note that a `gh auth status` check would be the way to confirm it. No runtime verification logic added — that's a bigger behavioral change for a separate discussion.

Closes #140, #137, #124, #138

## Notes
Pre-push codebase review flagged a pre-existing, out-of-scope gap: `_gh_wrapper_maybe_review` (a separate function used for the pre-merge-review gate) doesn't handle the `-Rowner/repo` compact form either, so `gh -Rowner/repo pr merge N` could silently skip that gate. This predates this PR and isn't introduced by it; flagging here for visibility rather than fixing inline, since it's a different function/concern than the four issues this PR targets.

## Test plan
- [x] `shellcheck -S info bash/gh-wrapper.sh` clean
- [x] Manual parsing test covering: combined short form (`-Rowner/repo`), space-separated (`-R owner/repo`), long form (`--repo owner/repo`), long form with `=` (`--repo=owner/repo`), `--` sentinel guard, and no-flag fallback — all 6 cases produced expected `repo_flag_value`
- [x] Local pre-commit hooks (code-reviewer + adversarial-reviewer): PASS
- [x] Local pre-push hooks (full-diff + codebase review): PASS
