### PR TITLE
docs(env): clarify MANPATH/INFOPATH drop and fix comment placement/refs

### DIFF
--- a/bash/env.sh
+++ b/bash/env.sh
@@ -3,6 +3,11 @@
 # Environment variable configuration
 
 # Load secret env vars
+#
+# 1Password CLI tokens (OP_SERVICE_ACCOUNT_TOKEN, GH_TOKEN) are injected
+# exclusively by claude-wrapper at CCCLI launch. Interactive shells started
+# outside claude-wrapper will have neither token set and must run `op signin`
+# (or use `opp()` from functions.sh) for 1Password CLI auth.
 #shellcheck disable=SC2154
 if [[ -f "${BASH_CONFIG_DIR}/secrets.sh" ]]; then
   #shellcheck source=/dev/null
@@ -16,11 +21,6 @@ if [[ -f "${BASH_CONFIG_DIR}/beacon.sh" ]]; then
   #shellcheck source=/dev/null
   source "${BASH_CONFIG_DIR}/beacon.sh"
 fi
-
-# 1Password CLI tokens (OP_SERVICE_ACCOUNT_TOKEN, GH_TOKEN) are injected
-# exclusively by claude-wrapper at CCCLI launch. Interactive shells started
-# outside claude-wrapper will have neither token set and must run `op signin`
-# (or use `opp` from functions.sh) for 1Password CLI auth.
 
 # Silence macOS Bash deprecation warning
 export BASH_SILENCE_DEPRECATION_WARNING=1
@@ -84,6 +84,13 @@ if command -v brew &>/dev/null; then
     echo "[ERROR] brew shellenv contains suspicious patterns, refusing to eval" >&2
     echo "[ERROR] Output: ${BREW_SHELLENV}" >&2
   else
+    # PATH is intentionally dropped here — path.sh owns PATH construction
+    # separately. MANPATH and INFOPATH are also intentionally dropped:
+    # Homebrew's installer writes /etc/manpaths.d/homebrew at install time,
+    # which macOS's man command reads automatically, so man pages for
+    # Homebrew-installed tools still resolve without MANPATH being set. If a
+    # machine was bootstrapped in a way that skipped that step, man pages
+    # could go missing silently.
     eval "$(grep -vE '^export (PATH|MANPATH|INFOPATH)=' <<<"${BREW_SHELLENV}")"
   fi
   if [[ $(type -t _profile_time) == "function" ]] && [[ "$-" == *i* ]]; then

--- a/install.sh
+++ b/install.sh
@@ -262,6 +262,8 @@ else
   _ensure_symlink "${HOME}/.config/dig/digrc" "${HOME}/.digrc"
   _ensure_symlink "${HOME}/.config/shellcheck/.shellcheckrc" "${HOME}/.shellcheckrc"
   _ensure_symlink "${HOME}/.config/markdownlint-cli/.markdownlint.json" "${HOME}/.markdownlint.json"
+  # ~/.local/bin must exist before this symlink is created; section 5
+  # (CREATE DIRECTORIES) runs after this block, so it's created here instead.
   mkdir -p "${HOME}/.local/bin"
   _ensure_symlink "${HOME}/.config/bash/gh-wrapper.sh" "${HOME}/.local/bin/gh"
 fi
@@ -270,17 +272,16 @@ fi
 # 5. CREATE DIRECTORIES
 # ============================================================================
 
-for dir in "${HOME}/.local/bin" "${HOME}/.local/state/bash"; do
-  if [[ -d "${dir}" ]]; then
-    _skip "Directory exists: ${dir}"
-  elif [[ "${DRY_RUN}" == true ]]; then
-    _dry "Would create directory: ${dir}"
-  else
-    mkdir -p "${dir}"
-    _ok "Created directory: ${dir}"
-    installed+=("dir:${dir}")
-  fi
-done
+dir="${HOME}/.local/state/bash"
+if [[ -d "${dir}" ]]; then
+  _skip "Directory exists: ${dir}"
+elif [[ "${DRY_RUN}" == true ]]; then
+  _dry "Would create directory: ${dir}"
+else
+  mkdir -p "${dir}"
+  _ok "Created directory: ${dir}"
+  installed+=("dir:${dir}")
+fi
 
 # ============================================================================
 # 6. PIPX PACKAGES


### PR DESCRIPTION
## Summary
- Documents why `brew shellenv`'s MANPATH/INFOPATH exports are intentionally dropped (Homebrew's installer writes `/etc/manpaths.d/homebrew`, so macOS's `man` still resolves pages without MANPATH set).
- Relocates the 1Password CLI token comment to sit directly above the `secrets.sh` source guard so it's found immediately when scanning for secrets-loading logic.
- Fixes a bare `opp` reference to `opp()` in a comment so it reads as a function call and stays grep-able.
- Removes the redundant `~/.local/bin` directory creation in `install.sh` — it's now created once, inline, immediately before the symlink step that needs it (section 4), instead of being duplicated in section 5's directory-creation loop.

All changes are cosmetic/doc-only with no behavior change.

Closes #125, #114, #50, #49

## Test plan
- [x] `shellcheck -S info bash/env.sh install.sh` — no new warnings (pre-existing SC2312 info-level warnings only)
- [x] Local pre-commit hook (code-reviewer + adversarial-reviewer) — both PASS
- [x] Local pre-push hook (full-diff + codebase review) — both PASS, one non-blocking cosmetic note about dry-run output fidelity (pre-existing behavior, not a regression)