### PR TITLE
fix(pre-commit): skip semgrep-secrets hook gracefully when semgrep absent

### DIFF
--- a/pre-commit/config.yaml
+++ b/pre-commit/config.yaml
@@ -9,7 +9,10 @@ repos:
     hooks:
       - id: semgrep-secrets
         name: "Semgrep Secrets Scan (p/secrets + p/gitleaks)"
-        entry: semgrep scan --config=p/secrets --config=p/gitleaks --error --quiet --oss-only
+        entry: >-
+          bash -c 'command -v semgrep &>/dev/null || exit 0;
+          semgrep scan --config=p/secrets --config=p/gitleaks
+          --error --quiet --oss-only "$@"' --
         language: system
         pass_filenames: true
         exclude_types: [binary]


### PR DESCRIPTION
## Summary
- The `semgrep-secrets` pre-commit hook assumed `semgrep` was on PATH; on a fresh clone without semgrep installed, every commit failed with `semgrep: command not found`.
- Wraps the hook entry in a `bash -c` availability check (`command -v semgrep &>/dev/null || exit 0`) before running the scan, matching the existing pattern in `git/hooks/pre-push`.
- The availability check and the scan are sequenced with `;` rather than `&&`/`||` chained across the whole expression — an earlier draft used `||` end-to-end, which silently swallowed genuine secret findings (a real semgrep failure would also trigger the `|| exit 0` fallback). Caught by local adversarial review before this PR was opened.

Closes #65

## Test plan
- [x] Verified filenames pass through correctly via `"$@"` when `pass_filenames: true` (including a filename with a space)
- [x] Verified graceful skip (exit 0) when semgrep binary is absent (simulated via bogus command name)
- [x] Verified a real semgrep finding (planted a fake AWS key) still produces a non-zero exit and blocks the commit
- [x] Verified `pre-commit run semgrep-secrets` passes with semgrep installed and staged files
- [x] `yamllint` clean (wrapped long entry line in YAML folded scalar `>-` to stay under 120 chars)
- [x] Local pre-commit and pre-push hooks (code-reviewer + adversarial-reviewer) passed