### PR TITLE
fix(hooks): harden semgrep fallback, CI filter, cleanup traps

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -315,6 +315,15 @@ SHIM
 }
 # Not exported - internal helper
 
+# Cleanup helper for the sudo shim, invoked both on the normal path and via
+# a TERM/INT trap so a killed process (e.g. LaunchAgent forcibly terminated)
+# doesn't leave the temp dir behind. Takes the shim dir as $1 so it can be
+# wired into `trap` with the value baked in at trap-set time.
+_updates_shim_cleanup() {
+  rm -rf "$1"
+}
+# Not exported - internal helper
+
 # Update Homebrew packages
 # Package managers provide their own network error diagnostics, so no pre-check needed
 _homebrew_update() {
@@ -363,6 +372,22 @@ _homebrew_update() {
     shim_dir=$(_updates_sudo_shim) || shim_dir=""
     if [[ -n "${shim_dir}" ]]; then
       upgrade_path="${shim_dir}:${PATH}"
+      # Normal-path cleanup happens after `brew upgrade` returns below, but
+      # if this process is killed mid-run (e.g. LaunchAgent forcibly
+      # terminated), that line never executes and the temp dir lingers.
+      # Catch SIGTERM/SIGINT too, via the shared cleanup helper with the
+      # shim dir path quoted into the trap command at set-time. Traps are
+      # process-scoped (not function-scoped), so save whatever TERM/INT
+      # handlers the caller already had and restore them on the cleanup
+      # path below instead of unconditionally clearing to "default" —
+      # this function may run inside an interactive shell or a parent
+      # script with its own signal handling.
+      local prev_term_trap prev_int_trap
+      prev_term_trap=$(trap -p TERM)
+      prev_int_trap=$(trap -p INT)
+      local shim_trap_cmd
+      printf -v shim_trap_cmd '_updates_shim_cleanup %q' "${shim_dir}"
+      trap -- "${shim_trap_cmd}" TERM INT
     else
       _notif "Warning: sudo shim unavailable - a sudo-invoking formula may prompt"
     fi
@@ -372,7 +397,14 @@ _homebrew_update() {
   output=$(PATH="${upgrade_path}" brew upgrade "${upgrade_args[@]}" 2>&1)
   result=$?
   echo "${output}" | _update_log
-  [[ -n "${shim_dir}" ]] && rm -rf "${shim_dir}"
+  if [[ -n "${shim_dir}" ]]; then
+    _updates_shim_cleanup "${shim_dir}"
+    # Restore whatever TERM/INT handling was in place before we set ours,
+    # rather than clearing to "default" (trap -p emits a ready-to-eval
+    # `trap -- '...' SIG` command, or nothing if no handler was set).
+    eval "${prev_term_trap:-trap - TERM}"
+    eval "${prev_int_trap:-trap - INT}"
+  fi
   if [[ "${result}" -ne 0 ]]; then
     if [[ "${tolerate_upgrade_failure}" == "true" ]]; then
       _notif "brew upgrade (formulae) completed with errors (exit ${result}) - check log"

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -178,7 +178,8 @@ run_supply_chain_scan
 # --dry-run: local run; do not upload findings (real CI uploads later).
 # --oss-only: Pro Engine local binary has a version-check issue; OSS engine
 #   still runs ~2866 rules (vs ~100 with --config auto). Remove this flag
-#   once the Pro binary installs cleanly locally.
+#   once the Pro binary installs cleanly locally — see #143 for removal
+#   tracking.
 # SEMGREP_BASELINE_REF=origin/main: diff-aware scan, matches CI PR behavior.
 run_static_analysis() {
   if ! command -v semgrep &>/dev/null; then
@@ -192,7 +193,13 @@ run_static_analysis() {
 
   if [[ -z "${token}" ]]; then
     log_warning "No Semgrep API token — falling back to --config auto (narrower ruleset than CI)"
-    if ! semgrep scan --config auto --error --quiet .; then
+    # Same origin/main baseline guard as the token path below, for
+    # diff-aware scanning consistency (and speed on large repos).
+    local -a fallback_args=(scan --config auto --error --quiet)
+    if git rev-parse --verify --quiet origin/main >/dev/null; then
+      fallback_args+=(--baseline-commit origin/main)
+    fi
+    if ! semgrep "${fallback_args[@]}" .; then
       echo "" >&2
       log_warning "🛑 Semgrep found issues. Fix them before pushing."
       echo "" >&2
@@ -315,6 +322,11 @@ run_reviews() {
     cat "${codebase_log}" >&2
   fi
   rm -f "${fulldiff_log}" "${codebase_log}"
+  # Explicit cleanup above already ran; unset the trap so it doesn't
+  # linger as a process-scoped handler referencing now-out-of-scope
+  # locals once this function returns (it's only meaningful for
+  # early-exit paths still inside this function's execution).
+  trap - EXIT
 
   # Evaluate results
   local has_failure=false
@@ -402,12 +414,20 @@ check_pr_review_iteration() {
     fi
 
     # Failing CI checks (excludes Seer — advisory per Protocol 5).
+    # statusCheckRollup mixes GitHub CheckRun objects (.conclusion,
+    # .name) with legacy StatusContext objects (.state, .context) — match
+    # both shapes, using whichever identifier field is present (.name for
+    # CheckRun, .context for StatusContext) so the Seer exclusion applies
+    # symmetrically regardless of which schema a given check reports.
     local ci_failures
     ci_failures=$(echo "${pr_json}" | jq -r '
       .statusCheckRollup // []
       | map(select(
-          (.conclusion == "FAILURE" or .conclusion == "FAILED")
-          and (.name | startswith("Seer") | not)
+          (
+            (.conclusion == "FAILURE" or .conclusion == "FAILED")
+            or (.state == "FAILURE")
+          )
+          and ((.name // .context // "") | startswith("Seer") | not)
         ))
       | length' 2>/dev/null || echo "0")
 


### PR DESCRIPTION
## Summary

Five low-risk hardening fixes to `git/hooks/pre-push` (and one to `bash/functions.sh`), each addressing a small correctness/consistency gap:

- **#63** — The no-token semgrep fallback path (`semgrep scan --config auto`) now applies the same `origin/main` baseline-commit guard as the token path (`semgrep ci`), via `--baseline-commit origin/main` when `origin/main` is verified fetched. Matches CI behavior and is faster on large repos.
- **#72** — The CI-failure jq filter in `check_pr_review_iteration` now also catches legacy `StatusContext` objects (`.state == "FAILURE"`), not just `CheckRun` objects (`.conclusion`). The Seer exclusion is applied symmetrically across both shapes via `(.name // .context // "")`.
- **#31** — `run_reviews()` now unsets its `EXIT` trap (`trap - EXIT`) right after the explicit `rm -f` cleanup runs, so the trap's actual scope-of-usefulness (early-exit paths only) matches what it looks like it does.
- **#54** — `_homebrew_update` (bash/functions.sh) now sets a TERM/INT trap around the sudo-shim temp dir so a forcibly-terminated LaunchAgent run doesn't leave it behind. Since traps are process-scoped (not function-scoped), prior TERM/INT handlers are saved via `trap -p` and restored on the cleanup path instead of being clobbered. Cleanup logic is factored into a shared `_updates_shim_cleanup` helper.
- **#64** — The `--oss-only` workaround comment now references a new tracking issue for its removal: **#143** (created during this work — "Remove --oss-only workaround once Semgrep Pro Engine version-check issue is resolved"). Issue #64 itself isn't closed by this PR since it's about the missing tracking-issue link; the underlying Pro Engine bug tracked in #143 is what still needs resolving before the flag can go away.

## Review notes

Local review (code-reviewer + adversarial-reviewer, run automatically via pre-commit hook) initially flagged two legitimate issues, both fixed before the final commit:
- The Seer exclusion in the jq filter didn't originally apply to the `StatusContext` branch — fixed by unifying the exclusion check across both shapes.
- The TERM/INT trap in `_homebrew_update` would have clobbered any pre-existing signal handlers in the calling shell — fixed by saving/restoring prior handlers via `trap -p`.

## Test plan

- [x] `bash -n git/hooks/pre-push` and `bash -n bash/functions.sh` — syntax clean
- [x] `shellcheck -S info git/hooks/pre-push bash/functions.sh` — zero warnings, no disable directives used
- [x] jq filter validated against sample `statusCheckRollup` payloads (CheckRun failure, StatusContext failure, Seer exclusion in both shapes)
- [x] Trap save/restore logic validated in a standalone sandbox script (no prior trap, and prior trap present)
- [x] Pushed this branch through the actual pre-push hook (semgrep + full-diff + codebase review) — all passed
- [x] Local pre-commit hook review (code-reviewer + adversarial-reviewer) passed on final commit

Closes #63, #72, #31, #54