### PR TITLE
fix(ci): pin reusable workflow refs to SHA and document zizmor SKIP flow

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -12,14 +12,14 @@ permissions:
 
 jobs:
   claude-review:
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.0.0
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@c30bec1e6c7b9c1634897b05f46a8703518a6c7a  # v3.0.0
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
   claude-review-haiku:
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.0.0
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@c30bec1e6c7b9c1634897b05f46a8703518a6c7a  # v3.0.0
     with:
       pr_number: ${{ github.event.pull_request.number }}
       model: "claude-haiku-4-5-20251001"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,6 +20,6 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@c30bec1e6c7b9c1634897b05f46a8703518a6c7a  # v3
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/git/README.md
+++ b/git/README.md
@@ -79,6 +79,26 @@ All hooks are configured via `core.hooksPath` to use this directory instead of p
 
 **Integration**: Works with [pre-commit framework](https://pre-commit.com/) configurations in individual repos
 
+#### Bypassing pre-existing zizmor findings
+
+The `zizmor` hook (GitHub Actions security lint) checks the whole workflow
+file on every run, not just your staged diff. This means a pre-existing
+finding elsewhere in the file can block a commit even when your actual
+change is unrelated and one line long — awkward in repos with strict
+no-drive-by-cleanup norms that forbid bundling unrelated fixes into your
+commit.
+
+The supported escape hatch is to skip the hook for that commit:
+
+```bash
+SKIP=zizmor git commit
+```
+
+Tradeoff: this also skips checking your own newly-staged lines for zizmor
+findings. If you want assurance your change didn't introduce a new
+finding, run `zizmor <file>` manually against the changed file afterward
+and check whether any reported findings' line ranges overlap your diff.
+
 ### commit-msg
 
 **Purpose**: Validates Conventional Commits format and runs AI code review — this is the primary AI-review entry point

--- a/pre-commit/config.yaml
+++ b/pre-commit/config.yaml
@@ -108,6 +108,16 @@ repos:
   # 2026-04-29 GitHub Actions security audit — see
   # smartwatermelon/dev-env#19. Requires `brew install zizmor` once locally
   # (language: system expects the binary already on PATH).
+  #
+  # zizmor lints the whole file, not just your staged diff — so pre-existing
+  # findings elsewhere in a workflow file can block a commit even when your
+  # actual change is a one-line, unrelated edit. In repos with strict
+  # no-drive-by-cleanup norms (where bundling an unrelated zizmor fix into
+  # your commit isn't welcome), use `SKIP=zizmor git commit` as the
+  # supported escape hatch. Tradeoff: this also skips checking your own
+  # newly-staged lines, so if you want assurance your change didn't
+  # introduce a new finding, run `zizmor <file>` manually afterward and
+  # check whether any reported findings' line ranges overlap your diff.
   - repo: local
     hooks:
       - id: zizmor


### PR DESCRIPTION
## Summary

- Resolves #133: `claude.yml` and `claude-blocking-review.yml` referenced `smartwatermelon/github-workflows` reusable workflows via floating tags (`@v3`, `@v3.0.0`). Both tags currently resolve to the same commit, `c30bec1e6c7b9c1634897b05f46a8703518a6c7a` (verified via `git/refs/tags/*`, following the annotated-tag object for `v3.0.0`, and cross-checked against `commits/v3` / `commits/v3.0.0`). Pinned both `uses:` refs to that SHA, keeping the original tag as a trailing comment for readability.
- Resolves #136: documented the existing `SKIP=zizmor` escape hatch (in `pre-commit/config.yaml` as a comment near the hook, and in `git/README.md` as a new subsection) for cases where zizmor's whole-file lint flags pre-existing findings unrelated to a small staged diff — e.g. repos with strict no-drive-by-cleanup norms. Per prior decision, no diff-aware wrapper or org-scoped leniency was built; this is documentation-only.

## Verification

- YAML validity checked for both workflow files and `pre-commit/config.yaml` via `python3 -c "import yaml; yaml.safe_load(...)"`.
- Ran `zizmor .github/workflows/claude.yml .github/workflows/claude-blocking-review.yml` locally: the `unpinned-uses` finding is gone after pinning. Remaining findings are pre-existing `excessive-permissions` warnings on `claude-blocking-review.yml` (workflow-level `pull-requests: write`, `issues: write`, `id-token: write`) — unrelated to this change, out of scope, and exactly the kind of finding the new `SKIP=zizmor` doc addresses.
- This PR's own commit used `SKIP=zizmor git commit` to demonstrate the documented escape hatch against those pre-existing, unrelated findings; both local review hooks (code-reviewer + adversarial-reviewer) passed on commit, and the pre-push full-diff/codebase reviews also passed.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude.yml'))"` passes
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-blocking-review.yml'))"` passes
- [x] `zizmor` confirms `unpinned-uses` finding cleared on both files
- [x] Local pre-commit / pre-push review hooks passed
- [ ] CI passes on this PR

Closes #133, #136