### PR TITLE
fix(bash): guard _mas_update against hangs in non-interactive mode

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -604,6 +604,17 @@ _mas_update() {
   _notif "Updating Mac App Store apps..."
   echo "=== mas update ${timestamp} ===" | _update_log
 
+  # In non-interactive mode, `mas upgrade` can hang waiting on a GUI App
+  # Store authentication dialog on macOS versions where mas account/auth
+  # still functions (mas account itself doesn't work on macOS 12+, but
+  # upgrade's underlying auth prompt is a separate concern). Skip the
+  # actual upgrade and defer to the next interactive `updates` run.
+  if _updates_noninteractive; then
+    _notif "Non-interactive: skipping mas upgrade (deferred to next interactive run)"
+    echo "mas upgrade deferred - non-interactive mode" | _update_log
+    return 0 # Don't fail the chain - upgrade deferred by design
+  fi
+
   # Note: mas account doesn't work on macOS 12+
   # Let mas upgrade fail naturally if not authenticated
   output=$(mas upgrade 2>&1)


### PR DESCRIPTION
## Summary
- `_mas_update` had no non-interactive guard, unlike `_softwareupdate_update`
- On macOS versions where `mas` account/auth still functions, running `mas upgrade` non-interactively (e.g. from a LaunchAgent) could hang waiting on a GUI App Store authentication dialog
- Add the same `_updates_noninteractive` guard used elsewhere: skip the upgrade and defer to the next interactive run

Closes #51

## Test plan
- [x] `shellcheck -S info bash/functions.sh` clean
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer): PASS
- [x] Local pre-push review (full-diff + codebase review): PASS
- [ ] Manual: verify `_mas_update` logs deferral and returns 0 when run with `UPDATES_NONINTERACTIVE=1`





