### PR TITLE
fix(bash): harden gpush against merge commits, stalled CI, and PR-lookup ambiguity

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -1080,6 +1080,9 @@ gpush() {
       pr_number=$(gh pr view --json number -q .number 2>/dev/null)
       if [[ -n "${pr_number}" ]]; then
         echo -e "${BLUE}[gpush]${NC} PR #${pr_number} already exists, continuing"
+      else
+        echo -e "${RED}[gpush]${NC} PR already exists but could not retrieve its number — check 'gh pr view' manually." >&2
+        return 1
       fi
     fi
     if [[ -z "${pr_number}" ]]; then
@@ -1131,13 +1134,18 @@ gpush() {
   while IFS=$'\t' read -r run_id run_name; do
     [[ -z "${run_id}" ]] && continue
     echo -e "${BLUE}[gpush]${NC} Watching run ${run_id} (${run_name})..."
-    gh run watch "${run_id}" >/dev/null 2>&1 || true
+    timeout 3600 gh run watch "${run_id}" >/dev/null 2>&1 || true
 
     local run_conclusion
     run_conclusion=$(gh run view "${run_id}" --json conclusion --jq '.conclusion') || {
       echo -e "${RED}[gpush]${NC} Failed to query run ${run_id} status." >&2
       return 1
     }
+
+    if [[ -z "${run_conclusion}" || "${run_conclusion}" == "null" ]]; then
+      echo -e "${RED}[gpush]${NC} CI run ${run_id} did not complete within 1 hour — check status manually: gh run view ${run_id}" >&2
+      return 1
+    fi
 
     if [[ "${run_conclusion}" == "success" ]]; then
       echo -e "${GREEN}[gpush]${NC} Passed: ${run_name}"
@@ -1213,8 +1221,8 @@ gpush() {
     echo -e "${RED}[gpush]${NC} Failed to switch to ${default_branch}." >&2
     return 1
   fi
-  if ! git pull; then
-    echo -e "${RED}[gpush]${NC} Failed to pull ${default_branch}. Run 'git pull' manually." >&2
+  if ! git pull --ff-only; then
+    echo -e "${RED}[gpush]${NC} Fast-forward pull of ${default_branch} failed — local branch has diverged from origin. Resolve manually with 'git pull' or 'git rebase'." >&2
     return 1
   fi
   git branch -D "${branch}" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Use `git pull --ff-only` in gpush's post-merge cleanup so a diverged local default branch fails loudly instead of silently creating a merge commit that entangles unrelated history.
- Wrap `gh run watch` with `timeout 3600` so a stalled/queued CI run can't block gpush indefinitely; an empty/null run conclusion after the timeout is now treated as a distinct stalled-CI failure with guidance to check the run manually.
- When gpush's PR-creation fallback detects an "already exists" error but `gh pr view` can't retrieve the PR number, emit a specific error instead of falling through to the generic "Failed to create PR" message, which was misleading since creation didn't actually fail.

Closes #40, #39, #38

## Test plan
- [x] `shellcheck -S info bash/functions.sh` — clean, no new warnings
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer) — PASS
- [x] Local pre-push review (full-diff + codebase review) — PASS, one non-blocking informational note (pre-existing edge case, not introduced by this change)
- [ ] CI on this PR


