### PR TITLE
fix(bash): make _claude_update bypass claude-wrapper alias

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -635,7 +635,11 @@ _mas_update() {
 # Returns 0 (success) if claude is not installed to allow graceful degradation
 # Respects DISABLE_AUTOUPDATER=1 in ~/.claude/settings.json
 _claude_update() {
-  if ! command -v claude &>/dev/null; then
+  # Bypass claude-wrapper (aliased over `claude` in interactive shells) —
+  # `claude update` is a self-update of the binary and has no business
+  # launching a full CCCLI session (and its 1Password secrets injection).
+  local claude_bin="${HOME}/.local/bin/claude"
+  if [[ ! -x "${claude_bin}" ]]; then
     _notif "claude not found, skipping"
     return 0 # Not an error - claude is optional
   fi
@@ -663,7 +667,7 @@ _claude_update() {
   _notif "Updating Claude Code..."
   echo "=== claude update ${timestamp} ===" | _update_log
 
-  binary_output=$(claude update 2>&1)
+  binary_output=$("${claude_bin}" update 2>&1)
   binary_result=$?
   echo "${binary_output}" | _update_log
 


### PR DESCRIPTION
## Summary
- `_claude_update` called bare `claude update`, which in interactive shells resolves through the `claude` → `claude-wrapper` alias (`bash/aliases.sh:36`)
- The wrapper launches a full CCCLI session (with 1Password secrets injection) just to proxy the `update` subcommand — that secrets step raced on tmp files and failed
- Fixed by invoking `~/.local/bin/claude` (the raw binary) directly, matching the existing `suclaude` bypass pattern

## Test plan
- [x] `shellcheck -S info bash/functions.sh` clean
- [x] Sourced `functions.sh` and ran `_claude_update` interactively — completed with no secrets-loader errors, both "claude update completed" and "claude tools update completed"
- [x] Confirmed via `~/.local/state/updates.out` log: old failing run vs. new clean run side by side
- [x] Local pre-commit + pre-push reviews (code-reviewer, adversarial-reviewer, codebase review) all PASS

https://claude.ai/code/session_014kTEJpWr6N9zy3jqDZdohk