### PR TITLE
fix(bash): dry-run reports ~/.local/bin creation; gh-wrapper -R parsing hardened

### DIFF
--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -157,12 +157,20 @@ _gh_wrapper_maybe_review() {
 
   local sub="" subsub="" skip_next=0 arg
   for arg in "$@"; do
+    # -- end-of-options sentinel: everything after it is positional, even if
+    # it looks like a flag. Mirrors the fix pattern from PR #146
+    # (_gh_wrapper_sync_identity) for smartwatermelon/dotfiles#153.
+    [[ "${arg}" == "--" ]] && break
     if [[ "${skip_next}" == "1" ]]; then
       skip_next=0
       continue
     fi
     case "${arg}" in
       -R | --repo | --hostname | --config-dir | --token) skip_next=1 ;;
+      # Combined short-flag form (-Rowner/repo): the value is embedded in
+      # this same token, so there's no next arg to skip — just consume this
+      # one token without treating it as `sub`. See PR #146 / issue #153.
+      -R*) ;;
       --*=*) ;; # --flag=value: single token, no separate value to skip
       -*) ;;    # other single-token flags: skip
       *)

--- a/install.sh
+++ b/install.sh
@@ -256,6 +256,7 @@ if [[ "${DRY_RUN}" == true ]]; then
   _dry "Would symlink: ~/.digrc -> ~/.config/dig/digrc"
   _dry "Would symlink: ~/.shellcheckrc -> ~/.config/shellcheck/.shellcheckrc"
   _dry "Would symlink: ~/.markdownlint.json -> ~/.config/markdownlint-cli/.markdownlint.json"
+  _dry "Would create directory: ~/.local/bin"
   _dry "Would symlink: ~/.local/bin/gh -> ~/.config/bash/gh-wrapper.sh"
 else
   _ensure_symlink "${HOME}/.config/bash/.bash_profile" "${HOME}/.bash_profile"


### PR DESCRIPTION
## Summary
- `install.sh`'s DRY_RUN branch for HOME SYMLINKS never mentioned the `mkdir -p ~/.local/bin` step that the real-run branch performs before creating the gh symlink. Added the matching `_dry "Would create directory: ~/.local/bin"` line, positioned before the "Would symlink" line for the gh wrapper, matching real-run ordering.
- `_gh_wrapper_maybe_review` in `bash/gh-wrapper.sh` had the same `-R` parsing gap that `_gh_wrapper_sync_identity` had before PR #146: no `--` end-of-options sentinel break, and no dedicated case arm for the combined short-flag form (`-Rowner/repo`). Added both, mirroring the existing fix pattern in `_gh_wrapper_sync_identity`.

## Verification
- `shellcheck -S info bash/gh-wrapper.sh install.sh` — clean (pre-existing SC2312 info notices at unrelated lines, confirmed present on main before this change).
- Manually traced `_gh_wrapper_maybe_review`'s parsing loop for four cases:
  - `-Rowner/repo pr merge 5` → sub=pr subsub=merge (review triggers correctly)
  - `-R owner/repo pr merge 5` → sub=pr subsub=merge
  - `-- -R owner/repo pr merge 5` → sentinel breaks the loop before any flag parsing, so nothing after `--` is misread as a flag
  - `pr merge 5` → unaffected
- Local pre-commit hook (code-reviewer + adversarial-reviewer) and pre-push hook (full-diff + codebase review) both passed.

Closes #152
Closes #153