### PR TITLE
fix(hooks): remove --oss-only Semgrep workaround now that Pro Engine works

### DIFF
--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -176,10 +176,6 @@ run_supply_chain_scan
 # Without a token: falls back to `--config auto` (public Registry rules only).
 #
 # --dry-run: local run; do not upload findings (real CI uploads later).
-# --oss-only: Pro Engine local binary has a version-check issue; OSS engine
-#   still runs ~2866 rules (vs ~100 with --config auto). Remove this flag
-#   once the Pro binary installs cleanly locally — see #143 for removal
-#   tracking.
 # SEMGREP_BASELINE_REF=origin/main: diff-aware scan, matches CI PR behavior.
 run_static_analysis() {
   if ! command -v semgrep &>/dev/null; then
@@ -219,7 +215,7 @@ run_static_analysis() {
     if git rev-parse --verify --quiet origin/main >/dev/null; then
       export SEMGREP_BASELINE_REF="origin/main"
     fi
-    semgrep ci --code --dry-run --oss-only --quiet
+    semgrep ci --code --dry-run --quiet
   ) || exit_code=$?
 
   case ${exit_code} in
@@ -235,7 +231,7 @@ run_static_analysis() {
     *)
       echo "" >&2
       log_warning "⚠️  Semgrep failed to complete (exit ${exit_code}) — likely network/auth/rules issue, not findings."
-      log_warning "   Diagnose: SEMGREP_APP_TOKEN=<token> semgrep ci --code --dry-run --oss-only"
+      log_warning "   Diagnose: SEMGREP_APP_TOKEN=<token> semgrep ci --code --dry-run"
       echo "" >&2
       if [[ -t 0 ]]; then
         local push_anyway


### PR DESCRIPTION
## Summary
- Removes the `--oss-only` flag from the `semgrep ci --code --dry-run --quiet` invocation in `run_static_analysis()` (`git/hooks/pre-push`), along with the matching diagnose-hint command and the now-stale comment explaining the workaround.
- The flag was added because the Semgrep Pro Engine local binary previously had a version-check issue; that issue is resolved.

Closes #143

## Verification
- `semgrep --version --pro` now auto-installs `semgrep-core-proprietary` (Semgrep 1.172.0) cleanly, no version-check error.
- Ran the actual post-fix invocation manually with a real `SEMGREP_APP_TOKEN` and `SEMGREP_BASELINE_REF=origin/main`: `semgrep ci --code --dry-run --quiet` completed with **exit code 0**, no findings.
- Pushing this branch exercised the real `pre-push` hook end-to-end (not bypassed with `--no-verify`), and the hook's own Semgrep static-analysis stage — now running the Pro Engine without `--oss-only` — reported "Semgrep static analysis clean (CI-equivalent)".
- Checked for other `--oss-only` references (`grep -rn "oss-only" .`). Found one additional occurrence in `pre-commit/config.yaml` (the `semgrep-secrets` hook, using `semgrep scan --config=p/secrets --config=p/gitleaks`). Confirmed this is an independent, intentionally OSS-only secrets scan (no token required, unrelated to the Pro Engine version-check issue) — left unchanged.
- `shellcheck -S info git/hooks/pre-push` — clean, no new warnings.

## Test plan
- [x] `shellcheck -S info git/hooks/pre-push` clean
- [x] Manual `semgrep ci --code --dry-run --quiet` exit 0
- [x] Real `git push` exercising the updated pre-push hook, confirming Pro Engine scan succeeds
- [x] Local pre-commit/pre-push review hooks passed (code-reviewer + adversarial-reviewer, full-diff + codebase review)

https://claude.ai/code/session_015wA3i5ASEVFQJx2SN7Fe1L