### PR TITLE
fix(pre-commit): defer to repo-local markdownlint config when present

### DIFF
--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -86,7 +86,11 @@ pre-commit/
 
 - **Repo**: <https://github.com/igorshubovych/markdownlint-cli>
 - **Version**: v0.45.0
-- **Args**: `--fix`, `--config ~/.config/markdownlint-cli/.markdownlint.json`
+- **Args**: `--fix`, plus `--config ~/.config/markdownlint-cli/.markdownlint.json` — only when
+  the repo has no `.markdownlint.{json,yaml,yml,jsonc}` / `.markdownlintrc` of its own at the
+  repo root. When one is present (e.g. a fork of an external repo with its own conventions),
+  `--config` is omitted so markdownlint's native auto-discovery uses the repo-local config
+  instead (smartwatermelon/dotfiles#116).
 - **Purpose**: Lints and fixes Markdown style
 - **When**: Runs on all Markdown files
 - **Settings**:

--- a/pre-commit/config.yaml
+++ b/pre-commit/config.yaml
@@ -68,11 +68,27 @@ repos:
 
   # Markdown linting (Homebrew binary — avoids pre-commit's node-lang npm
   # bootstrap, which breaks on npm releases that dropped --ignore-prepublish)
+  #
+  # Defers to a repo-local markdownlint config when the target repo has one
+  # (e.g. a fork of someone else's repo with its own conventions) instead of
+  # always forcing our personal global config — see smartwatermelon/dotfiles#116.
+  # Without --config, markdownlint auto-discovers .markdownlint.{json,yaml,yml,jsonc}
+  # / .markdownlintrc by walking up from each target file, so we only need to
+  # check whether the repo root already has one of those.
   - repo: local
     hooks:
       - id: markdownlint
         name: "Markdown Lint (fix)"
-        entry: bash -c 'markdownlint --fix --config "$HOME/.config/markdownlint-cli/.markdownlint.json" "$@"' --
+        entry: >-
+          bash -c 'has_local_config=0;
+          for f in .markdownlint.json .markdownlint.yaml .markdownlint.yml
+          .markdownlint.jsonc .markdownlintrc; do
+          [[ -f "$f" ]] && { has_local_config=1; break; }; done;
+          if [[ "$has_local_config" -eq 1 ]]; then
+          markdownlint --fix "$@";
+          else
+          markdownlint --fix --config "$HOME/.config/markdownlint-cli/.markdownlint.json" "$@";
+          fi' --
         language: system
         types: [markdown]
         pass_filenames: true


### PR DESCRIPTION
## Summary
- The markdownlint pre-commit hook always forced our personal global config via `--config`, even on forks of external repos with their own markdownlint conventions — the concrete trigger for #116 (MD025 tripping on a fork's existing README structure).
- Without `--config`, markdownlint auto-discovers a repo-local config by walking up from each target file. Now the hook only passes `--config` pointing at our global config when the repo has no `.markdownlint.{json,yaml,yml,jsonc}` / `.markdownlintrc` of its own at the repo root — otherwise it defers entirely to the target repo's own config.
- This fixes the root cause without needing fork/owner detection: it trusts whatever lint config the target repo already committed, rather than guessing when to relax our own rules.
- Updated `pre-commit/README.md` to document the new conditional `--config` behavior (closes #163, a doc-staleness follow-up auto-filed by pre-push review on the first commit).

## Test plan
- [x] Verified locally: no repo-local config → global config applies, MD025 fires on a synthetic multi-H1 file
- [x] Verified locally: repo-local config present (with `MD025: false`) → deferred entirely, MD025 suppressed
- [x] `shellcheck -S info` clean on the embedded bash logic
- [x] `yamllint` clean on `pre-commit/config.yaml`
- [x] `pre-commit run markdownlint --files README.md` exercises the real hook end-to-end in this repo (global-config fallback path, since dotfiles has no root-level `.markdownlint.json`)
- [x] Local pre-commit/pre-push review hooks passed (code-reviewer, adversarial-reviewer, arbiter, full-diff + codebase review)

Refs #116

https://claude.ai/code/session_015wA3i5ASEVFQJx2SN7Fe1L