### PR TITLE
docs(pre-commit): fix Local vs Remote hook classification in README

### DIFF
--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -206,14 +206,14 @@ brew install pre-commit
 
 ### Local vs Remote Hooks
 
-**Remote hooks** (Python, Markdown):
+**Remote hooks** (Python — black, flake8):
 
 - Downloaded and managed by pre-commit framework
 - Isolated in their own virtualenvs
 - Versioned via git tags
 - Automatically cached
 
-**Local/System hooks** (Shell, YAML, HTML):
+**Local/System hooks** (Secrets, Shell, YAML, HTML, Markdown, Lua, JS/TS/JSON/CSS, GitHub Actions):
 
 - Use system-installed tools
 - Faster execution (no virtual environment overhead)


### PR DESCRIPTION
## Summary
- `pre-commit/README.md`'s "Local vs Remote Hooks" table listed Markdown under remote (framework-managed) hooks, but `markdownlint` is actually `repo: local` in `config.yaml`.
- Corrected both categories against the actual config: only `black`/`flake8` (Python) are true remote hooks; everything else (secrets scan, shell, yaml, html, markdown, lua, prettier, zizmor) is local/system.

Fixes #164

## Test plan
- [x] `markdownlint --config markdownlint-cli/.markdownlint.json pre-commit/README.md` clean
- [x] Verified hook types directly against `pre-commit/config.yaml` (`repo: local` vs `repo: https://...`)
- [x] Local pre-commit/pre-push review hooks passed

https://claude.ai/code/session_015wA3i5ASEVFQJx2SN7Fe1L