### PR TITLE
docs(pre-push): clarify STRICT_PREPUSH=0 is user-only, not temporary

### DIFF
--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -35,8 +35,13 @@ log_warning() {
 #
 # Escape hatches:
 #   POSTPUSH_LOOP=1   — post-push-loop manages review externally (pre-existing)
-#   STRICT_PREPUSH=0  — temporary opt-out during hook bake-in
-#                       Remove once the default has proven itself. Tracked.
+#   STRICT_PREPUSH=0  — human-authorized opt-out from local blocking review.
+#                       USER-ONLY: agents must never set this autonomously.
+#                       An agent may ask the user for permission to use it in
+#                       a given situation, but must not set it unilaterally
+#                       or claim prior authorization that didn't happen in
+#                       this conversation. See docs/HUMAN-BYPASS.md in
+#                       claude-config for the full explanation.
 strict_noninteractive_block() {
   [[ ! -t 0 ]] \
     && [[ "${CLAUDECODE:-}" == "1" ]] \
@@ -157,7 +162,7 @@ run_supply_chain_scan() {
       fi
     elif strict_noninteractive_block; then
       log_warning "🛑 Non-interactive strict mode — blocking push due to SCA findings"
-      log_warning "   Escape hatches: STRICT_PREPUSH=0 (temporary) or POSTPUSH_LOOP=1"
+      log_warning "   Escape hatches: STRICT_PREPUSH=0 (ask user first) or POSTPUSH_LOOP=1"
       exit 1
     else
       log_warning "Non-interactive advisory mode — continuing despite SCA findings"
@@ -242,7 +247,7 @@ run_static_analysis() {
         fi
       elif strict_noninteractive_block; then
         log_warning "🛑 Non-interactive strict mode — blocking push due to scan infra error"
-        log_warning "   Escape hatches: STRICT_PREPUSH=0 (temporary) or POSTPUSH_LOOP=1"
+        log_warning "   Escape hatches: STRICT_PREPUSH=0 (ask user first) or POSTPUSH_LOOP=1"
         exit 1
       else
         log_warning "Non-interactive advisory mode — continuing despite scan infra error"
@@ -355,7 +360,7 @@ run_reviews() {
       fi
     elif strict_noninteractive_block; then
       log_warning "🛑 Non-interactive strict mode — blocking push due to review findings"
-      log_warning "   Escape hatches: STRICT_PREPUSH=0 (temporary) or POSTPUSH_LOOP=1"
+      log_warning "   Escape hatches: STRICT_PREPUSH=0 (ask user first) or POSTPUSH_LOOP=1"
       exit 1
     else
       log_warning "Non-interactive advisory mode — continuing despite review findings"
@@ -459,7 +464,7 @@ check_pr_review_iteration() {
       elif strict_noninteractive_block; then
         log_warning "🛑 Non-interactive strict mode — blocking push; Protocol 4 checkpoint triggered"
         log_warning "   Run code-reviewer locally, address findings, then retry."
-        log_warning "   Escape hatches: STRICT_PREPUSH=0 (temporary) or POSTPUSH_LOOP=1"
+        log_warning "   Escape hatches: STRICT_PREPUSH=0 (ask user first) or POSTPUSH_LOOP=1"
         exit 1
       else
         # Non-interactive advisory (legacy CI / opt-out): skip prompt, don't block automation.


### PR DESCRIPTION
## Summary
- Reframes the `STRICT_PREPUSH=0` escape hatch comment: it's a permanent, human-authorized opt-out — not a temporary measure to be removed once hooks "prove themselves."
- Makes explicit that agents must never set `STRICT_PREPUSH=0` autonomously; they may ask the user for permission for a specific push, but must never assume standing authorization from an earlier conversation.
- Updates all four `log_warning` call sites (SCA scan, scan infra error, review findings, Protocol 4 checkpoint) so the runtime warning text ("(ask user first)") no longer contradicts the corrected comment.
- No change to `strict_noninteractive_block()` logic — documentation/messaging only.
- Companion PR in claude-config adds a caveat + new section to `docs/HUMAN-BYPASS.md` explaining that `STRICT_PREPUSH=0` (unlike `--no-verify`) is not currently hook-blocked for the agent, so the "ask first, no standing authorization" rule is behavioral, not technically enforced.

## Test plan
- [x] `shellcheck -S info git/hooks/pre-push` clean
- [x] `grep "(temporary)"` in pre-push returns zero matches
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer): PASS
- [x] Local pre-push review (full-diff + codebase review): PASS

https://claude.ai/code/session_01BmuTHyHEJv26WZkyTWHZDp