### PR TITLE
fix(git): update beacon includeIf path to beacon-biosignals

### DIFF
--- a/bash/beacon.sh.example
+++ b/bash/beacon.sh.example
@@ -12,7 +12,7 @@
 #
 # ~/.config/bash/beacon.sh itself is intentionally NOT tracked by this repo —
 # only this template is. install.sh warns if it's missing while
-# ~/Developer/beacon/ exists.
+# ~/Developer/beacon-biosignals/ exists.
 
 #shellcheck shell=bash
 

--- a/bash/env.sh
+++ b/bash/env.sh
@@ -16,7 +16,7 @@ fi
 
 # Load work-specific (Beacon) env vars — untracked, machine-local.
 # See bash/beacon.sh.example for the template; install.sh warns if
-# ~/Developer/beacon/ exists but this file doesn't.
+# ~/Developer/beacon-biosignals/ exists but this file doesn't.
 if [[ -f "${BASH_CONFIG_DIR}/beacon.sh" ]]; then
   #shellcheck source=/dev/null
   source "${BASH_CONFIG_DIR}/beacon.sh"

--- a/git/config
+++ b/git/config
@@ -50,5 +50,5 @@
 	conflictstyle = zdiff3
 [pull]
 	rebase = true
-[includeIf "gitdir:~/Developer/beacon/"]
+[includeIf "gitdir:~/Developer/beacon-biosignals/"]
 	path = ~/.gitconfig-beacon

--- a/git/gitconfig-beacon.example
+++ b/git/gitconfig-beacon.example
@@ -6,12 +6,12 @@
 #
 # Referenced by an includeIf block in git/config:
 #
-#   [includeIf "gitdir:~/Developer/beacon/"]
+#   [includeIf "gitdir:~/Developer/beacon-biosignals/"]
 #       path = ~/.gitconfig-beacon
 #
 # ~/.gitconfig-beacon itself is intentionally NOT tracked by this repo —
 # only this template is. install.sh warns if it's missing while
-# ~/Developer/beacon/ exists.
+# ~/Developer/beacon-biosignals/ exists.
 
 [user]
 	email = your-work-email@example.com

--- a/install.sh
+++ b/install.sh
@@ -383,9 +383,10 @@ else
 fi
 
 # Check per-machine work-identity gitconfig — only relevant if a
-# ~/Developer/beacon/ (or similar) workdir exists but its includeIf target
-# is missing, which would silently fall back to the personal git identity.
-BEACON_WORKDIR="${HOME}/Developer/beacon"
+# ~/Developer/beacon-biosignals/ (or similar) workdir exists but its
+# includeIf target is missing, which would silently fall back to the
+# personal git identity.
+BEACON_WORKDIR="${HOME}/Developer/beacon-biosignals"
 BEACON_GITCONFIG="${HOME}/.gitconfig-beacon"
 if [[ -d "${BEACON_WORKDIR}" ]]; then
   if [[ -f "${BEACON_GITCONFIG}" ]]; then
@@ -398,9 +399,9 @@ if [[ -d "${BEACON_WORKDIR}" ]]; then
 fi
 
 # Check per-machine work (Beacon) bash env overrides — only relevant if a
-# ~/Developer/beacon/ workdir exists but env.sh's sourced target is missing,
-# which would silently skip work-only env vars (e.g. AWS_PROFILE) with no
-# warning.
+# ~/Developer/beacon-biosignals/ workdir exists but env.sh's sourced target
+# is missing, which would silently skip work-only env vars (e.g. AWS_PROFILE)
+# with no warning.
 BEACON_BASHENV="${HOME}/.config/bash/beacon.sh"
 if [[ -d "${BEACON_WORKDIR}" ]]; then
   if [[ -f "${BEACON_BASHENV}" ]]; then


### PR DESCRIPTION
Fixes a stale includeIf path. ~/Developer/beacon was renamed to ~/Developer/beacon-biosignals, so the includeIf gitdir glob in git/config stopped matching, and Beacon-repo commits silently fell back to my personal git identity instead of ~/.gitconfig-beacon. I found this after noticing two commits I made in a Beacon repo were attributed to my personal GitHub identity.

Updates the same stale path in install.sh's BEACON_WORKDIR check (which had gone silently inert for the same reason) and in the gitconfig-beacon.example / beacon.sh.example templates and comments.

No other references to the old path remain in the repo (checked with grep).