### PR TITLE
feat(gh-wrapper): hard-force draft PRs for off-org gh pr create

### DIFF
--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # ~/.config/bash/gh-wrapper.sh
 # shellcheck shell=bash
-# Canonical implementation of the `gh` identity auto-switch and PR-merge
-# guard (pre-merge review + REST/GraphQL merge-bypass blocking). One file,
-# two invocation modes:
+# Canonical implementation of the `gh` identity auto-switch, PR-merge guard
+# (pre-merge review + REST/GraphQL merge-bypass blocking), and off-org draft
+# enforcement (`gh pr create` targeting a repo outside
+# smartwatermelon/nightowlstudiollc is forced to --draft, no opt-out). One
+# file, two invocation modes:
 #
 #   1. Sourced from functions.sh: defines gh() as a bash function. This wins
 #      over PATH lookup for any bash process — interactive shells (via
@@ -24,23 +26,18 @@
 
 _gh_wrapper_review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
 
-# gh has one active account per host (not per repo), unlike git+SSH which
-# already resolves the right identity per remote via ~/.ssh/config host
-# aliases. This keeps gh in sync with that same per-repo intent: repos owned
-# by smartwatermelon or nightowlstudiollc (both authenticated as the
-# smartwatermelon gh account) use that account; everything else (Beacon
-# repos, etc.) falls back to andrewmrich. Local-only (reads/writes gh's
-# config file, no network), so it's cheap to run on every invocation.
-# Caveat: this mutates global gh state, so concurrent shells working in
-# different-owner repos at the same time can race each other.
+# Resolves the repo owner a gh invocation is acting on: an explicit -R/--repo
+# target on the command line takes precedence (that's the repo the call
+# actually acts on), falling back to cwd's git remote only when no such flag
+# is given. This keeps behavior consistent regardless of which repo checkout
+# the caller happens to be sitting in — see smartwatermelon/dotfiles#135.
 #
-# Owner is resolved from an explicit -R/--repo target on the command line
-# when present, since that's the repo the call actually acts on; only when
-# no such flag is given do we fall back to cwd's git remote. This keeps
-# behavior consistent regardless of which repo checkout the caller happens
-# to be sitting in — see smartwatermelon/dotfiles#135.
-_gh_wrapper_sync_identity() {
-  local owner desired current repo_flag_value skip_next=0 arg remote_url
+# Shared by _gh_wrapper_sync_identity (identity auto-switch) and
+# _gh_wrapper_force_draft_for_off_org (draft enforcement) so the two checks
+# can never drift on what "owner" means for a given invocation — prints the
+# resolved owner (raw case) on stdout, or nothing if it can't be resolved.
+_gh_wrapper_resolve_owner() {
+  local repo_flag_value skip_next=0 arg remote_url owner
 
   repo_flag_value=""
   for arg in "$@"; do
@@ -73,6 +70,23 @@ _gh_wrapper_sync_identity() {
     [[ -z "${remote_url}" ]] && return 0
     owner=$(printf '%s\n' "${remote_url}" | sed -E 's#^(git@[^:]+:|[a-zA-Z]+://[^/]+/)##; s#/.*##')
   fi
+  [[ -z "${owner}" ]] && return 0
+  printf '%s\n' "${owner}"
+}
+
+# gh has one active account per host (not per repo), unlike git+SSH which
+# already resolves the right identity per remote via ~/.ssh/config host
+# aliases. This keeps gh in sync with that same per-repo intent: repos owned
+# by smartwatermelon or nightowlstudiollc (both authenticated as the
+# smartwatermelon gh account) use that account; everything else (Beacon
+# repos, etc.) falls back to andrewmrich. Local-only (reads/writes gh's
+# config file, no network), so it's cheap to run on every invocation.
+# Caveat: this mutates global gh state, so concurrent shells working in
+# different-owner repos at the same time can race each other.
+_gh_wrapper_sync_identity() {
+  local owner desired current
+
+  owner="$(_gh_wrapper_resolve_owner "$@")"
   [[ -z "${owner}" ]] && return 0
 
   # NOTE: the nightowlstudiollc -> smartwatermelon mapping below is asserted,
@@ -200,6 +214,68 @@ _gh_wrapper_maybe_review() {
   return 0
 }
 
+# Hard, mechanical guard: a PR created against a repo outside the two orgs
+# this environment is scoped to (smartwatermelon/nightowlstudiollc) must
+# land as a draft, unconditionally — no AI judgement call, no opt-out flag,
+# no environment-variable escape hatch. Later promotion out of draft is a
+# manual, human-only action via the GitHub UI; this function only concerns
+# itself with creation time. See smartwatermelon/dotfiles#174.
+#
+# Bash can't let a function reassign the caller's positional params, so this
+# prints the (possibly modified) argument list, one arg per line, on stdout;
+# the caller rebuilds its array with `mapfile`/`readarray`. Always prints
+# something — even when no change is needed — so callers can unconditionally
+# replace their arg array from the output.
+#
+# Parses args with the same sub/subsub walk as _gh_wrapper_maybe_review, so
+# `pr create` detection can't drift between the two.
+_gh_wrapper_force_draft_for_off_org() {
+  local sub="" subsub="" skip_next=0 arg owner
+
+  for arg in "$@"; do
+    [[ "${arg}" == "--" ]] && break
+    if [[ "${skip_next}" == "1" ]]; then
+      skip_next=0
+      continue
+    fi
+    case "${arg}" in
+      -R | --repo | --hostname | --config-dir | --token) skip_next=1 ;;
+      -R*) ;;
+      --*=*) ;;
+      -*) ;;
+      *)
+        if [[ -z "${sub}" ]]; then
+          sub="${arg}"
+        else
+          subsub="${arg}"
+          break
+        fi
+        ;;
+    esac
+  done
+
+  if [[ "${sub}" == "pr" && "${subsub}" == "create" ]]; then
+    owner="$(_gh_wrapper_resolve_owner "$@")"
+    if [[ -n "${owner}" ]]; then
+      case "${owner,,}" in
+        smartwatermelon | nightowlstudiollc) ;; # in-org: no change
+        *)
+          # Off-org target: force --draft. Don't bother deduplicating if the
+          # caller already passed --draft (or --draft=false, which gh doesn't
+          # support as a real flag) — an extra --draft is harmless, and the
+          # point is nothing the caller does can produce a non-draft PR here.
+          printf '%s\n' "$@"
+          printf -- '--draft\n'
+          return 0
+          ;;
+      esac
+    fi
+  fi
+
+  printf '%s\n' "$@"
+  return 0
+}
+
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   # --- Standalone-wrapper mode (executed directly, e.g. via the
   # ~/.local/bin/gh symlink) ---
@@ -216,7 +292,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     fi
   done
 
-  # Safe to skip all three checks when _GH_REVIEW_DONE is set: that only
+  # Safe to skip all four checks when _GH_REVIEW_DONE is set: that only
   # happens when function mode already ran them before calling `command gh`
   # (which lands here). If a future change ever sets _GH_REVIEW_DONE before
   # running those checks in function mode, this skip becomes unsafe — keep
@@ -231,6 +307,19 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     _gh_wrapper_block_bypass "$@" || exit 1
     if [[ "${_gh_wrapper_help}" != "1" ]]; then
       _gh_wrapper_maybe_review strict "$@" || exit 1
+      # Off-org `gh pr create` must land as a draft — hard, mechanical,
+      # no opt-out. Rebuild the positional params from the (possibly
+      # --draft-appended) output; a function can't reassign "$@" directly.
+      # Captured via command substitution (not process substitution) so the
+      # function's own exit status isn't masked from `set -e`. Only rebuild
+      # when there's at least one original arg — with zero args, `mapfile
+      # <<<""` would otherwise produce a single empty-string element instead
+      # of an empty array, turning bare `gh` into `gh ""`.
+      if [[ "$#" -gt 0 ]]; then
+        _gh_wrapper_new_args_raw="$(_gh_wrapper_force_draft_for_off_org "$@")"
+        mapfile -t _gh_wrapper_new_args <<<"${_gh_wrapper_new_args_raw}"
+        set -- "${_gh_wrapper_new_args[@]}"
+      fi
     fi
   fi
 
@@ -286,6 +375,19 @@ else
 
     _gh_wrapper_maybe_review warn "$@" || return 1
 
+    # Off-org `gh pr create` must land as a draft — hard, mechanical, no
+    # opt-out. Rebuild the positional params from the (possibly
+    # --draft-appended) output; a function can't reassign "$@" directly.
+    # Only rebuild when there's at least one original arg — with zero args,
+    # `mapfile <<<""` would otherwise produce a single empty-string element
+    # instead of an empty array, turning bare `gh` into `gh ""`.
+    if [[ "$#" -gt 0 ]]; then
+      local _gh_wrapper_new_args _gh_wrapper_new_args_raw
+      _gh_wrapper_new_args_raw="$(_gh_wrapper_force_draft_for_off_org "$@")"
+      mapfile -t _gh_wrapper_new_args <<<"${_gh_wrapper_new_args_raw}"
+      set -- "${_gh_wrapper_new_args[@]}"
+    fi
+
     # Run the real gh command. Set _GH_REVIEW_DONE so the ~/.local/bin/gh
     # wrapper (found again via `command gh`, since ~/.local/bin is early in
     # PATH) does not run the review a second time.
@@ -305,6 +407,6 @@ else
   # its own body into subshells, not functions it calls. Without exporting
   # these too, gh() would break in any subshell that inherits the exported
   # gh but didn't source this file (e.g. BASH_ENV unset/overridden there).
-  export -f gh sugh _gh_wrapper_block_bypass _gh_wrapper_maybe_review _gh_wrapper_sync_identity _gh_wrapper_find_real_gh
+  export -f gh sugh _gh_wrapper_block_bypass _gh_wrapper_maybe_review _gh_wrapper_sync_identity _gh_wrapper_find_real_gh _gh_wrapper_resolve_owner _gh_wrapper_force_draft_for_off_org
   export _gh_wrapper_review_script
 fi

--- a/bash/tests/test-gh-wrapper-draft-off-org.sh
+++ b/bash/tests/test-gh-wrapper-draft-off-org.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#shellcheck shell=bash
+# Standalone verification for bash/gh-wrapper.sh's off-org draft-forcing.
+# Run directly: bash bash/tests/test-gh-wrapper-draft-off-org.sh
+#
+# Coverage for smartwatermelon/dotfiles#174: `gh pr create` targeting a repo
+# outside smartwatermelon/nightowlstudiollc must have --draft injected into
+# the argument list, unconditionally, with no way for the caller to opt out.
+set -euo pipefail
+
+unset CDPATH
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export BASH_CONFIG_DIR="${REPO_ROOT}/bash"
+
+# Sourcing (not executing) the file puts it in function-definition mode,
+# where _gh_wrapper_force_draft_for_off_org is defined but gh() itself is
+# not invoked.
+#shellcheck source=/dev/null
+source "${BASH_CONFIG_DIR}/gh-wrapper.sh"
+
+fail=0
+
+assert_args() {
+  local label="$1"
+  shift
+  local expected_has_draft="$1"
+  shift
+  local -a got=()
+  local out
+  out="$(_gh_wrapper_force_draft_for_off_org "$@")"
+  mapfile -t got <<<"${out}"
+
+  local has_draft=0 a
+  for a in "${got[@]}"; do
+    [[ "${a}" == "--draft" ]] && has_draft=1
+  done
+
+  if [[ "${has_draft}" == "${expected_has_draft}" ]]; then
+    echo "PASS: ${label}"
+  else
+    echo "FAIL: ${label} — expected --draft present=${expected_has_draft}, got=${has_draft} (args: ${got[*]})"
+    fail=1
+  fi
+}
+
+# In-org, explicit -R: no draft forced.
+assert_args "in-org explicit --repo" 0 pr create --repo smartwatermelon/dotfiles --title x
+
+# Off-org, explicit --repo=: draft forced.
+assert_args "off-org explicit --repo=" 1 pr create --repo=someoutsideorg/foo --title x
+
+# nightowlstudiollc counts as in-org: no draft forced.
+assert_args "nightowlstudiollc explicit -R" 0 pr create -R nightowlstudiollc/somerepo --title x
+
+# Case-insensitive owner match, mirroring _gh_wrapper_sync_identity's
+# regression coverage for smartwatermelon/dotfiles#159.
+assert_args "mixed-case in-org owner" 0 pr create --repo SmartWatermelon/dotfiles --title x
+
+# Not `pr create`: unaffected regardless of owner.
+assert_args "gh issue create off-org (unaffected)" 0 issue create --repo someoutsideorg/foo --title x
+assert_args "gh pr merge off-org (unaffected)" 0 pr merge 5 --repo someoutsideorg/foo
+
+# --help on an off-org pr create: the caller (standalone/function-mode entry
+# points) skips calling this function at all for --help requests, but the
+# function itself must still not misbehave if invoked directly.
+assert_args "off-org pr create --help (function itself is harmless)" 1 pr create --repo someoutsideorg/foo --help
+
+# Caller already passed --draft explicitly: harmless, still present exactly
+# once more isn't required to be deduped, just confirm it's present.
+assert_args "off-org pr create with explicit --draft already present" 1 pr create --repo someoutsideorg/foo --draft --title x
+
+# Zero args: must not error and must not fabricate an argument.
+out="$(_gh_wrapper_force_draft_for_off_org)"
+mapfile -t zero_args <<<"${out}"
+if [[ "${#zero_args[@]}" == "1" && -z "${zero_args[0]}" ]]; then
+  echo "PASS: zero-arg call produces a single empty line (caller guards against rebuilding \$@ from this)"
+else
+  echo "FAIL: zero-arg call produced unexpected output: ${zero_args[*]}"
+  fail=1
+fi
+
+# cwd-remote fallback: no explicit -R/--repo, owner resolved from `origin`.
+off_org_clone="/tmp/gh-wrapper-draft-test-off-org-$$"
+in_org_clone="/tmp/gh-wrapper-draft-test-in-org-$$"
+mkdir -p "${off_org_clone}" "${in_org_clone}"
+trap 'rm -rf "${off_org_clone}" "${in_org_clone}"' EXIT
+(cd "${off_org_clone}" && command git init -q && command git remote add origin git@github.com:someoutsideorg/foo.git)
+(cd "${in_org_clone}" && command git init -q && command git remote add origin git@github.com:smartwatermelon/dotfiles.git)
+
+cwd_fail_file="/tmp/gh-wrapper-draft-test-cwd-fail-$$"
+rm -f "${cwd_fail_file}"
+(
+  cd "${off_org_clone}"
+  assert_args "off-org cwd remote fallback" 1 pr create --title x
+  if [[ "${fail}" == "1" ]]; then touch "${cwd_fail_file}"; fi
+)
+(
+  cd "${in_org_clone}"
+  assert_args "in-org cwd remote fallback" 0 pr create --title x
+  if [[ "${fail}" == "1" ]]; then touch "${cwd_fail_file}"; fi
+)
+if [[ -f "${cwd_fail_file}" ]]; then
+  fail=1
+fi
+rm -f "${cwd_fail_file}"
+
+exit "${fail}"


### PR DESCRIPTION
## Summary

Closes #174.

Adds a hard, mechanical check to `gh-wrapper.sh`: any `gh pr create` whose target repo owner resolves to something other than `smartwatermelon`/`nightowlstudiollc` (case-insensitive) now has `--draft` injected into the argument list before it reaches the real `gh` binary — no flag or environment variable can opt out. Promotion out of draft remains a manual, human-only action via the GitHub UI (out of scope here, per the issue).

### Approach

- Factored owner-resolution parsing out of `_gh_wrapper_sync_identity` into a shared `_gh_wrapper_resolve_owner` helper, reused by the new `_gh_wrapper_force_draft_for_off_org`, so identity-switch and draft-forcing can never drift on what "owner" means for a given invocation.
- `_gh_wrapper_force_draft_for_off_org` detects `pr create` using the same sub/subsub arg-walk pattern as `_gh_wrapper_maybe_review`. Since a bash function can't reassign the caller's `"$@"` directly, it prints the (possibly `--draft`-appended) arg list on stdout, one arg per line; both invocation modes (standalone-wrapper `~/.local/bin/gh` and the sourced `gh()` function) capture that via command substitution and rebuild their positional params with `mapfile`, guarding the zero-arg case so a bare `gh` call isn't corrupted into `gh ""`.
- Wired into both invocation modes, mirroring exactly how `_gh_wrapper_block_bypass`/`_gh_wrapper_maybe_review` are already threaded through both, and respecting the existing `--help`/`-h` and `auth` skip conventions.
- Added `bash/tests/test-gh-wrapper-draft-off-org.sh`, following the existing `test-gh-wrapper-identity.sh` conventions, covering: in-org vs off-org via explicit `-R`/`--repo`/`--repo=`, `nightowlstudiollc` counting as in-org, case-insensitive owner matching, non-`pr create` subcommands being unaffected, `--help` being harmless, an already-present `--draft` being harmless, zero-arg safety, and both the off-org and in-org cwd-remote-fallback paths.

### Note on a bypassed pre-push finding

The pre-commit review's adversarial-reviewer raised a BLOCKING finding claiming the `mapfile -t arr <<<"$(...)"` argument-array reconstruction (`bash/gh-wrapper.sh` lines ~319 and ~386) leaves a trailing empty-string argument on every `gh` call, due to a supposed "double newline." This was investigated and is a false positive: `$(...)` command substitution strips all trailing newlines before the here-string (`<<<`) adds its own, so there's only ever one newline at reconstruction time, not two. Verified directly against the actual function output (`_gh_wrapper_force_draft_for_off_org pr create --repo=someoutsideorg/foo --title x` reconstructs to exactly 6 elements, ending in `--draft`, no trailing empty string), and via a full end-to-end trace through both invocation modes with a stub `gh` binary. The subsequent pre-push whole-codebase review passed cleanly and did not reproduce this finding. `STRICT_PREPUSH=0` was used for this one push, with the user's explicit authorization after independently verifying the trace.

## Test plan

- [x] `shellcheck -S info bash/gh-wrapper.sh` clean, no errors/warnings/info
- [x] `shellcheck -S info bash/tests/test-gh-wrapper-draft-off-org.sh` clean
- [x] `bash bash/tests/test-gh-wrapper-draft-off-org.sh` 11/11 pass
- [x] `bash bash/tests/test-gh-wrapper-identity.sh` no regression, 5/5 pass
- [x] `bash bash/tests/test-path-order.sh` no regression
- [x] Manual end-to-end trace through both standalone-wrapper mode and sourced `gh()` function mode with a stub `gh` binary, covering: in-org explicit `-R`, off-org explicit `--repo=`, off-org via cwd `origin` remote, `nightowlstudiollc` (in-org), `gh issue create` (unaffected), `gh pr merge` (unaffected, review guard still fires), `gh pr create --repo off-org --help` (no draft injection attempted), zero-arg bare `gh` (no corruption)

Claude-Session: https://claude.ai/code/session_01Sr9Qbx6v59pUTXvgZib6m7
