### PR TITLE
Remove "." from CDPATH — fixes cd auto-echo corrupting script output

### DIFF
--- a/bash/env.sh
+++ b/bash/env.sh
@@ -147,8 +147,15 @@ else
 fi
 
 # Directory navigation
-# Set CDPATH to include Developer directory (from previous .profile)
-export CDPATH=".:${HOME}/Developer:${HOME}/Developer/clients:${HOME}/Developer/netlify"
+# Set CDPATH to include Developer directory (from previous .profile).
+# Deliberately omits "." as the first entry: when cd resolves via CDPATH
+# (even a "." entry), bash's cd builtin echoes the resolved path to
+# stdout as a side effect — this silently corrupts any script's
+# `cd -- "$dir" && pwd` idiom (a very common pattern) by duplicating the
+# captured output whenever the script is invoked with a relative path.
+# Without "." here, cd only consults CDPATH for paths that aren't already
+# resolvable relative to $PWD, which is the behavior actually wanted.
+export CDPATH="${HOME}/Developer:${HOME}/Developer/clients:${HOME}/Developer/netlify"
 
 # Set correct terminal type for SSH sessions with color support
 export TERM=xterm-256color


### PR DESCRIPTION
## Summary

Discovered while running `lock-sync`'s `bin/install`: it failed with
`cd: $'/path/bin\n/path/bin/..': No such file or directory` when invoked
as a relative path (`bin/install`) from the repo root.

Root cause: `CDPATH` was set to `".:${HOME}/Developer:..."`. Bash's `cd`
builtin echoes the resolved directory to stdout whenever it resolves via
CDPATH — including the `.` entry — as a side effect (the same mechanism
`pushd` uses intentionally). Any script anywhere on this machine using the
common `cd -- "$dir" && pwd` idiom silently breaks when invoked with a
relative path, because the auto-echo duplicates the captured output.

Reproduced and verified in isolation:
```
$ bash -c 'x=bin; y=$(cd -- "$x" && pwd); echo "$y"'
/Users/andrewrich/Developer/lock-sync/bin
/Users/andrewrich/Developer/lock-sync/bin
```

## Fix

Removed `.` from `CDPATH`. The remaining entries (`~/Developer` and
subdirectories) are unchanged — `cd <name>` shorthand for those still
works. Only the specific "resolve relative to current directory via
CDPATH" case (which triggers the echo for zero benefit, since `.` is
already implicitly searched first by `cd` regardless) is removed.

## Follow-up filed (not blocking)

#176 — the fix narrows but doesn't fully eliminate the echo risk: `cd`-ing
into a directory whose name happens to match one of the remaining CDPATH
entries (e.g. `cd netlify` matching `~/Developer/netlify`) would still
trigger the echo. Scripts that capture `cd` output should defensively
`unset CDPATH` or use `CDPATH= cd ...` regardless of this fix.

## Test plan

- [x] Reproduced the bug in isolation (`cd -- "bin" && pwd` inside a nested `bash -c`) before the fix
- [x] Verified the fix in a fresh shell (`env -i ... bash --login`) with the corrected `env.sh`: single clean output, no duplication
- [x] Ran `lock-sync`'s `bin/install` end-to-end in a fresh shell — no errors, all symlinks and the LaunchAgent installed correctly

https://claude.ai/code/session_01Sasr2N9Rj9n8rv2sjwN2YJ
