### PR TITLE
fix(hooks): don't hard-block pre-push on stale CI status

### DIFF
--- a/bash/tests/test-pre-push-stale-ci.sh
+++ b/bash/tests/test-pre-push-stale-ci.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#shellcheck shell=bash
+# Standalone verification for git/hooks/pre-push's check_pr_review_iteration()
+# staleness detection. Run directly: bash bash/tests/test-pre-push-stale-ci.sh
+#
+# Regression coverage for #169: statusCheckRollup necessarily reflects the
+# PR's CURRENT remote head commit, not the commit this invocation of the
+# hook is about to push (GitHub hasn't run CI on it yet). The hook must not
+# hard-block on CI failures that belong to a commit other than the one being
+# pushed — see git/hooks/pre-push, check_pr_review_iteration().
+#
+# Strategy: the hook auto-executes every check top-to-bottom when run (it is
+# not designed to be sourced and cherry-picked), so each case below runs it
+# as a real subprocess: a scratch git repo, a mocked `gh` on PATH that
+# returns controlled JSON, and controlled stdin in the git pre-push hook's
+# standard format (<local ref> <local sha1> <remote ref> <remote sha1>).
+set -uo pipefail
+
+unset CDPATH
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="${REPO_ROOT}/git/hooks/pre-push"
+
+fail=0
+
+# ---------------------------------------------------------------
+# Shared scratch repo + mock gh setup
+# ---------------------------------------------------------------
+WORKDIR="/tmp/pre-push-stale-ci-test-$$"
+mkdir -p "${WORKDIR}"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# Isolate from this machine's global git hooks/templates (this repo sets
+# core.hooksPath / init.templateDir globally) — scratch test repos must not
+# inherit real commit-msg / pre-commit enforcement.
+setup_repo() {
+  local dir="$1"
+  mkdir -p "${dir}"
+  (
+    cd "${dir}" || exit 1
+    /usr/bin/git -c core.hooksPath= -c init.templateDir= init -q -b main
+    /usr/bin/git config core.hooksPath ""
+    /usr/bin/git config user.email "test@example.com"
+    /usr/bin/git config user.name "Test"
+    /usr/bin/git commit -q --allow-empty -m "test: init"
+    /usr/bin/git checkout -q -b feature
+    /usr/bin/git commit -q --allow-empty -m "test: feature commit"
+  )
+}
+
+# Mocked gh: `gh pr view --json ...` returns canned JSON depending on
+# GH_MOCK_JSON env var. Any other gh subcommand is a harmless no-op.
+write_mock_gh() {
+  local bin_dir="$1" json_var_file="$2"
+  cat >"${bin_dir}/gh" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+  cat "${json_var_file}"
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "${bin_dir}/gh"
+}
+
+# Run the hook as a subprocess with a controlled PATH (mock gh first),
+# controlled stdin (pre-push protocol line), and non-interactive strict mode
+# forced on so the CI-failure path actually attempts to block.
+run_hook() {
+  local repo_dir="$1" local_sha="$2" bin_dir="$3"
+  (
+    cd "${repo_dir}" || exit 1
+    export PATH="${bin_dir}:${PATH}"
+    export CLAUDECODE=1
+    export STRICT_PREPUSH=1
+    unset POSTPUSH_LOOP
+    printf 'refs/heads/feature %s refs/heads/feature deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n' "${local_sha}" \
+      | bash "${HOOK}" origin git@example.com:test/test.git </dev/stdin >"${WORKDIR}/out.log" 2>&1
+  )
+}
+
+# ---------------------------------------------------------------
+# Case 1: statusCheckRollup SHA matches the commit being pushed,
+# and has real failures -> must still hard-block.
+# ---------------------------------------------------------------
+REPO1="${WORKDIR}/repo1"
+BIN1="${WORKDIR}/bin1"
+mkdir -p "${BIN1}"
+setup_repo "${REPO1}"
+PUSHED_SHA_1=$(cd "${REPO1}" && /usr/bin/git rev-parse HEAD)
+
+JSON1="${WORKDIR}/gh1.json"
+cat >"${JSON1}" <<EOF
+{"number":42,"reviewDecision":null,"reviews":[],"statusCheckRollup":[{"name":"docker","conclusion":"FAILURE"}],"headRefOid":"${PUSHED_SHA_1}"}
+EOF
+write_mock_gh "${BIN1}" "${JSON1}"
+
+run_hook "${REPO1}" "${PUSHED_SHA_1}" "${BIN1}"
+exit1=$?
+out1=$(cat "${WORKDIR}/out.log")
+
+if [[ ${exit1} -ne 0 ]] && echo "${out1}" | grep -q "failing CI check"; then
+  echo "PASS: matching-SHA CI failures still hard-block"
+else
+  echo "FAIL: matching-SHA CI failures did not block as expected (exit=${exit1})"
+  echo "${out1}"
+  fail=1
+fi
+
+if echo "${out1}" | grep -qi "not the commit\|stale"; then
+  echo "FAIL: matching-SHA case incorrectly labeled as stale"
+  fail=1
+else
+  echo "PASS: matching-SHA case not mislabeled as stale"
+fi
+
+# ---------------------------------------------------------------
+# Case 2: statusCheckRollup SHA differs from the commit being
+# pushed (stale-by-construction) -> must NOT hard-block, and the
+# message must make clear the failures are against the old commit.
+# ---------------------------------------------------------------
+REPO2="${WORKDIR}/repo2"
+BIN2="${WORKDIR}/bin2"
+mkdir -p "${BIN2}"
+setup_repo "${REPO2}"
+PUSHED_SHA_2=$(cd "${REPO2}" && /usr/bin/git rev-parse HEAD)
+OLD_SHA_2="1111111111111111111111111111111111111"
+
+JSON2="${WORKDIR}/gh2.json"
+cat >"${JSON2}" <<EOF
+{"number":42,"reviewDecision":null,"reviews":[],"statusCheckRollup":[{"name":"docker","conclusion":"FAILURE"}],"headRefOid":"${OLD_SHA_2}"}
+EOF
+write_mock_gh "${BIN2}" "${JSON2}"
+
+run_hook "${REPO2}" "${PUSHED_SHA_2}" "${BIN2}"
+exit2=$?
+out2=$(cat "${WORKDIR}/out.log")
+
+if [[ ${exit2} -eq 0 ]]; then
+  echo "PASS: stale-SHA CI failures do not hard-block"
+else
+  echo "FAIL: stale-SHA CI failures incorrectly blocked the push (exit=${exit2})"
+  echo "${out2}"
+  fail=1
+fi
+
+if echo "${out2}" | grep -qi "not the commit you're\|currently on the remote"; then
+  echo "PASS: stale-SHA case message explicitly disclaims staleness"
+else
+  echo "FAIL: stale-SHA case message does not explain staleness"
+  echo "${out2}"
+  fail=1
+fi
+
+# ---------------------------------------------------------------
+# Case 3: statusCheckRollup SHA matches, no failures -> clean pass,
+# no Protocol 4 checkpoint triggered at all.
+# ---------------------------------------------------------------
+REPO3="${WORKDIR}/repo3"
+BIN3="${WORKDIR}/bin3"
+mkdir -p "${BIN3}"
+setup_repo "${REPO3}"
+PUSHED_SHA_3=$(cd "${REPO3}" && /usr/bin/git rev-parse HEAD)
+
+JSON3="${WORKDIR}/gh3.json"
+cat >"${JSON3}" <<EOF
+{"number":42,"reviewDecision":null,"reviews":[],"statusCheckRollup":[{"name":"docker","conclusion":"SUCCESS"}],"headRefOid":"${PUSHED_SHA_3}"}
+EOF
+write_mock_gh "${BIN3}" "${JSON3}"
+
+run_hook "${REPO3}" "${PUSHED_SHA_3}" "${BIN3}"
+exit3=$?
+out3=$(cat "${WORKDIR}/out.log")
+
+if [[ ${exit3} -eq 0 ]] && ! echo "${out3}" | grep -q "PROTOCOL 4 CHECKPOINT"; then
+  echo "PASS: clean CI (matching SHA) does not trigger Protocol 4 checkpoint"
+else
+  echo "FAIL: clean CI case unexpectedly blocked or triggered checkpoint (exit=${exit3})"
+  echo "${out3}"
+  fail=1
+fi
+
+if [[ "${fail}" -eq 1 ]]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "All pre-push stale-CI tests passed"

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -67,13 +67,29 @@ _read_semgrep_token() {
 # =========================================================
 # BRANCH PROTECTION - Do not push directly to main/master
 # =========================================================
+# Populated as a side effect of draining stdin below: the local SHA about to
+# be pushed for the ref matching the currently checked-out branch. stdin can
+# only be read once per hook invocation, so this is the one place we see it;
+# check_pr_review_iteration() (Protocol 4, later in this file) reads this
+# global to detect stale statusCheckRollup data (see #169).
+PUSHED_LOCAL_SHA=""
+
 protected_branch_check() {
+  local current_branch
+  current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+
   # Read push data from stdin
   # Format: <local ref> <local sha1> <remote ref> <remote sha1>
-  while read -r _local_ref _local_sha remote_ref _remote_sha; do
+  while read -r local_ref local_sha remote_ref _remote_sha; do
     # Allow tag pushes - tags don't modify branch history
     if [[ "${remote_ref}" =~ ^refs/tags/ ]]; then
       continue
+    fi
+
+    # Capture the local SHA for the ref matching the current branch, so
+    # later checks (Protocol 4) know exactly which commit is being pushed.
+    if [[ -n "${current_branch}" && "${local_ref}" == "refs/heads/${current_branch}" ]]; then
+      PUSHED_LOCAL_SHA="${local_sha}"
     fi
 
     # Block direct pushes to main/master branches
@@ -383,8 +399,13 @@ check_pr_review_iteration() {
 
   # Fetch PR state once. statusCheckRollup needs Checks permission on the PAT;
   # fall back gracefully if not granted (reviewDecision alone is still useful).
+  # headRefOid identifies which commit statusCheckRollup is reporting against
+  # — GitHub hasn't seen the commit this hook is about to push yet, so
+  # statusCheckRollup necessarily reflects the PR's CURRENT remote head, not
+  # the new commit (see #169). We fetch it in the same call so we can detect
+  # that staleness below rather than presenting old CI results as current.
   local pr_json
-  pr_json=$(gh pr view --json number,reviewDecision,reviews,statusCheckRollup 2>/dev/null || echo "")
+  pr_json=$(gh pr view --json number,reviewDecision,reviews,statusCheckRollup,headRefOid 2>/dev/null || echo "")
   if [[ -z "${pr_json}" ]]; then
     pr_json=$(gh pr view --json number,reviewDecision,reviews 2>/dev/null || echo "")
   fi
@@ -396,6 +417,23 @@ check_pr_review_iteration() {
   if [[ -n "${pr_number}" ]]; then
     echo ""
     log "Pushing to existing PR #${pr_number}"
+
+    # Determine which commit statusCheckRollup reports against (the PR's
+    # current remote head) vs. which commit is about to be pushed. If they
+    # differ, GitHub has not run CI against the new commit yet — any
+    # statusCheckRollup failures are necessarily against the OLD commit and
+    # must not be presented as if they belong to the push in flight (#169).
+    local head_ref_oid pushed_sha ci_is_stale=false
+    head_ref_oid=$(echo "${pr_json}" | jq -r '.headRefOid // empty' 2>/dev/null || echo "")
+    pushed_sha="${PUSHED_LOCAL_SHA:-}"
+    if [[ -z "${pushed_sha}" ]]; then
+      # Fallback: stdin didn't yield a match (e.g. unexpected ref shape) —
+      # the commit about to be pushed for a normal single-branch push is HEAD.
+      pushed_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
+    fi
+    if [[ -n "${head_ref_oid}" && -n "${pushed_sha}" && "${head_ref_oid}" != "${pushed_sha}" ]]; then
+      ci_is_stale=true
+    fi
 
     local has_issues=false
 
@@ -433,8 +471,19 @@ check_pr_review_iteration() {
       | length' 2>/dev/null || echo "0")
 
     if [[ "${ci_failures}" -gt 0 ]]; then
-      has_issues=true
-      log_warning "⚠️  PR has ${ci_failures} failing CI check(s)"
+      if [[ "${ci_is_stale}" == true ]]; then
+        # Known-stale by construction: GitHub hasn't run CI against the
+        # commit we're about to push, so these failures are against the
+        # commit CURRENTLY on the remote (${head_ref_oid:0:7}), not the one
+        # in flight (${pushed_sha:0:7}). Informational only — not blocking.
+        log_warning "ℹ️  PR has ${ci_failures} failing CI check(s) — but against the commit"
+        log_warning "   currently on the remote (${head_ref_oid:0:7}), NOT the commit you're"
+        log_warning "   about to push (${pushed_sha:0:7}). GitHub hasn't run CI on your new"
+        log_warning "   commit yet, so this is not evidence your fix is broken."
+      else
+        has_issues=true
+        log_warning "⚠️  PR has ${ci_failures} failing CI check(s)"
+      fi
     fi
 
     if [[ "${has_issues}" == true ]]; then


### PR DESCRIPTION
## Summary
- Fixes #169: `check_pr_review_iteration()` in `git/hooks/pre-push` queried `statusCheckRollup` before the commit being pushed had reached GitHub, so it always saw CI results for the PR's current remote head, not the commit in flight — causing a false-positive hard block when a fix commit for known-broken CI got blocked by the failures it was fixing.
- Captures the local SHA about to be pushed while draining pre-push's stdin, fetches `headRefOid` alongside `statusCheckRollup`, and compares them. When they differ, CI data is stale by construction and failures are downgraded to an informational warning naming both SHAs instead of hard-blocking. When they match, blocking behavior is unchanged.

## Test plan
- [x] Added `bash/tests/test-pre-push-stale-ci.sh`: matching-SHA CI failures still hard-block; stale-SHA CI failures do not block and the message explains why; matching-SHA clean CI doesn't trigger the Protocol 4 checkpoint at all.
- [x] Ran full local `bash/tests/*.sh` suite — all pass.
- [x] `shellcheck -S info` clean on both changed files, no disable directives.
- [x] Local code-reviewer + adversarial-reviewer both pass clean (pre-commit hook).
- [x] Full-diff + codebase review pass clean on push (one non-blocking cosmetic note filed automatically about a test fixture SHA length, no functional impact).

https://claude.ai/code/session_01N1j4BYRDeSmbsvxDdaaL69
