### PR TITLE
chore(ci): standardize dependabot-auto-merge.yml and claude-blocking-review.yml on tag-pinning

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -18,7 +18,7 @@ jobs:
   # inside the job instead, so it still reports PASS. See
   # smartwatermelon/github-workflows#115/#117.
   claude-review:
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@9615f932744f8cb372e4650c73d52559219efdf1  # v3.1.0
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.1.0
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
@@ -31,7 +31,7 @@ jobs:
   # inside the job instead, so it still reports PASS. See
   # smartwatermelon/github-workflows#115/#117.
   claude-review-haiku:
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@9615f932744f8cb372e4650c73d52559219efdf1  # v3.1.0
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.1.0
     with:
       pr_number: ${{ github.event.pull_request.number }}
       model: "claude-haiku-4-5-20251001"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,6 +28,6 @@ jobs:
   # yields an effective allowlist of dependabot|actions|smartwatermelon
   # — identical coverage to the inline logic this replaces.
   dependabot-auto-merge:
-    uses: smartwatermelon/github-workflows/.github/workflows/dependabot-auto-merge.yml@cd83f054fe1129b5d3a1cf22dc6598e5b1524224  # dependabot-auto-merge-v2
+    uses: smartwatermelon/github-workflows/.github/workflows/dependabot-auto-merge.yml@dependabot-auto-merge-v2
     with:
       trusted_namespaces: 'smartwatermelon'


### PR DESCRIPTION
Reverts both files to the fleet-wide tag-pinned convention for
smartwatermelon/github-workflows reusable workflow refs, matching the
other 27 repos in the fleet (migrated in smartwatermelon/dev-env#20).

Both tags were confirmed to resolve to the exact same underlying commits
that were previously SHA-pinned (dependabot-auto-merge-v2 -> cd83f054,
v3.1.0 -> 9615f932) -- this is a pin-style change only, not a version
bump.

Bypasses local code-reviewer/adversarial-reviewer hooks with --no-verify,
authorized by the user for this specific commit. See #173 for the full
history: these hooks hard-blocked the tag-pinned form 8 consecutive times
during the dev-env#20 migration, objecting to the sibling-file pin-style
inconsistency (claude-blocking-review.yml was already SHA-pinned before
that migration). Multiple rounds of added documentation did not resolve
it, so SHA-pinning was adopted as the practical workaround at the time,
leaving dotfiles as the one fleet outlier. This commit closes that gap.

Fixes #173

Claude-Session: https://claude.ai/code/session_01N1j4BYRDeSmbsvxDdaaL69
