### PR TITLE
fix(hooks): deploy post-checkout via core.hooksPath so clone/checkout fire it

### DIFF
--- a/bash/tests/test-post-checkout-hookspath.sh
+++ b/bash/tests/test-post-checkout-hookspath.sh
@@ -63,12 +63,13 @@ fi
 # --- Case 2: real `git clone` fires the delegate via core.hooksPath -------
 HOOKS_DIR="${WORKDIR}/hookspath"
 mkdir -p "${HOOKS_DIR}"
-ln -sf "${DELEGATE}" "${HOOKS_DIR}/post-checkout"
 
-# Point the delegate's REPO_DIR at REPO_ROOT for this case (real canonical
-# hook), but redirect its TEMPLATE_DIR lookup to a scratch template so it
-# doesn't touch the real ~/.config/git/template or create .claude/ from
-# the real template contents.
+# Both REPO_DIR and the canonical hook path get sed-redirected to WORKDIR
+# stubs below (DELEGATE_FOR_CLONE) so this case only proves the *delegate
+# fires* on a real `git clone` through core.hooksPath — it doesn't exercise
+# git/template/hooks/post-checkout's actual .claude scaffolding logic
+# (already covered by test-git-wrapper-init-hook.sh), and it doesn't touch
+# the real ~/.config/git/template or ~/Developer/dotfiles.
 SRC="${WORKDIR}/src"
 mkdir -p "${SRC}"
 git -c init.templateDir="" -C "${SRC}" init -q -b main

--- a/bash/tests/test-post-checkout-hookspath.sh
+++ b/bash/tests/test-post-checkout-hookspath.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#shellcheck shell=bash
+# Standalone verification that git/hooks/post-checkout (deployed via
+# core.hooksPath) correctly delegates to git/template/hooks/post-checkout
+# and fires on real git-resolved checkout events. Run directly:
+# bash bash/tests/test-post-checkout-hookspath.sh
+#
+# Regression coverage: this machine sets a global core.hooksPath
+# (~/.config/git/hooks), which makes git ignore a repo's own .git/hooks/
+# entirely. `git init` only ever worked because bash/git-wrapper.sh
+# resolves and execs git/template/hooks/post-checkout directly by path,
+# bypassing hook resolution — but `git clone` and real branch-switch
+# `git checkout` go through git's normal core.hooksPath resolution, which
+# had no post-checkout entry at all, so .claude/ scaffolding silently
+# never ran for those. This test proves git/hooks/post-checkout (the
+# core.hooksPath delegate) exists, execs the canonical template hook with
+# args passed through unchanged, and that a real `git clone` through a
+# core.hooksPath-configured hooks dir triggers it end-to-end.
+set -euo pipefail
+
+REPO_ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DELEGATE="${REPO_ROOT}/git/hooks/post-checkout"
+
+WORKDIR="/tmp/post-checkout-hookspath-test-$$"
+mkdir -p "${WORKDIR}"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+fail=0
+
+# --- Case 1: delegate execs the canonical hook with args intact -----------
+# Point the delegate at a stub canonical target (via a symlink swap) so this
+# case doesn't depend on ~/Developer/dotfiles existing or create a real
+# .claude/ directory.
+STUB_DIR="${WORKDIR}/stub-repo"
+mkdir -p "${STUB_DIR}"
+STUB_LOG="${WORKDIR}/stub.log"
+STUB_CANONICAL="${WORKDIR}/stub-canonical-post-checkout"
+cat >"${STUB_CANONICAL}" <<EOF
+#!/usr/bin/env bash
+echo "\$1 \$2 \$3" > "${STUB_LOG}"
+EOF
+chmod +x "${STUB_CANONICAL}"
+
+STUB_DELEGATE="${WORKDIR}/stub-delegate-post-checkout"
+sed "s|REPO_DIR=\"\${HOME}/Developer/dotfiles\"|REPO_DIR=\"${WORKDIR}\"|; s|git/template/hooks/post-checkout|stub-canonical-post-checkout|" \
+  "${DELEGATE}" >"${STUB_DELEGATE}"
+chmod +x "${STUB_DELEGATE}"
+
+(cd "${STUB_DIR}" && "${STUB_DELEGATE}" \
+  0000000000000000000000000000000000000000 \
+  1111111111111111111111111111111111111111 \
+  1)
+
+stub_log_contents=""
+[[ -f "${STUB_LOG}" ]] && stub_log_contents="$(cat "${STUB_LOG}")"
+if [[ "${stub_log_contents}" == "0000000000000000000000000000000000000000 1111111111111111111111111111111111111111 1" ]]; then
+  echo "PASS: delegate execs canonical hook with args passed through unchanged"
+else
+  echo "FAIL: delegate did not exec canonical hook with correct args"
+  fail=1
+fi
+
+# --- Case 2: real `git clone` fires the delegate via core.hooksPath -------
+HOOKS_DIR="${WORKDIR}/hookspath"
+mkdir -p "${HOOKS_DIR}"
+ln -sf "${DELEGATE}" "${HOOKS_DIR}/post-checkout"
+
+# Point the delegate's REPO_DIR at REPO_ROOT for this case (real canonical
+# hook), but redirect its TEMPLATE_DIR lookup to a scratch template so it
+# doesn't touch the real ~/.config/git/template or create .claude/ from
+# the real template contents.
+SRC="${WORKDIR}/src"
+mkdir -p "${SRC}"
+git -c init.templateDir="" -C "${SRC}" init -q -b main
+echo "content" >"${SRC}/file.txt"
+git -C "${SRC}" add file.txt
+git -C "${SRC}" -c user.email=t@t.com -c user.name=t -c core.hooksPath="" commit -q -m "chore: test fixture"
+
+DST="${WORKDIR}/dst"
+# TEMPLATE_DIR resolution inside the canonical hook falls back to
+# init.templateDir or ~/.config/git/template; neither exists in this
+# sandboxed HOME, so the canonical hook exits 0 without creating .claude —
+# that's fine, this case only proves the *delegate fires*, not the full
+# .claude scaffold (already covered by test-git-wrapper-init-hook.sh).
+MARKER_LOG="${WORKDIR}/clone-fired.log"
+DELEGATE_FOR_CLONE="${WORKDIR}/delegate-for-clone"
+sed "s|git/template/hooks/post-checkout|stub-canonical-post-checkout|; s|REPO_DIR=\"\${HOME}/Developer/dotfiles\"|REPO_DIR=\"${WORKDIR}\"|" \
+  "${DELEGATE}" >"${DELEGATE_FOR_CLONE}"
+chmod +x "${DELEGATE_FOR_CLONE}"
+cat >"${STUB_CANONICAL}" <<EOF
+#!/usr/bin/env bash
+echo "clone fired: \$3" >> "${MARKER_LOG}"
+EOF
+ln -sf "${DELEGATE_FOR_CLONE}" "${HOOKS_DIR}/post-checkout"
+
+git -c core.hooksPath="${HOOKS_DIR}" clone -q "${SRC}" "${DST}" >/dev/null 2>&1
+
+if [[ -f "${MARKER_LOG}" ]] && grep -q "clone fired: 1" "${MARKER_LOG}"; then
+  echo "PASS: real git clone through core.hooksPath fires the delegate"
+else
+  echo "FAIL: git clone did not fire post-checkout via core.hooksPath"
+  fail=1
+fi
+
+if [[ "${fail}" -eq 1 ]]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "All post-checkout hookspath tests passed"

--- a/git/hooks/post-checkout
+++ b/git/hooks/post-checkout
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Deployed via core.hooksPath (~/.config/git/hooks/post-checkout) so it
+# fires on `git clone` and real branch-switch `git checkout` — cases
+# git resolves through core.hooksPath, not a repo's own .git/hooks/ or
+# init.templateDir. `git init` doesn't need this delegate: bash/git-wrapper.sh
+# invokes git/template/hooks/post-checkout directly by path after init,
+# bypassing hook resolution entirely.
+set -euo pipefail
+
+REPO_DIR="${HOME}/Developer/dotfiles"
+exec "${REPO_DIR}/git/template/hooks/post-checkout" "$@"


### PR DESCRIPTION
## Summary

`git/template/hooks/post-checkout` only ever ran for `git init` on this machine, because `bash/git-wrapper.sh` resolves and execs it directly by path after init, bypassing git's normal hook resolution entirely.

This machine sets a global `core.hooksPath` (`~/.config/git/hooks`), which makes git ignore a repo's own `.git/hooks/` for every other operation — including `git clone` and real branch-switch `git checkout`. That directory never had a `post-checkout` entry, so `.claude/` infrastructure scaffolding silently never ran for clone — arguably the more common way to start working on a repo.

## Changes

- Adds `git/hooks/post-checkout` as a thin delegate to the canonical `git/template/hooks/post-checkout` implementation, so the repo's existing symlink-repair machinery deploys it into `~/.config/git/hooks/post-checkout` alongside the other hooks (`commit-msg`, `pre-commit`, `pre-push`, `post-commit`).
- Adds `bash/tests/test-post-checkout-hookspath.sh` covering the delegate's args pass-through and a real `git clone`-through-`core.hooksPath` firing.

Verified end-to-end: a real `git clone` of this repo now creates `.claude/` in the destination, which it did not before this change.

## Test plan

- [x] Full local test suite passes (8/8 files)
- [x] shellcheck -S info clean on both changed files
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer) passed
- [x] Pre-push full-diff + codebase review passed
- [x] Manually verified: `git clone` of the real repo now creates `.claude/`, confirmed against the unpatched behavior first

Claude-Session: https://claude.ai/code/session_01N1j4BYRDeSmbsvxDdaaL69
