### PR TITLE
fix(tests): stop test-git-wrapper-init-hook.sh from corrupting the real repo

### DIFF
--- a/bash/tests/test-git-wrapper-init-hook.sh
+++ b/bash/tests/test-git-wrapper-init-hook.sh
@@ -26,6 +26,21 @@ unset _GIT_WRAPPER_ACTIVE
 # Isolate test repos from any ambient git context
 export GIT_CEILING_DIRECTORIES="${WORKDIR}"
 
+# Disable the global init.templateDir for every `git init` this test runs.
+# On a machine with init.templateDir configured (this repo's own install.sh
+# sets it to ~/.config/git/template), git's template-copy step preserves
+# symlinks rather than dereferencing them — and ~/.config/git/template's own
+# hooks/post-checkout is a symlink straight into this repo's
+# git/template/hooks/post-checkout. Without this override, `command git
+# init` below would populate each scratch repo's .git/hooks/post-checkout
+# as a symlink to the real file, and install_hook()'s `cat >` would then
+# write through that symlink and clobber the real repo file instead of the
+# scratch fixture. Confirmed by direct reproduction: prior to this fix,
+# every run of this test corrupted git/template/hooks/post-checkout.
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0="init.templateDir"
+export GIT_CONFIG_VALUE_0=""
+
 #shellcheck source=/dev/null
 source "${BASH_CONFIG_DIR}/git-wrapper.sh"
 


### PR DESCRIPTION
## Summary

Root cause of the recurring `git/template/hooks/post-checkout` stub corruption seen while working on #184: `test-git-wrapper-init-hook.sh` never overrode `init.templateDir`, so every `command git init` it ran in its `/tmp` scratch dirs inherited this machine's global `init.templateDir` (`~/.config/git/template`, set by `install.sh`).

Git's template-copy step preserves symlinks rather than dereferencing them, and `~/.config/git/template/hooks/post-checkout` is itself a symlink straight into this repo's `git/template/hooks/post-checkout` (the repo's own symlink-deployment model). So each scratch repo's `.git/hooks/post-checkout` ended up as a symlink to the real file, and `install_hook()`'s `cat > "${repo_dir}/.git/hooks/post-checkout"` wrote through that symlink, clobbering the real repo file with the test's stub fixture content.

Reproduced deterministically: prior to this fix, every single run of this test corrupted the real file, regardless of `GIT_CEILING_DIRECTORIES` (which only isolates ceiling-directory resolution, not template sourcing).

## Fix

Export `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` to force `init.templateDir=""` for every git invocation in this test's process tree. The env-var form is needed (not a `-c` flag) because it must apply to both the test's own `command git init` calls and the wrapper's internal `git init` calls inside `git-wrapper.sh`.

## Test plan

- [x] Verified clean across 5 consecutive runs (previously corrupted the real file on 100% of runs)
- [x] Full local test suite passes (8/8 files), no corruption anywhere in the suite
- [x] shellcheck -S info clean
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer) passed
- [x] Pre-push full-diff + codebase review passed

Claude-Session: https://claude.ai/code/session_01N1j4BYRDeSmbsvxDdaaL69
