### PR TITLE
fix(gh-wrapper): NUL-delimited arg rebuild to survive multi-line values

### DIFF
--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -222,10 +222,14 @@ _gh_wrapper_maybe_review() {
 # itself with creation time. See smartwatermelon/dotfiles#174.
 #
 # Bash can't let a function reassign the caller's positional params, so this
-# prints the (possibly modified) argument list, one arg per line, on stdout;
-# the caller rebuilds its array with `mapfile`/`readarray`. Always prints
-# something — even when no change is needed — so callers can unconditionally
-# replace their arg array from the output.
+# prints the (possibly modified) argument list, NUL-separated, on stdout; the
+# caller rebuilds its array with `mapfile -d ''`. NUL (not newline) because
+# argument values themselves may contain embedded newlines (e.g. a multi-line
+# --body) — a newline delimiter can't be told apart from one inside a value,
+# which shreds such args into multiple positional params downstream. NUL
+# cannot appear in a shell argument, so it's an unambiguous separator. Always
+# prints something — even when no change is needed — so callers can
+# unconditionally replace their arg array from the output.
 #
 # Parses args with the same sub/subsub walk as _gh_wrapper_maybe_review, so
 # `pr create` detection can't drift between the two.
@@ -264,15 +268,18 @@ _gh_wrapper_force_draft_for_off_org() {
           # caller already passed --draft (or --draft=false, which gh doesn't
           # support as a real flag) — an extra --draft is harmless, and the
           # point is nothing the caller does can produce a non-draft PR here.
-          printf '%s\n' "$@"
-          printf -- '--draft\n'
+          printf '%s\0' "$@"
+          printf -- '--draft\0'
           return 0
           ;;
       esac
     fi
   fi
 
-  printf '%s\n' "$@"
+  # printf with zero operands still runs its format string once, emitting a
+  # single stray NUL for `"$@"` empty — guard so zero args truly produces
+  # zero bytes of output, matching `mapfile -d ''`'s empty-array behavior.
+  [[ "$#" -gt 0 ]] && printf '%s\0' "$@"
   return 0
 }
 
@@ -310,14 +317,24 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
       # Off-org `gh pr create` must land as a draft — hard, mechanical,
       # no opt-out. Rebuild the positional params from the (possibly
       # --draft-appended) output; a function can't reassign "$@" directly.
-      # Captured via command substitution (not process substitution) so the
-      # function's own exit status isn't masked from `set -e`. Only rebuild
-      # when there's at least one original arg — with zero args, `mapfile
-      # <<<""` would otherwise produce a single empty-string element instead
-      # of an empty array, turning bare `gh` into `gh ""`.
+      # NUL-delimited via process substitution (mapfile -d '' requires it —
+      # command substitution can't carry NUL bytes at all; bash discards
+      # them outright, so the NUL contract is structurally impossible
+      # through `$(...)`). `|| true` is just to satisfy shellcheck SC2312
+      # (don't mask a pipeline component's exit status): the function
+      # always returns 0, so there's no real status being discarded. Only
+      # rebuild when there's at least one original arg.
       if [[ "$#" -gt 0 ]]; then
-        _gh_wrapper_new_args_raw="$(_gh_wrapper_force_draft_for_off_org "$@")"
-        mapfile -t _gh_wrapper_new_args <<<"${_gh_wrapper_new_args_raw}"
+        mapfile -t -d '' _gh_wrapper_new_args < <(_gh_wrapper_force_draft_for_off_org "$@" || true)
+        # The function is contractually guaranteed to emit at least as many
+        # elements as it received (it only ever appends --draft, never
+        # drops args). A short rebuild means the producer failed partway
+        # through — trust nothing and refuse rather than silently exec'ing
+        # gh with a truncated command line (which could drop --draft itself).
+        if [[ "${#_gh_wrapper_new_args[@]}" -lt "$#" ]]; then
+          echo "[gh] ERROR: internal arg rebuild truncated; refusing to proceed" >&2
+          exit 1
+        fi
         set -- "${_gh_wrapper_new_args[@]}"
       fi
     fi
@@ -378,13 +395,19 @@ else
     # Off-org `gh pr create` must land as a draft — hard, mechanical, no
     # opt-out. Rebuild the positional params from the (possibly
     # --draft-appended) output; a function can't reassign "$@" directly.
-    # Only rebuild when there's at least one original arg — with zero args,
-    # `mapfile <<<""` would otherwise produce a single empty-string element
-    # instead of an empty array, turning bare `gh` into `gh ""`.
+    # NUL-delimited via process substitution — see the standalone-mode call
+    # site above for why (embedded newlines in arg values, e.g. --body).
+    # Only rebuild when there's at least one original arg.
     if [[ "$#" -gt 0 ]]; then
-      local _gh_wrapper_new_args _gh_wrapper_new_args_raw
-      _gh_wrapper_new_args_raw="$(_gh_wrapper_force_draft_for_off_org "$@")"
-      mapfile -t _gh_wrapper_new_args <<<"${_gh_wrapper_new_args_raw}"
+      local _gh_wrapper_new_args
+      mapfile -t -d '' _gh_wrapper_new_args < <(_gh_wrapper_force_draft_for_off_org "$@" || true)
+      # See the standalone-mode call site above: a short rebuild means the
+      # producer failed partway through — refuse rather than silently
+      # exec'ing gh with a truncated command line.
+      if [[ "${#_gh_wrapper_new_args[@]}" -lt "$#" ]]; then
+        echo "[gh] ERROR: internal arg rebuild truncated; refusing to proceed" >&2
+        return 1
+      fi
       set -- "${_gh_wrapper_new_args[@]}"
     fi
 

--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -227,9 +227,11 @@ _gh_wrapper_maybe_review() {
 # argument values themselves may contain embedded newlines (e.g. a multi-line
 # --body) — a newline delimiter can't be told apart from one inside a value,
 # which shreds such args into multiple positional params downstream. NUL
-# cannot appear in a shell argument, so it's an unambiguous separator. Always
-# prints something — even when no change is needed — so callers can
-# unconditionally replace their arg array from the output.
+# cannot appear in a shell argument, so it's an unambiguous separator. Prints
+# nothing for zero args (callers already guard with `[[ "$#" -gt 0 ]]`
+# accordingly); otherwise always prints at least the original args,
+# NUL-separated, so callers can unconditionally replace their arg array
+# from the output.
 #
 # Parses args with the same sub/subsub walk as _gh_wrapper_maybe_review, so
 # `pr create` detection can't drift between the two.

--- a/bash/tests/test-gh-wrapper-draft-off-org.sh
+++ b/bash/tests/test-gh-wrapper-draft-off-org.sh
@@ -27,9 +27,7 @@ assert_args() {
   local expected_has_draft="$1"
   shift
   local -a got=()
-  local out
-  out="$(_gh_wrapper_force_draft_for_off_org "$@")"
-  mapfile -t got <<<"${out}"
+  mapfile -t -d '' got < <(_gh_wrapper_force_draft_for_off_org "$@" || true)
 
   local has_draft=0 a
   for a in "${got[@]}"; do
@@ -70,11 +68,22 @@ assert_args "off-org pr create --help (function itself is harmless)" 1 pr create
 # once more isn't required to be deduped, just confirm it's present.
 assert_args "off-org pr create with explicit --draft already present" 1 pr create --repo someoutsideorg/foo --draft --title x
 
+# Regression for smartwatermelon/dotfiles#186: a --body value containing
+# embedded newlines must survive the arg-list rebuild intact as a single
+# argument, not get shredded into multiple positional params at each \n.
+multiline_body="$(printf 'line one\nline two\nline three')"
+mapfile -t -d '' multiline_got < <(_gh_wrapper_force_draft_for_off_org pr create --repo smartwatermelon/dotfiles --title x --body "${multiline_body}" || true)
+if [[ "${#multiline_got[@]}" == "8" && "${multiline_got[7]}" == "${multiline_body}" ]]; then
+  echo "PASS: multi-line --body value survives arg rebuild intact"
+else
+  echo "FAIL: multi-line --body value was shredded (count=${#multiline_got[@]}): ${multiline_got[*]@Q}"
+  fail=1
+fi
+
 # Zero args: must not error and must not fabricate an argument.
-out="$(_gh_wrapper_force_draft_for_off_org)"
-mapfile -t zero_args <<<"${out}"
-if [[ "${#zero_args[@]}" == "1" && -z "${zero_args[0]}" ]]; then
-  echo "PASS: zero-arg call produces a single empty line (caller guards against rebuilding \$@ from this)"
+mapfile -t -d '' zero_args < <(_gh_wrapper_force_draft_for_off_org || true)
+if [[ "${#zero_args[@]}" == "0" ]]; then
+  echo "PASS: zero-arg call produces an empty array"
 else
   echo "FAIL: zero-arg call produced unexpected output: ${zero_args[*]}"
   fail=1


### PR DESCRIPTION
## Summary

- Fixes #186: `gh pr create --body "<multi-line>"` (and any other flag whose value contains an embedded newline) was getting shredded by `_gh_wrapper_force_draft_for_off_org`'s arg-rebuild path — newline-delimited `printf`/`mapfile` couldn't tell an argument boundary from a newline inside a value, so multi-line values split into extra positional args and corrupted the reconstructed `gh` command line (Cobra then misread continuation lines as shorthand flags).
- Fixes #187: stale comment claiming the function "always prints something," which stopped being true once a zero-args guard was added.

## Changes

- Switch the arg-list serialization from `printf '%s\n'` + newline-delimited `mapfile` to `printf '%s\0'` + `mapfile -t -d ''` (NUL-delimited) at both call sites — standalone-wrapper mode (`~/.local/bin/gh`) and sourced-function mode (`functions.sh`/`BASH_ENV`). NUL cannot appear in a shell argv element, so it's an unambiguous separator.
- Switch from command substitution to process substitution on the receiving end, since `$(...)` strips NUL bytes entirely and can't carry them.
- Guard the zero-args case so the function emits zero bytes rather than a stray NUL (`printf` with zero operands still runs its format string once).
- Add a truncation guard at both call sites: if the rebuilt arg count is ever shorter than the original, refuse to proceed rather than silently `exec`'ing `gh` with a truncated command line (which could drop the forced `--draft` itself).
- Update `bash/tests/test-gh-wrapper-draft-off-org.sh` for the new contract and add a regression test asserting a multi-line `--body` value survives the rebuild intact as a single argument.

## Test plan

- [x] `shellcheck -S info` clean on both changed files
- [x] All 8 suites in `bash/tests/*.sh` pass, including the new multi-line `--body` regression test and updated zero-args test
- [x] Manually verified `_gh_wrapper_force_draft_for_off_org` preserves multi-line body values (in-org and off-org/draft-forcing paths), and correctly still appends `--draft` for off-org targets
- [x] Independent code review (2 parallel agents) + adversarial review, both clean; adversarial review's non-blocking findings (truncation guard, stale comment) applied
- [x] Local pre-commit/pre-push hook reviews (code-reviewer + adversarial-reviewer, full-diff + codebase review) all passed

https://claude.ai/code/session_015qWVmJH3zZPDR9wvpxMa88