### PR TITLE
fix(git): raise pre-merge review timeout to 420s

### DIFF
--- a/git/config
+++ b/git/config
@@ -52,3 +52,5 @@
 	rebase = true
 [includeIf "gitdir:~/Developer/beacon-biosignals/"]
 	path = ~/.gitconfig-beacon
+[review]
+	preMergeTimeout = 420


### PR DESCRIPTION
The pre-merge review analysis times out at 180s and **hard-fails the merge** (`pre-merge-review.sh:851` exits 1). A reviewer that never ran gets treated as a reviewer that objected, and the operator sees "Analysis timed out after 180s" — which reads as a problem with the PR.

## Observed twice on 2026-08-18

| PR | diff | prompt | outcome |
|---|---|---|---|
| `dotfiles#202` | 12 lines | 7.4 KB | timed out once, passed on retry |
| `claude-config#336` | 460 lines | **33.8 KB** | timed out **twice** at 180s; passed at 420s |

`#336` is the informative case. Two consecutive timeouts is not flakiness — the merge was unblockable without changing config.

## Cause

Prompt size and timeout are set independently. `pre-merge-review.sh:592` embeds the **full diff** for anything ≤1000 lines:

```bash
if [[ ${DIFF_LINES} -le 1000 ]]; then
  # include the FULL diff
```

So a 460-line diff — comfortably "under threshold" — produced a 33.8 KB prompt, while the timeout stayed a flat constant with nothing connecting the two.

This has bitten before: the header comment at `:37-38` records the default already being raised 120s → 180s for the same reason. That fix treated the symptom and it recurred at the new ceiling.

## Why global, not per-repo

`hooks/pre-merge-review.sh` is a **single shared script** — `~/.claude/hooks/pre-merge-review.sh` symlinks into `claude-config`, and no other repo has its own copy. Every repo runs identical code; only the config value it reads differs.

The timeout is a property of *the analysis* — it scales with prompt size, which scales with diff size — not of any individual repo. A repo-local value drifts immediately, which is exactly what happened when I first set this in `claude-config` alone and left the other four on the 180s default.

Verified the key matches what the script reads (`pre-merge-review.sh:40`):

```bash
TIMEOUT_SECONDS=$(git config --get --type=int review.preMergeTimeout 2>/dev/null || echo "180")
```

## Scope

This is a **workaround, not the fix**. Scaling the timeout with the already-computed prompt size (the script logs `Prompt size: 33835 bytes`) is tracked in [smartwatermelon/claude-config#343](https://github.com/smartwatermelon/claude-config/issues/343).

https://claude.ai/code/session_0165j8uC57NWoexNQ6wwbLC8