### PR TITLE
fix(gh): correct identity auto-switch defaults and add Beacon heuristic

### DIFF
--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -74,15 +74,73 @@ _gh_wrapper_resolve_owner() {
   printf '%s\n' "${owner}"
 }
 
+# Directory whose subtree marks a checkout as Beacon work. Overridable for
+# tests; defaults to the standard work checkout root. No trailing slash —
+# _gh_wrapper_is_beacon_context appends its own when matching.
+: "${GH_WRAPPER_BEACON_DIR:=${HOME}/Developer/beacon-biosignals}"
+
+# Second-tier signal for the "Beacon work, but not under the beacon-biosignals
+# org" case: repos created/forked during Beacon work that live under a
+# personal or third-party owner (e.g. andrewmrich/git-pkgs-proxy, a fork of an
+# unrelated upstream). Owner name alone can't classify those, so fall back to
+# where the checkout lives and what it was forked from.
+#
+# Two signals, checked in order:
+#   1. The repo's toplevel is inside ${GH_WRAPPER_BEACON_DIR}.
+#   2. An `upstream` remote pointing at the beacon-biosignals org.
+#
+# Both are cwd-relative by nature, so this is only consulted for owners that
+# aren't explicitly claimed by either identity (see _gh_wrapper_sync_identity).
+# Returns 0 (true) if this looks like Beacon work.
+_gh_wrapper_is_beacon_context() {
+  local toplevel upstream_url upstream_owner
+
+  # Signal 1: checkout location. Compare canonicalized paths so symlinked
+  # checkouts and trailing-slash differences don't produce false negatives.
+  toplevel=$(command git rev-parse --show-toplevel 2>/dev/null)
+  if [[ -n "${toplevel}" && -d "${GH_WRAPPER_BEACON_DIR}" ]]; then
+    local real_top real_beacon
+    real_top=$(realpath "${toplevel}" 2>/dev/null || printf '%s' "${toplevel}")
+    real_beacon=$(realpath "${GH_WRAPPER_BEACON_DIR}" 2>/dev/null || printf '%s' "${GH_WRAPPER_BEACON_DIR}")
+    # Match the dir itself or anything beneath it, but not a sibling whose
+    # name merely shares the prefix (…/beacon-biosignals-scratch).
+    if [[ "${real_top}" == "${real_beacon}" || "${real_top}" == "${real_beacon}/"* ]]; then
+      return 0
+    fi
+  fi
+
+  # Signal 2: forked from the beacon-biosignals org. Uses the same
+  # host/scheme-stripping shape as _gh_wrapper_resolve_owner.
+  upstream_url=$(command git config --get remote.upstream.url 2>/dev/null)
+  if [[ -n "${upstream_url}" ]]; then
+    upstream_owner=$(printf '%s\n' "${upstream_url}" | sed -E 's#^(git@[^:]+:|[a-zA-Z]+://[^/]+/)##; s#/.*##')
+    [[ "${upstream_owner,,}" == "beacon-biosignals" ]] && return 0
+  fi
+
+  return 1
+}
+
 # gh has one active account per host (not per repo), unlike git+SSH which
 # already resolves the right identity per remote via ~/.ssh/config host
-# aliases. This keeps gh in sync with that same per-repo intent: repos owned
-# by smartwatermelon or nightowlstudiollc (both authenticated as the
-# smartwatermelon gh account) use that account; everything else (Beacon
-# repos, etc.) falls back to andrewmrich. Local-only (reads/writes gh's
-# config file, no network), so it's cheap to run on every invocation.
-# Caveat: this mutates global gh state, so concurrent shells working in
-# different-owner repos at the same time can race each other.
+# aliases. This keeps gh in sync with that same per-repo intent.
+#
+# Mapping, in precedence order:
+#   1. Owners explicitly claimed by an identity win outright, in BOTH
+#      directions — smartwatermelon/nightowlstudiollc -> smartwatermelon,
+#      beacon-biosignals/andrewmrich -> andrewmrich. An explicitly-owned repo
+#      means the same thing no matter which directory you invoke gh from,
+#      preserving the cwd-independence established in
+#      smartwatermelon/dotfiles#135.
+#   2. Otherwise (an owner claimed by neither — a third-party org, an
+#      upstream you've been added to), consult the Beacon-context heuristic:
+#      checkout under the beacon dir, or forked from beacon-biosignals.
+#   3. Otherwise, default to smartwatermelon. This is the personal-default
+#      environment; Beacon work is the specifically-marked exception.
+#
+# Local-only (reads/writes gh's config file, no network), so it's cheap to
+# run on every invocation. Caveat: this mutates global gh state, so
+# concurrent shells working in different-owner repos at the same time can
+# race each other.
 _gh_wrapper_sync_identity() {
   local owner desired current
 
@@ -97,7 +155,14 @@ _gh_wrapper_sync_identity() {
   # as a future enhancement rather than added here to avoid scope creep.
   case "${owner,,}" in
     smartwatermelon | nightowlstudiollc) desired="smartwatermelon" ;;
-    *) desired="andrewmrich" ;;
+    beacon-biosignals | andrewmrich) desired="andrewmrich" ;;
+    *)
+      if _gh_wrapper_is_beacon_context; then
+        desired="andrewmrich"
+      else
+        desired="smartwatermelon"
+      fi
+      ;;
   esac
 
   current=$(awk '/^github\.com:/{f=1} f && /^ *user:/{print $2; exit}' "${HOME}/.config/gh/hosts.yml" 2>/dev/null | tr -d "\"'")
@@ -105,6 +170,8 @@ _gh_wrapper_sync_identity() {
   if [[ -n "${current}" && "${current}" != "${desired}" ]]; then
     if ! command gh auth switch --hostname github.com --user "${desired}" >/dev/null 2>&1; then
       echo "[gh] ERROR: failed to switch identity to '${desired}' (repo owner: '${owner}') — refusing to run as '${current}' instead" >&2
+      echo "[gh] If '${desired}' is not authenticated on this machine, run: gh auth login --hostname github.com" >&2
+      echo "[gh] Failing closed rather than acting on '${owner}' as the wrong identity." >&2
       return 1
     fi
   fi
@@ -432,6 +499,6 @@ else
   # its own body into subshells, not functions it calls. Without exporting
   # these too, gh() would break in any subshell that inherits the exported
   # gh but didn't source this file (e.g. BASH_ENV unset/overridden there).
-  export -f gh sugh _gh_wrapper_block_bypass _gh_wrapper_maybe_review _gh_wrapper_sync_identity _gh_wrapper_find_real_gh _gh_wrapper_resolve_owner _gh_wrapper_force_draft_for_off_org
-  export _gh_wrapper_review_script
+  export -f gh sugh _gh_wrapper_block_bypass _gh_wrapper_maybe_review _gh_wrapper_sync_identity _gh_wrapper_find_real_gh _gh_wrapper_resolve_owner _gh_wrapper_force_draft_for_off_org _gh_wrapper_is_beacon_context
+  export _gh_wrapper_review_script GH_WRAPPER_BEACON_DIR
 fi

--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -74,10 +74,29 @@ _gh_wrapper_resolve_owner() {
   printf '%s\n' "${owner}"
 }
 
-# Directory whose subtree marks a checkout as Beacon work. Overridable for
-# tests; defaults to the standard work checkout root. No trailing slash —
+# Directory whose subtree marks a checkout as Beacon work. Built from ${HOME}
+# so it resolves on any machine regardless of username (the work machine's
+# home is /Users/arich, this one's is /Users/andrewrich — same layout, so the
+# same default is correct for both). No trailing slash —
 # _gh_wrapper_is_beacon_context appends its own when matching.
-: "${GH_WRAPPER_BEACON_DIR:=${HOME}/Developer/beacon-biosignals}"
+#
+# Whether a missing beacon dir is worth warning about depends on whether the
+# caller set it explicitly: an explicitly-configured path that doesn't exist is
+# a misconfiguration, while an unset default that doesn't exist is just a
+# machine with no Beacon work on it (the normal personal-machine state).
+#
+# That distinction is evaluated lazily, at check time, rather than being cached
+# in a variable here. A cached flag would be exported into subshells and go
+# stale the moment anything set GH_WRAPPER_BEACON_DIR after this file was
+# sourced — the stale value then silently decides whether the warning fires.
+# _gh_wrapper_beacon_dir_is_explicit re-derives it from the live environment on
+# every call, so setting the variable at any point behaves identically.
+_gh_wrapper_beacon_dir_is_explicit() {
+  [[ "${GH_WRAPPER_BEACON_DIR:-}" != "${_GH_WRAPPER_BEACON_DIR_DEFAULT}" ]]
+}
+
+_GH_WRAPPER_BEACON_DIR_DEFAULT="${HOME}/Developer/beacon-biosignals"
+: "${GH_WRAPPER_BEACON_DIR:=${_GH_WRAPPER_BEACON_DIR_DEFAULT}}"
 
 # Second-tier signal for the "Beacon work, but not under the beacon-biosignals
 # org" case: repos created/forked during Beacon work that live under a
@@ -97,6 +116,21 @@ _gh_wrapper_is_beacon_context() {
 
   # Signal 1: checkout location. Compare canonicalized paths so symlinked
   # checkouts and trailing-slash differences don't produce false negatives.
+  # An explicitly-configured beacon dir that doesn't exist means the path
+  # signal can never fire — warn rather than silently falling through to the
+  # default identity, which is the same class of wrong-identity bug this
+  # mapping exists to prevent. Warn once per process so it stays a signal
+  # rather than noise on every unclaimed-owner invocation.
+  if [[ ! -d "${GH_WRAPPER_BEACON_DIR}" && -z "${_GH_WRAPPER_BEACON_DIR_WARNED:-}" ]] \
+    && _gh_wrapper_beacon_dir_is_explicit; then
+    # Deliberately not exported: the latch is per-process, so a subshell that
+    # inherits the exported gh() gets one warning of its own rather than
+    # inheriting a "already warned" state it never saw output for.
+    _GH_WRAPPER_BEACON_DIR_WARNED=1
+    echo "[gh] WARNING: GH_WRAPPER_BEACON_DIR is set to '${GH_WRAPPER_BEACON_DIR}' but that directory does not exist." >&2
+    echo "[gh] The Beacon checkout-path signal cannot fire; identity may fall back to the default." >&2
+  fi
+
   toplevel=$(command git rev-parse --show-toplevel 2>/dev/null)
   if [[ -n "${toplevel}" && -d "${GH_WRAPPER_BEACON_DIR}" ]]; then
     local real_top real_beacon
@@ -499,6 +533,6 @@ else
   # its own body into subshells, not functions it calls. Without exporting
   # these too, gh() would break in any subshell that inherits the exported
   # gh but didn't source this file (e.g. BASH_ENV unset/overridden there).
-  export -f gh sugh _gh_wrapper_block_bypass _gh_wrapper_maybe_review _gh_wrapper_sync_identity _gh_wrapper_find_real_gh _gh_wrapper_resolve_owner _gh_wrapper_force_draft_for_off_org _gh_wrapper_is_beacon_context
-  export _gh_wrapper_review_script GH_WRAPPER_BEACON_DIR
+  export -f gh sugh _gh_wrapper_block_bypass _gh_wrapper_maybe_review _gh_wrapper_sync_identity _gh_wrapper_find_real_gh _gh_wrapper_resolve_owner _gh_wrapper_force_draft_for_off_org _gh_wrapper_is_beacon_context _gh_wrapper_beacon_dir_is_explicit
+  export _gh_wrapper_review_script GH_WRAPPER_BEACON_DIR _GH_WRAPPER_BEACON_DIR_DEFAULT
 fi

--- a/bash/tests/test-gh-wrapper-identity.sh
+++ b/bash/tests/test-gh-wrapper-identity.sh
@@ -179,4 +179,64 @@ assert_desired_in "${beacon_repo}" "claimed owner beats beacon cwd" \
 
 cd "${HOME}/neutral-cwd"
 
+# --- Missing-beacon-dir warning ----------------------------------------------
+# An explicitly-configured beacon dir that doesn't exist must warn on stderr;
+# an unset default that doesn't exist must stay silent (the normal state on a
+# personal machine with no Beacon work).
+assert_warns() {
+  local label="$1" expect_warn="$2" explicit="$3" dir="$4"
+  local out
+  cat >"${HOME}/.config/gh/hosts.yml" <<EOF
+github.com:
+    user: smartwatermelon
+EOF
+  # A separate `bash -c` process per case, not a subshell: the warning latches
+  # via _GH_WRAPPER_BEACON_DIR_WARNED and the explicit-vs-default decision is
+  # made at source time, so each case needs a genuinely fresh shell to be a
+  # real test rather than an artifact of ordering.
+  if [[ "${explicit}" == "1" ]]; then
+    out=$(GH_WRAPPER_BEACON_DIR="${dir}" bash -c '
+      source "$1/gh-wrapper.sh"
+      _gh_wrapper_is_beacon_context 2>&1 >/dev/null || true
+    ' _ "${BASH_CONFIG_DIR}" 2>&1)
+  else
+    # Unset override, and point HOME at a pristine dir so the default path
+    # resolves to something absent.
+    # `unset` in the child rather than `env -u`, so the linter can still see
+    # the positional hand-off into `bash -c`.
+    out=$(HOME="${dir}" bash -c '
+      unset GH_WRAPPER_BEACON_DIR
+      source "$1/gh-wrapper.sh"
+      _gh_wrapper_is_beacon_context 2>&1 >/dev/null || true
+    ' _ "${BASH_CONFIG_DIR}" 2>&1)
+  fi
+  if [[ "${expect_warn}" == "1" ]]; then
+    if [[ "${out}" == *"GH_WRAPPER_BEACON_DIR is set to"* ]]; then
+      echo "PASS: ${label} (warned)"
+    else
+      echo "FAIL: ${label} — expected a warning, got: '${out}'"
+      fail=1
+    fi
+  else
+    if [[ -z "${out}" ]]; then
+      echo "PASS: ${label} (silent)"
+    else
+      echo "FAIL: ${label} — expected silence, got: '${out}'"
+      fail=1
+    fi
+  fi
+}
+
+# A directory this test creates itself. Deriving it from the ambient
+# GH_WRAPPER_BEACON_DIR would mean an empty/unset value silently collapses
+# this case into a duplicate of the unset-default case below — still passing,
+# but no longer testing explicit+present at all.
+beacon_dir_present="${HOME}/explicit-beacon-present"
+mkdir -p "${beacon_dir_present}"
+mkdir -p "${HOME}/pristine-home"
+assert_warns "explicit beacon dir missing warns" 1 1 "${HOME}/no-such-beacon-dir"
+assert_warns "explicit beacon dir present is silent" 0 1 "${beacon_dir_present}"
+# The personal-machine case: no override set, default path absent -> silent.
+assert_warns "unset default missing stays silent" 0 0 "${HOME}/pristine-home"
+
 exit "${fail}"

--- a/bash/tests/test-gh-wrapper-identity.sh
+++ b/bash/tests/test-gh-wrapper-identity.sh
@@ -3,10 +3,12 @@
 # Standalone verification for bash/gh-wrapper.sh's owner->identity mapping.
 # Run directly: bash bash/tests/test-gh-wrapper-identity.sh
 #
-# Regression coverage for smartwatermelon/dotfiles#159: owner matching in
-# _gh_wrapper_sync_identity must be case-insensitive, since GitHub owner
-# names are case-insensitive but callers (--repo flags, URLs) may supply
-# any casing.
+# Covers the three-tier mapping in _gh_wrapper_sync_identity:
+#   1. Explicitly-claimed owners (both directions), case-insensitively
+#      (regression: smartwatermelon/dotfiles#159).
+#   2. The Beacon-context heuristic for owners claimed by neither identity
+#      (checkout under the beacon dir, or forked from beacon-biosignals).
+#   3. The smartwatermelon default for everything else.
 set -euo pipefail
 
 unset CDPATH
@@ -16,6 +18,11 @@ export BASH_CONFIG_DIR="${REPO_ROOT}/bash"
 
 export HOME="/tmp/gh-wrapper-identity-test-home-$$"
 mkdir -p "${HOME}/.config/gh"
+
+# git init inside the sandboxed HOME must not pick up interactive prompts.
+export GIT_CONFIG_GLOBAL="${HOME}/.gitconfig"
+export GIT_CONFIG_SYSTEM=/dev/null
+printf '[user]\n\tname = test\n\temail = test@example.invalid\n' >"${HOME}/.gitconfig"
 trap 'rm -rf "${HOME}"' EXIT
 
 # Sourcing (not executing) the file puts it in function-definition mode,
@@ -28,7 +35,10 @@ fail=0
 # Stub `command gh auth switch` so we can observe the desired identity
 # without touching real gh state. Records the requested user to a file.
 switch_log="${HOME}/switch-log"
-command() {
+# _gh_wrapper_sync_identity reaches this only indirectly, via its own
+# `command gh auth switch ...` call — shellcheck can't see that call site from
+# here, so the stub is routed through an explicit dispatcher that it can.
+_test_command_stub() {
   if [[ "$1" == "gh" && "$2" == "auth" && "$3" == "switch" ]]; then
     # args: gh auth switch --hostname github.com --user <desired>
     printf '%s' "${*: -1}" >"${switch_log}"
@@ -36,6 +46,19 @@ command() {
   fi
   builtin command "$@"
 }
+# Install the stub as the `command` builtin override. Defined via eval so the
+# linter doesn't try to trace invocations of a name that only the code under
+# test calls.
+eval 'command() { _test_command_stub "$@"; }'
+# Prove the stub is wired up before relying on it for every assertion below:
+# a clean result from a stub that never fired would be meaningless.
+_test_command_stub gh auth switch --hostname github.com --user __selftest__
+command gh auth switch --hostname github.com --user __selftest__
+if [[ "$(cat "${switch_log}" 2>/dev/null || true)" != "__selftest__" ]]; then
+  echo "FAIL: command stub is not intercepting 'gh auth switch' — aborting"
+  exit 1
+fi
+rm -f "${switch_log}"
 
 assert_desired() {
   local label="$1" current_user="$2" repo_arg="$3" expected="$4"
@@ -71,16 +94,89 @@ EOF
   fi
 }
 
-# Baseline: lowercase owners resolve as before.
+# Same as assert_desired, but runs the check from inside a given directory so
+# the cwd-sensitive Beacon-context signals (checkout path, upstream remote)
+# come into play. Restores the previous cwd afterward.
+assert_desired_in() {
+  local dir="$1"
+  shift
+  local prev
+  prev="$(pwd)"
+  cd "${dir}"
+  assert_desired "$@"
+  cd "${prev}"
+}
+
+# Isolate the heuristic: point the beacon dir at a path that does not exist
+# unless a test deliberately creates it, and run from a directory that is not
+# a git repo, so no stray cwd remote leaks into owner resolution.
+export GH_WRAPPER_BEACON_DIR="${HOME}/Developer/beacon-biosignals"
+mkdir -p "${HOME}/neutral-cwd"
+cd "${HOME}/neutral-cwd"
+
+# --- Tier 1: explicitly-claimed owners -------------------------------------
+# These win in both directions and must never depend on cwd.
 assert_desired "lowercase smartwatermelon" "smartwatermelon" "smartwatermelon/dotfiles" "smartwatermelon"
 assert_desired "lowercase nightowlstudiollc" "andrewmrich" "nightowlstudiollc/kebab-tax" "smartwatermelon"
+assert_desired "beacon-biosignals org" "smartwatermelon" "beacon-biosignals/somerepo" "andrewmrich"
+# The git-pkgs-proxy case: a fork created during Beacon work, owned by
+# andrewmrich rather than the beacon-biosignals org.
+assert_desired "andrewmrich personal fork" "smartwatermelon" "andrewmrich/git-pkgs-proxy" "andrewmrich"
 
-# Regression: mixed/upper case owner must still resolve to smartwatermelon,
-# not fall through to the andrewmrich default (smartwatermelon/dotfiles#159).
+# Case-insensitivity across all four claimed owners
+# (regression: smartwatermelon/dotfiles#159).
 assert_desired "mixed-case SmartWatermelon" "andrewmrich" "SmartWatermelon/dotfiles" "smartwatermelon"
 assert_desired "upper-case NIGHTOWLSTUDIOLLC" "andrewmrich" "NIGHTOWLSTUDIOLLC/kebab-tax" "smartwatermelon"
+assert_desired "mixed-case Beacon-BioSignals" "smartwatermelon" "Beacon-BioSignals/somerepo" "andrewmrich"
+assert_desired "mixed-case AndrewMRich" "smartwatermelon" "AndrewMRich/git-pkgs-proxy" "andrewmrich"
 
-# An owner that is genuinely neither still falls back to andrewmrich.
-assert_desired "unrelated owner" "smartwatermelon" "beacon-biosignals/somerepo" "andrewmrich"
+# --- Tier 3: default ---------------------------------------------------------
+# An owner claimed by neither identity, with no Beacon context, defaults to
+# smartwatermelon. This is the inversion of the old behavior, which defaulted
+# unclaimed owners to andrewmrich.
+assert_desired "unclaimed owner defaults to smartwatermelon" "andrewmrich" "someotherorg/somerepo" "smartwatermelon"
+
+# --- Tier 2: Beacon-context heuristic ----------------------------------------
+# Only consulted for owners claimed by neither identity.
+
+# Signal 1: checkout lives under the beacon dir.
+beacon_repo="${GH_WRAPPER_BEACON_DIR}/thirdparty-tool"
+mkdir -p "${beacon_repo}"
+git -C "${beacon_repo}" init -q
+assert_desired_in "${beacon_repo}" "unclaimed owner, checkout under beacon dir" \
+  "smartwatermelon" "someotherorg/thirdparty-tool" "andrewmrich"
+
+# A sibling dir sharing the prefix must NOT match.
+sibling_repo="${GH_WRAPPER_BEACON_DIR}-scratch/thirdparty-tool"
+mkdir -p "${sibling_repo}"
+git -C "${sibling_repo}" init -q
+assert_desired_in "${sibling_repo}" "prefix-sibling dir does not count as beacon" \
+  "andrewmrich" "someotherorg/thirdparty-tool" "smartwatermelon"
+
+# Signal 2: forked from the beacon-biosignals org, checkout anywhere.
+fork_repo="${HOME}/elsewhere/forked-tool"
+mkdir -p "${fork_repo}"
+git -C "${fork_repo}" init -q
+git -C "${fork_repo}" remote add upstream "git@github.com:beacon-biosignals/forked-tool.git"
+assert_desired_in "${fork_repo}" "unclaimed owner, upstream is beacon-biosignals" \
+  "smartwatermelon" "someotherorg/forked-tool" "andrewmrich"
+
+# An upstream pointing somewhere else must NOT match.
+other_fork="${HOME}/elsewhere/other-fork"
+mkdir -p "${other_fork}"
+git -C "${other_fork}" init -q
+git -C "${other_fork}" remote add upstream "git@github.com:unrelated/other-fork.git"
+assert_desired_in "${other_fork}" "unrelated upstream does not count as beacon" \
+  "andrewmrich" "someotherorg/other-fork" "smartwatermelon"
+
+# --- Tier 1 beats Tier 2 -----------------------------------------------------
+# An explicitly-claimed owner is authoritative even from inside a beacon
+# checkout: the heuristic must not hijack a repo you clearly own. This keeps
+# `gh -R smartwatermelon/dotfiles ...` meaning the same thing from any
+# directory (smartwatermelon/dotfiles#135).
+assert_desired_in "${beacon_repo}" "claimed owner beats beacon cwd" \
+  "andrewmrich" "smartwatermelon/dotfiles" "smartwatermelon"
+
+cd "${HOME}/neutral-cwd"
 
 exit "${fail}"


### PR DESCRIPTION
## Problem

The `gh` wrapper's owner→identity mapping had its default inverted:

```bash
smartwatermelon | nightowlstudiollc) desired="smartwatermelon" ;;
*) desired="andrewmrich" ;;   # ← everything else
```

Any owner outside that pair fell through to `andrewmrich`, making it the effective default. This is the personal-default environment; Beacon work is the exception, not the other way round.

## Change

Three explicit tiers, in precedence order:

1. **Claimed owners win outright, in both directions.** `smartwatermelon`/`nightowlstudiollc` → `smartwatermelon`; `beacon-biosignals`/`andrewmrich` → `andrewmrich`.
2. **Unclaimed owners consult a Beacon-context heuristic** — checkout under `$GH_WRAPPER_BEACON_DIR`, or an `upstream` remote pointing at `beacon-biosignals`.
3. **Everything else defaults to `smartwatermelon`.**

The `andrewmrich/git-pkgs-proxy` case (a fork made during Beacon work under a personal owner) is handled by tier 1 on owner name alone. Tier 2 exists for Beacon-adjacent repos under *third-party* owners, where the name carries no signal.

Claimed owners deliberately beat the path heuristic, so `gh -R smartwatermelon/dotfiles ...` means the same thing from any directory — preserving the cwd-independence established in #135. Pinned by a test.

Second commit adds a stderr warning when `GH_WRAPPER_BEACON_DIR` is set explicitly but points at a missing directory: the path signal silently never fires there, which is the same class of wrong-identity bug this mapping exists to prevent. Scoped to explicit configuration only — an unset default that doesn't exist is the normal personal-machine state and must stay quiet.

Identity-switch failure now names the likely cause (desired account not authenticated) and states it is failing closed rather than acting as the wrong user.

## Notes

The default path is built from `${HOME}`, so it resolves on both the work machine (`/Users/arich/Developer/beacon-biosignals`) and the personal one despite differing usernames. No per-machine override needed.

Explicit-vs-default is derived lazily at check time rather than cached at source time — a cached flag is exported into subshells and goes stale as soon as anything sets the variable after sourcing, at which point the stale value silently decides whether the warning fires. Observed in practice during review.

## Verification

- `shellcheck -S info` clean on both files; no `# shellcheck disable` directives.
- Both suites pass: 17 identity cases, 12 draft-off-org cases.
- New tier-mapping assertions confirmed to **fail against the pre-change wrapper** (3 failures, all inverted-default cases).
- Each of the three warning cases confirmed to fail under a *distinct* mutation (warning removed / guard forced true / existence check removed), so none is vacuous.
- Identity suite verified independent of live `gh` state — it passes with the gh config pointed at a nonexistent path, so it exercises the `andrewmrich` branches on a machine where no such account exists.
- Real `gh` calls on this machine confirmed silent (no warning noise).

This machine has only `smartwatermelon` authenticated, so the `andrewmrich` paths are exercised by tests rather than live use; the auto-chooser matters on the work machine, where both identities exist.

## Follow-up

#205 (auto-filed, non-blocking) tracks the "personal collaborator on an unrelated external org" gap — such repos now route to `smartwatermelon` absent any Beacon signal.