### PR TITLE
feat(install): add --sync mode and make allup --continue skip pulls

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -749,9 +749,28 @@ _claude_update() {
 # Records the failing step to a state file so `updates --continue` can resume
 # after the user fixes the underlying problem, instead of re-running steps
 # that already succeeded (e.g. brew update/upgrade before a broken gem dir).
+# State file format: "<failed_step> <entrypoint>" where entrypoint is the
+# command the user actually ran ("updates" or "allup"). The tag lets
+# `allup --continue` tell whether the recorded failure came from its own run —
+# without it, a bare `updates` failure would make the next `allup --continue`
+# silently skip its repo pulls based on state it never wrote.
 _UPDATES_STATE_FILE="${HOME}/.local/state/updates.progress"
 
+# Echo the entrypoint recorded in the state file, or nothing if absent.
+# Legacy state files (step only, no tag) yield an empty entrypoint, which
+# callers treat as "not mine" — the conservative direction.
+_updates_state_entrypoint() {
+  [[ -f "${_UPDATES_STATE_FILE}" ]] || return 1
+  local entrypoint
+  entrypoint="$(awk 'NR==1{print $2}' "${_UPDATES_STATE_FILE}")"
+  [[ -n "${entrypoint}" ]] || return 1
+  printf '%s\n' "${entrypoint}"
+}
+
+# _UPDATES_ENTRYPOINT is set by allup so a failure is tagged with the command
+# the user ran, not the inner function. Defaults to "updates".
 updates() {
+  local entrypoint="${_UPDATES_ENTRYPOINT:-updates}"
   local -a steps=(
     _homebrew_update
     _softwareupdate
@@ -771,7 +790,8 @@ updates() {
 
     if [[ -f "${_UPDATES_STATE_FILE}" ]]; then
       local last_failed i found=false
-      last_failed=$(<"${_UPDATES_STATE_FILE}")
+      # Field 1 is the step; field 2 (if present) is the entrypoint tag.
+      last_failed="$(awk 'NR==1{print $1}' "${_UPDATES_STATE_FILE}")"
       for i in "${!steps[@]}"; do
         if [[ "${steps[i]}" == "${last_failed}" ]]; then
           start_index="${i}"
@@ -807,10 +827,10 @@ updates() {
     "${step}"
     result=$?
     if [[ "${result}" -ne 0 ]]; then
-      if ! mkdir -p "${HOME}/.local/state" || ! echo "${step}" >"${_UPDATES_STATE_FILE}"; then
-        _notif "Warning: could not save resume state; 'updates --continue' will run from the start"
+      if ! mkdir -p "${HOME}/.local/state" || ! echo "${step} ${entrypoint}" >"${_UPDATES_STATE_FILE}"; then
+        _notif "Warning: could not save resume state; '${entrypoint} --continue' will run from the start"
       fi
-      _notif "updates stopped at ${step} (exit ${result}); fix the issue and run 'updates --continue'"
+      _notif "updates stopped at ${step} (exit ${result}); fix the issue and run '${entrypoint} --continue'"
       return "${result}"
     fi
   done
@@ -823,12 +843,48 @@ updates() {
 
 # Update all local repos, repair local config symlinks, run software updates
 # pull-my-repos and pull-beacon-repos are from ~/Developer/scripts, symlinked into ~/.local/bin
+# `allup --continue` resumes after a failed step without re-running the
+# network-bound repo pulls, which are the slow part. The two install.sh
+# --sync calls always run: they are fast, idempotent, and are what installs
+# files that the pulls brought in, so skipping them could leave the deployed
+# tree stale for exactly the run that needed it.
+#
+# Pulls are skipped only when the recorded failure was tagged by allup. A
+# state file left by a bare `updates` run is not ours to resume from, so we
+# fall back to a full run rather than silently dropping the pulls.
 allup() {
-  if command -v pull-my-repos &>/dev/null; then pull-my-repos || return $?; fi
-  if command -v pull-beacon-repos &>/dev/null; then pull-beacon-repos || return $?; fi
-  "${HOME}/Developer/dotfiles/install.sh" --repair || return $?
-  "${HOME}/Developer/claude-config/install.sh" --repair || return $?
-  updates "$@"
+  local skip_pulls=false state_entrypoint
+
+  if [[ -n "${1:-}" ]]; then
+    if [[ "${1}" != "--continue" ]]; then
+      _notif "Unknown option '${1}'; only --continue is supported"
+      return 1
+    fi
+
+    state_entrypoint="$(_updates_state_entrypoint)" || state_entrypoint=""
+    case "${state_entrypoint}" in
+      allup)
+        skip_pulls=true
+        _notif "Resuming allup — skipping repo pulls (already done this cycle)"
+        ;;
+      "")
+        _notif "No allup failure recorded; running full allup including pulls"
+        ;;
+      *)
+        _notif "Recorded failure came from '${state_entrypoint}', not allup; running full allup including pulls"
+        ;;
+    esac
+  fi
+
+  if [[ "${skip_pulls}" != true ]]; then
+    if command -v pull-my-repos &>/dev/null; then pull-my-repos || return $?; fi
+    if command -v pull-beacon-repos &>/dev/null; then pull-beacon-repos || return $?; fi
+  fi
+
+  "${HOME}/Developer/dotfiles/install.sh" --sync || return $?
+  "${HOME}/Developer/claude-config/install.sh" --sync || return $?
+
+  _UPDATES_ENTRYPOINT=allup updates "$@"
 }
 # Not exported - interactive command only
 

--- a/bash/tests/test-allup-continue-state.sh
+++ b/bash/tests/test-allup-continue-state.sh
@@ -31,6 +31,15 @@ _UPDATES_STATE_FILE="${WORKDIR}/updates.progress"
 _fn_src="$(sed -n '/^_updates_state_entrypoint() {/,/^}/p' "${REPO_ROOT}/bash/functions.sh")"
 if [[ -z "${_fn_src}" ]]; then
   echo "FAIL: could not extract _updates_state_entrypoint from functions.sh" >&2
+  echo "      (the function may have been renamed, indented, or reformatted)" >&2
+  exit 1
+fi
+# Guard against a partial match that would silently under-test: the extracted
+# body must contain the awk field-2 read the whole tag scheme depends on.
+# Match on "NR==1" plus the awk call rather than the literal field
+# reference, so the check does not embed a dollar sign of its own.
+if [[ "${_fn_src}" != *"awk"* || "${_fn_src}" != *"NR==1"* ]]; then
+  echo "FAIL: extracted _updates_state_entrypoint does not read the tag field" >&2
   exit 1
 fi
 eval "${_fn_src}"
@@ -99,10 +108,12 @@ for repo in "${REPO_ROOT}" "${HOME}/Developer/claude-config"; do
   script="${repo}/install.sh"
   [[ -f "${script}" ]] || continue
   name="$(basename "${repo}")"
-  if grep -q -- '--sync) SYNC_ONLY=true ;;\|--sync)    SYNC_ONLY=true ;;' "${script}"; then
+  # Behavioral, not source-text: --sync must be accepted, and --dry-run
+  # keeps it side-effect free so the check is safe to run here.
+  if "${script}" --sync --dry-run >/dev/null 2>&1; then
     echo "  PASS: ${name}/install.sh accepts --sync"
   else
-    echo "  FAIL: ${name}/install.sh does not accept --sync"
+    echo "  FAIL: ${name}/install.sh rejected --sync"
     fail=1
   fi
   if "${script}" --repair --sync >/dev/null 2>&1; then

--- a/bash/tests/test-allup-continue-state.sh
+++ b/bash/tests/test-allup-continue-state.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#shellcheck shell=bash
+# Standalone verification of the `updates`/`allup` resume state machine.
+# Run directly: bash bash/tests/test-allup-continue-state.sh
+#
+# `updates` records the failing step so `--continue` can resume instead of
+# re-running steps that already succeeded. `allup --continue` additionally
+# skips the network-bound repo pulls. That skip is only safe if allup can
+# tell its own recorded failure from one left by a bare `updates` run —
+# otherwise a `updates` failure would silently turn the next
+# `allup --continue` into a no-pull run, quietly dropping the repo sync that
+# is the whole point of allup.
+#
+# The state file is therefore "<step> <entrypoint>". This test covers the
+# parsing of that format, including legacy untagged files written before the
+# tag existed, which must resume the correct step but must NOT be claimed by
+# allup as its own.
+set -euo pipefail
+unset CDPATH
+
+REPO_ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail=0
+
+WORKDIR="$(mktemp -d "/tmp/allup-continue-test.XXXXXX")"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# Pull the function under test out of functions.sh by name rather than
+# sourcing the whole file, which would run interactive-shell setup.
+_UPDATES_STATE_FILE="${WORKDIR}/updates.progress"
+_fn_src="$(sed -n '/^_updates_state_entrypoint() {/,/^}/p' "${REPO_ROOT}/bash/functions.sh")"
+if [[ -z "${_fn_src}" ]]; then
+  echo "FAIL: could not extract _updates_state_entrypoint from functions.sh" >&2
+  exit 1
+fi
+eval "${_fn_src}"
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "${expected}" == "${actual}" ]]; then
+    echo "  PASS: ${label}"
+  else
+    echo "  FAIL: ${label} — expected [${expected}], got [${actual}]"
+    fail=1
+  fi
+}
+
+# The step is always field 1 — this is what `updates --continue` resumes from.
+# The entrypoint is field 2, absent in legacy files; a missing tag must make
+# the helper return non-zero so callers fall back to "not mine". Both are read
+# into `got` on their own line so no command substitution masks a status.
+read_step() {
+  got="$(awk 'NR==1{print $1}' "${_UPDATES_STATE_FILE}")"
+}
+
+read_entrypoint() {
+  if ! got="$(_updates_state_entrypoint)"; then
+    got="<none>"
+  fi
+}
+
+echo "Case: no state file at all"
+rm -f "${_UPDATES_STATE_FILE}"
+read_entrypoint
+check "entrypoint unavailable" "<none>" "${got}"
+
+echo "Case: failure tagged by allup"
+echo "_gem_update allup" >"${_UPDATES_STATE_FILE}"
+read_step
+check "step parses" "_gem_update" "${got}"
+read_entrypoint
+check "entrypoint is allup" "allup" "${got}"
+
+echo "Case: failure tagged by a bare updates run"
+echo "_gem_update updates" >"${_UPDATES_STATE_FILE}"
+read_step
+check "step parses" "_gem_update" "${got}"
+read_entrypoint
+check "entrypoint is updates (allup must not claim it)" "updates" "${got}"
+
+echo "Case: legacy untagged state file (written before the tag existed)"
+echo "_gem_update" >"${_UPDATES_STATE_FILE}"
+read_step
+check "step still parses, so resume works" "_gem_update" "${got}"
+read_entrypoint
+check "entrypoint unavailable, so allup runs pulls" "<none>" "${got}"
+
+echo "Case: trailing whitespace does not create a phantom tag"
+printf '_gem_update \n' >"${_UPDATES_STATE_FILE}"
+read_step
+check "step parses" "_gem_update" "${got}"
+read_entrypoint
+check "entrypoint unavailable" "<none>" "${got}"
+
+# Guard the two install.sh contracts allup depends on: --sync must exist, and
+# it must be rejected alongside --repair rather than silently doing both.
+echo "Case: install.sh --sync/--repair contract"
+for repo in "${REPO_ROOT}" "${HOME}/Developer/claude-config"; do
+  script="${repo}/install.sh"
+  [[ -f "${script}" ]] || continue
+  name="$(basename "${repo}")"
+  if grep -q -- '--sync) SYNC_ONLY=true ;;\|--sync)    SYNC_ONLY=true ;;' "${script}"; then
+    echo "  PASS: ${name}/install.sh accepts --sync"
+  else
+    echo "  FAIL: ${name}/install.sh does not accept --sync"
+    fail=1
+  fi
+  if "${script}" --repair --sync >/dev/null 2>&1; then
+    echo "  FAIL: ${name}/install.sh allowed --repair --sync together"
+    fail=1
+  else
+    echo "  PASS: ${name}/install.sh rejects --repair --sync"
+  fi
+done
+
+echo ""
+if [[ "${fail}" -eq 0 ]]; then
+  echo "ALL CHECKS PASSED"
+else
+  echo "SOME CHECKS FAILED"
+fi
+exit "${fail}"

--- a/install.sh
+++ b/install.sh
@@ -24,17 +24,24 @@ failures=()
 # ── Parse arguments ──────────────────────────────────────
 DRY_RUN=false
 REPAIR_ONLY=false
+SYNC_ONLY=false
 for arg in "$@"; do
   case "${arg}" in
     --dry-run) DRY_RUN=true ;;
     --repair) REPAIR_ONLY=true ;;
+    --sync) SYNC_ONLY=true ;;
     *)
       _err "Unknown argument: ${arg}"
-      echo "Usage: install.sh [--dry-run] [--repair]"
+      echo "Usage: install.sh [--dry-run] [--repair] [--sync]"
       exit 1
       ;;
   esac
 done
+
+if [[ "${REPAIR_ONLY}" == true && "${SYNC_ONLY}" == true ]]; then
+  _err "--repair and --sync are mutually exclusive (--sync already repairs)"
+  exit 1
+fi
 
 if [[ "${DRY_RUN}" == true ]]; then
   _info "Dry-run mode — no changes will be made"
@@ -97,8 +104,13 @@ fi
 # ============================================================================
 # 2. HOMEBREW
 # ============================================================================
+# Skipped in --sync mode: sync reconciles the deployed tree with the repo
+# (sections 3-4) and must stay fast enough to run on every `allup`. Package
+# installation is bootstrap-only.
 
-if command -v brew &>/dev/null; then
+if ${SYNC_ONLY}; then
+  _info "Sync mode — reconciling symlinks only (skipping package installation)"
+elif command -v brew &>/dev/null; then
   _skip "Homebrew already installed"
 else
   if [[ "${DRY_RUN}" == true ]]; then
@@ -115,7 +127,9 @@ else
   fi
 fi
 
-if [[ "${DRY_RUN}" == true ]]; then
+if ${SYNC_ONLY}; then
+  :
+elif [[ "${DRY_RUN}" == true ]]; then
   if ! command -v brew &>/dev/null; then
     _dry "Would verify Homebrew is on PATH (not currently available)"
   fi
@@ -124,14 +138,16 @@ elif ! command -v brew &>/dev/null; then
   exit 1
 fi
 
-_info "Running brew bundle..."
-if [[ "${DRY_RUN}" == true ]]; then
-  _dry "Would run: brew bundle --file=${REPO_DIR}/Brewfile"
-elif brew bundle check --file="${REPO_DIR}/Brewfile" &>/dev/null; then
-  _skip "All Brewfile packages already installed"
-else
-  brew bundle --file="${REPO_DIR}/Brewfile"
-  installed+=("Brewfile packages")
+if ! ${SYNC_ONLY}; then
+  _info "Running brew bundle..."
+  if [[ "${DRY_RUN}" == true ]]; then
+    _dry "Would run: brew bundle --file=${REPO_DIR}/Brewfile"
+  elif brew bundle check --file="${REPO_DIR}/Brewfile" &>/dev/null; then
+    _skip "All Brewfile packages already installed"
+  else
+    brew bundle --file="${REPO_DIR}/Brewfile"
+    installed+=("Brewfile packages")
+  fi
 fi
 
 # ============================================================================
@@ -223,6 +239,19 @@ _is_known_config_path() {
   return 1
 }
 
+# In sync mode, run the repair pass first. _ensure_symlink would replace a
+# clobbered regular file by backing it up, but repair_config_symlinks copies
+# changed content back to the repo before restoring the link — preserving
+# edits that atomic writes landed in ~/.config. Repair must therefore win.
+if ${SYNC_ONLY} && [[ "${DRY_RUN}" != true ]]; then
+  # shellcheck source=git/hooks/lib-symlink-repair.sh
+  source "${REPO_DIR}/git/hooks/lib-symlink-repair.sh"
+  repair_config_symlinks false
+  if [[ ${#SYMLINK_REPAIRS[@]} -gt 0 ]]; then
+    _ok "Repaired ${#SYMLINK_REPAIRS[@]} clobbered symlink(s)"
+  fi
+fi
+
 _info "Creating config symlinks from repo to ~/.config..."
 
 while IFS= read -r file; do
@@ -274,6 +303,37 @@ else
   mkdir -p "${HOME}/.local/bin"
   _ensure_symlink "${HOME}/.config/bash/gh-wrapper.sh" "${HOME}/.local/bin/gh"
   _ensure_symlink "${HOME}/.config/bash/gpush-wrapper.sh" "${HOME}/.local/bin/gpush"
+fi
+
+# ── Sync-mode exit ───────────────────────────────────────
+# Sections 3-4 above reconcile the deployed tree with the repo: they create
+# symlinks for newly-pulled files (which --repair deliberately skips, since it
+# only restores links clobbered into regular files) and repair existing ones.
+# Everything below is bootstrap-only, so --sync stops here.
+#
+# Unlike the bootstrap summary, this exits non-zero on failures so that
+# `allup`'s `|| return $?` actually surfaces an unrecognized config path.
+if ${SYNC_ONLY}; then
+  echo ""
+  if [[ ${#installed[@]} -gt 0 ]]; then
+    _info "Sync created:"
+    for item in "${installed[@]}"; do
+      echo "  + ${item}"
+    done
+  fi
+  if [[ ${#failures[@]} -gt 0 ]]; then
+    _warn "Sync completed with ${#failures[@]} issue(s):"
+    for item in "${failures[@]}"; do
+      echo "  ! ${item}"
+    done
+    exit 1
+  fi
+  if [[ ${#installed[@]} -eq 0 ]]; then
+    _ok "Sync complete — deployed tree already matches repo"
+  else
+    _ok "Sync complete — ${#installed[@]} item(s) created"
+  fi
+  exit 0
 fi
 
 # ============================================================================


### PR DESCRIPTION
## Problem

`allup` called both `install.sh` scripts with `--repair`, but `--repair` only
restores symlinks that were clobbered into regular files. It explicitly skips
paths where no link exists:

```bash
# Skip if link doesn't exist (install.sh handles creation)
if [[ ! -e "${link}" ]]; then
  continue
fi
```

A file newly added to a repo has no deploy path yet, so it matched neither
condition and was never symlinked. Since `allup` is the only workflow that
pulls and then reconciles, new tools/scripts/helpers silently failed to
install until the next manual full install.

This wasn't theoretical: running `--sync` on this machine immediately
deployed three `bash/tests/*` files in dotfiles and one submodule symlink in
claude-config that had been pulled but never linked.

## Changes

**`--sync` mode** (both repos): repair pass first — `repair_config_symlinks`
copies edited deploy content back to the repo before restoring the link,
whereas `_ensure_symlink` would back it up and overwrite, so repair must win
— then the symlink creation loop installs newly-added files. Stops before
bootstrap-only work (Homebrew, `brew bundle`, and in claude-config the
destructive deploy-dir git cleanup). Exits non-zero on failures so `allup`'s
`|| return $?` actually surfaces them; the bootstrap summary exits 0 even
with failures. `--repair` and `--sync` are mutually exclusive.

**`allup --continue`**: skips the network-bound repo pulls when resuming, but
always runs both `--sync` calls. Those are fast, idempotent, and are what
install files the pulls brought in — skipping them would leave the deployed
tree stale for exactly the run that needed it.

**Entrypoint-tagged state**: the state file becomes `<step> <entrypoint>` so
`allup` can tell its own failure from one left by a bare `updates` run.
Without the tag, a `updates` failure would silently turn the next
`allup --continue` into a no-pull run. Legacy untagged files still resume the
correct step but are treated as not-allup's — the conservative direction.
Failure messages now name the command actually run.

## Verification

- New `bash/tests/test-allup-continue-state.sh`, validated against a
  known-bad implementation: with the naive "any state file is allup's" logic
  it fails with 3 failures; with the real logic it passes. Not vacuous.
- Full suite 9/9 passing.
- `shellcheck -S info` clean on all modified files, no disable directives.
- End-to-end resume simulated: `_gem_update` fails → state records
  `_gem_update allup` → `allup --continue` skips pulls, re-runs
  `_homebrew_update` for the deferred-casks catch-up, resumes at
  `_gem_update`, clears state.
- Cross-ownership case confirmed: bare `updates` failure → `allup --continue`
  correctly runs pulls instead of skipping.
- `--sync` idempotent (second run reports nothing to do) and
  `--sync --dry-run` verified to make zero filesystem changes.

Pairs with smartwatermelon/claude-config#345.

https://claude.ai/code/session_01EUkJ9CMWtqDNhQko1K1oe9