### PR TITLE
fix(tests): extract function via bash parser; drop dead Black link

### DIFF
--- a/bash/tests/test-allup-continue-state.sh
+++ b/bash/tests/test-allup-continue-state.sh
@@ -25,13 +25,30 @@ fail=0
 WORKDIR="$(mktemp -d "/tmp/allup-continue-test.XXXXXX")"
 trap 'rm -rf "${WORKDIR}"' EXIT
 
-# Pull the function under test out of functions.sh by name rather than
-# sourcing the whole file, which would run interactive-shell setup.
+# Pull the function under test out of functions.sh by name. Extraction goes
+# through bash's own parser -- source the file in a clean subshell, then let
+# `declare -f` print the parsed function -- rather than slicing the file with
+# a text pattern.
+#
+# The previous approach, `sed -n '/^_updates_state_entrypoint() {/,/^}/p'`,
+# matched `^}` at column 0 to find the end of the function. That is correct
+# only while the closing brace is unindented AND no line of the body is itself
+# a bare `}` -- a `case` arm or a nested block closing at column 0 would
+# truncate the extraction mid-function (smartwatermelon/dotfiles#208). Brace
+# counting does not fix that case either, since the stray `}` is
+# indistinguishable from a real one by counting alone. Asking bash is the only
+# approach immune to how the source happens to be formatted.
+#
+# The subshell uses --norc --noprofile so no interactive-shell setup runs, and
+# functions.sh is side-effect-free at source time (it only defines functions).
 _UPDATES_STATE_FILE="${WORKDIR}/updates.progress"
-_fn_src="$(sed -n '/^_updates_state_entrypoint() {/,/^}/p' "${REPO_ROOT}/bash/functions.sh")"
+_fn_src="$(bash --norc --noprofile -c '
+  source "$1" >/dev/null 2>&1 || exit 1
+  declare -f _updates_state_entrypoint
+' _ "${REPO_ROOT}/bash/functions.sh")"
 if [[ -z "${_fn_src}" ]]; then
   echo "FAIL: could not extract _updates_state_entrypoint from functions.sh" >&2
-  echo "      (the function may have been renamed, indented, or reformatted)" >&2
+  echo "      (the function may have been renamed or removed)" >&2
   exit 1
 fi
 # Guard against a partial match that would silently under-test: the extracted

--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -340,7 +340,6 @@ pre-commit install --install-hooks
 
 - [Pre-commit Documentation](https://pre-commit.com/)
 - [Supported Hooks](https://pre-commit.com/hooks.html)
-- [Black Formatter](https://black.readthedocs.io/)
 - [Flake8 Docs](https://flake8.pycqa.org/)
 - [ShellCheck Wiki](https://www.shellcheck.net/wiki/)
 - [yamllint Docs](https://yamllint.readthedocs.io/)


### PR DESCRIPTION
Clears the open tech-debt items in this repo. Two are fixed here; the third needs no code change and is explained below.

## #208 — fragile function extraction in the allup test

`bash/tests/test-allup-continue-state.sh` pulled `_updates_state_entrypoint` out of `functions.sh` with:

```bash
sed -n '/^_updates_state_entrypoint() {/,/^}/p'
```

That matches `^}` at column 0 to find the end of the function, which holds only while the closing brace is unindented **and** no line of the body is itself a bare `}`.

Extraction now goes through bash's own parser — source the file in a `--norc --noprofile` subshell, then print the function with `declare -f`. That is immune to indentation, nesting, and stray braces, because it round-trips through the thing that actually defines what a function is.

**Brace-counting was considered and rejected.** It fails the same case: a stray `}` is indistinguishable from a real one by counting alone. Asking bash is the only approach that genuinely fixes it.

**Verified, not assumed.** Against a valid-bash fixture whose body contains a heredoc line that is literally `}` at column 0:

| | lines extracted | retains `NR==1`? |
|---|---|---|
| old `sed` | 5 (truncated) | no — test would hard-fail |
| new `declare -f` | 12 (complete) | yes |

Sourcing is safe here: `functions.sh` only defines functions and produces no output when sourced, so the original comment's concern about running interactive-shell setup does not apply to it.

## #198 — dead Black link

Removed `[Black Formatter](https://black.readthedocs.io/)` from `pre-commit/README.md`. `black` was dropped as a global hook in #190 and now appears in `config.yaml` only inside comments explaining its removal, so the link pointed at tooling the config no longer runs. Flake8 docs are already listed, so no replacement is warranted.

## #207 — no change needed, closing as invalid

Not fixed here because there is nothing to fix. The issue body itself concludes *"No issue to act on — this is correct. Filed as a note only."*

Confirmed against the source: `allup` guards its argument before the passthrough to `updates`, so `allup --foo` is rejected with `Unknown option '--foo'; only --continue is supported` and returns 1 — it never reaches `updates "$@"`. Closing it separately with that explanation rather than bundling a no-op into this PR.

## Verification

- Full bash test suite: **9/9 passing**
- `shellcheck -S info` clean on the changed test
- Both local reviewers passed

Closes #208
Closes #198

https://claude.ai/code/session_01Jek7cuYDFwiqEqFLXoyetC
