### PR TITLE
fix(markdownlint): disable MD060 (table-column-style)

### DIFF
--- a/markdownlint-cli/.markdownlint.json
+++ b/markdownlint-cli/.markdownlint.json
@@ -8,5 +8,6 @@
   "MD033": false,
   "MD036": false,
   "MD040": false,
-  "MD046": false
+  "MD046": false,
+  "MD060": false
 }


### PR DESCRIPTION
## Problem

MD060 (`table-column-style: aligned`) is enabled implicitly by `"default": true` in the global markdownlint config, so it turned on silently across every repo that uses it. It fails commits on pre-existing table formatting the author never touched.

## Why this rule doesn't meet the bar for a global rule

**1. It is not auto-fixable — but it rewrites anyway.**

The pre-commit hook runs `markdownlint --fix`. `--fix` cannot satisfy MD060's `aligned` style. Measured against `smartwatermelon/dev-env` `docs/github-actions-security-methodology.md`:

- `--fix` rewrote one separator row (`|----------|` → `| ---------- | ---------- |`)
- and **still exited with 15 errors standing**

So the hook dirties the working tree with a change the author didn't make *and* fails the commit. Worst of both behaviors.

**2. The cost recurs; the benefit is cosmetic.**

Markdown renders identically either way. Satisfying MD060 means padding every cell to the widest row — in tables with 150+ character cells — and touching tables unrelated to whatever change is being made. That cost repeats on every future wide table.

## Precedent

This is the same failure shape as #190, already documented in `config/pre-commit/config.yaml`: a global hook that rewrites files fails repos on content they didn't touch. That comment justifies keeping *linting* global on the grounds that "flake8 reports, it does not rewrite."

MD060 rewrites. By the standard already written into that file, it doesn't qualify.

## Verification

- JSON validated (`python3 -m json.tool`)
- Confirmed effective through the live symlink path the hook actually reads (`~/.config/markdownlint-cli/.markdownlint.json`)
- Measured effect on `smartwatermelon/dev-env`: **117 MD060 errors across 6 files → 0**
- Remaining findings there (MD032/MD031/MD009) are genuinely auto-fixable and are cleaned up in smartwatermelon/dev-env#61

## Scope

Config-only. No behavior change beyond the rule itself; all other markdownlint rules stay active.

Refs: smartwatermelon/dev-env#59

https://claude.ai/code/session_01A6feWoJeof7dcTT82dSaE1
