### PR TITLE
fix(allup): call my-repos/beacon-repos after rename

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -842,7 +842,7 @@ updates() {
 # Not exported - interactive command only
 
 # Update all local repos, repair local config symlinks, run software updates
-# pull-my-repos and pull-beacon-repos are from ~/Developer/scripts, symlinked into ~/.local/bin
+# my-repos and beacon-repos are from ~/Developer/scripts, symlinked into ~/.local/bin
 # `allup --continue` resumes after a failed step without re-running the
 # network-bound repo pulls, which are the slow part. The two install.sh
 # --sync calls always run: they are fast, idempotent, and are what installs
@@ -877,8 +877,8 @@ allup() {
   fi
 
   if [[ "${skip_pulls}" != true ]]; then
-    if command -v pull-my-repos &>/dev/null; then pull-my-repos || return $?; fi
-    if command -v pull-beacon-repos &>/dev/null; then pull-beacon-repos || return $?; fi
+    if command -v my-repos &>/dev/null; then my-repos || return $?; fi
+    if command -v beacon-repos &>/dev/null; then beacon-repos || return $?; fi
   fi
 
   "${HOME}/Developer/dotfiles/install.sh" --sync || return $?


### PR DESCRIPTION
## Summary

`smartwatermelon/scripts#128` renamed `pull-my-repos.sh` -> `my-repos.sh` and
`pull-beacon-repos.sh` -> `beacon-repos.sh`. The `allup` shell function here
still called the old names.

`allup` guards each call with `command -v`:

```bash
if command -v pull-my-repos &>/dev/null; then pull-my-repos || return $?; fi
```

`command -v` returns false for a name that doesn't resolve, so a stale name
makes `allup` **silently skip** the repo pull and still exit 0 -- no error,
indistinguishable from a successful run where everything was already up to
date. This was actively happening: `~/.local/bin/pull-my-repos` was a
dangling symlink after the rename, so `allup` was skipping repo pulls while
reporting success.

This PR updates both call sites and the neighboring comment to the new
command names.

Follows smartwatermelon/scripts#128.

## Test plan

- [x] `grep -rn 'pull-my-repos\|pull-beacon-repos' bash/ README.md` returns nothing
- [x] `shellcheck -S info bash/functions.sh` clean, no new findings
- [x] `bash bash/tests/test-allup-continue-state.sh` -- all checks pass
- [x] Local pre-commit/pre-push code review agents: PASS