### PR TITLE
refactor(bash): centralize BEACON_WORKDIR in env.sh, add to CDPATH

### DIFF
--- a/bash/beacon.sh.example
+++ b/bash/beacon.sh.example
@@ -11,8 +11,8 @@
 #   fi
 #
 # ~/.config/bash/beacon.sh itself is intentionally NOT tracked by this repo —
-# only this template is. install.sh warns if it's missing while
-# ~/Developer/beacon-biosignals/ exists.
+# only this template is. install.sh warns if it's missing while the work
+# checkout root (${BEACON_WORKDIR}, defined in bash/env.sh) exists.
 
 #shellcheck shell=bash
 

--- a/bash/beacon.sh.example
+++ b/bash/beacon.sh.example
@@ -14,6 +14,12 @@
 # only this template is. install.sh warns if it's missing while the work
 # checkout root (${BEACON_WORKDIR}, defined in bash/env.sh) exists.
 
+# NOTE: if you override BEACON_WORKDIR (see bash/env.sh) to point somewhere
+# other than ~/Developer/beacon-biosignals, you must also hand-edit the
+# includeIf gitdir path in git/config — git config cannot interpolate
+# variables, so it will not follow the override and work repos would
+# silently use your personal git identity.
+
 #shellcheck shell=bash
 
 # AWS defaults (Beacon). Leave AWS_PROFILE unset when aws-vault is managing

--- a/bash/env.sh
+++ b/bash/env.sh
@@ -14,9 +14,25 @@ if [[ -f "${BASH_CONFIG_DIR}/secrets.sh" ]]; then
   source "${BASH_CONFIG_DIR}/secrets.sh"
 fi
 
+# Canonical location of the work (Beacon) checkout root. Single source of
+# truth for every consumer that needs to know where work repos live:
+# gh-wrapper.sh's identity auto-switch (GH_WRAPPER_BEACON_DIR), install.sh's
+# beacon-config warnings, and the CDPATH entry below.
+#
+# Exported so non-interactive shells and standalone scripts inherit it.
+# Consumers that can run WITHOUT this file having been sourced — install.sh
+# (which never sources env.sh) and gh-wrapper.sh in standalone-wrapper mode
+# (LaunchAgents/cron/GUI apps with a stripped environment) — must still spell
+# the fallback default themselves via ${BEACON_WORKDIR:-...}, so the value is
+# defined in one place but never depends on load order to be correct.
+#
+# Assigned with := so an explicit override from the environment wins.
+: "${BEACON_WORKDIR:=${HOME}/Developer/beacon-biosignals}"
+export BEACON_WORKDIR
+
 # Load work-specific (Beacon) env vars — untracked, machine-local.
 # See bash/beacon.sh.example for the template; install.sh warns if
-# ~/Developer/beacon-biosignals/ exists but this file doesn't.
+# ${BEACON_WORKDIR} exists but this file doesn't.
 if [[ -f "${BASH_CONFIG_DIR}/beacon.sh" ]]; then
   #shellcheck source=/dev/null
   source "${BASH_CONFIG_DIR}/beacon.sh"
@@ -169,6 +185,14 @@ fi
 # top of the script (see bash/tests/*.sh for the established pattern) or
 # scope it out per-invocation with `CDPATH='' cd -- "$dir"`.
 export CDPATH="${HOME}/Developer:${HOME}/Developer/clients:${HOME}/Developer/netlify"
+
+# Append the work (Beacon) checkout root, but only on machines where it
+# actually exists — a CDPATH entry pointing at a missing directory is dead
+# weight that bash stats on every CDPATH-resolved cd. Appended last so work
+# repos never shadow a same-named personal repo under ~/Developer.
+if [[ -d "${BEACON_WORKDIR}" ]]; then
+  export CDPATH="${CDPATH}:${BEACON_WORKDIR}"
+fi
 
 # Set correct terminal type for SSH sessions with color support
 export TERM=xterm-256color

--- a/bash/env.sh
+++ b/bash/env.sh
@@ -27,6 +27,13 @@ fi
 # defined in one place but never depends on load order to be correct.
 #
 # Assigned with := so an explicit override from the environment wins.
+#
+# IMPORTANT — overriding this does NOT fully relocate the work root. git
+# config has no variable interpolation, so the includeIf that selects the
+# work git identity (git/config, "gitdir:~/Developer/beacon-biosignals/")
+# is a literal path and will NOT follow an override. Change it there too,
+# or work repos silently keep using the personal git identity. See
+# smartwatermelon/dotfiles#213.
 : "${BEACON_WORKDIR:=${HOME}/Developer/beacon-biosignals}"
 export BEACON_WORKDIR
 

--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -95,7 +95,11 @@ _gh_wrapper_beacon_dir_is_explicit() {
   [[ "${GH_WRAPPER_BEACON_DIR:-}" != "${_GH_WRAPPER_BEACON_DIR_DEFAULT}" ]]
 }
 
-_GH_WRAPPER_BEACON_DIR_DEFAULT="${HOME}/Developer/beacon-biosignals"
+# bash/env.sh is the canonical definition of BEACON_WORKDIR, but this file
+# also runs in standalone-wrapper mode (LaunchAgents/cron/GUI apps with a
+# stripped environment) where env.sh was never sourced, so the default is
+# spelled out here as a fallback. Keep the two in sync.
+_GH_WRAPPER_BEACON_DIR_DEFAULT="${BEACON_WORKDIR:-${HOME}/Developer/beacon-biosignals}"
 : "${GH_WRAPPER_BEACON_DIR:=${_GH_WRAPPER_BEACON_DIR_DEFAULT}}"
 
 # Second-tier signal for the "Beacon work, but not under the beacon-biosignals

--- a/bash/tests/test-cdpath-echo.sh
+++ b/bash/tests/test-cdpath-echo.sh
@@ -100,4 +100,55 @@ else
   fail=1
 fi
 
+# --- Case 5: BEACON_WORKDIR is appended to CDPATH only when the directory
+# actually exists. Both branches are exercised against a synthetic HOME so
+# the result does not depend on whether this particular machine happens to
+# be the work machine — a test that only ever sees the absent case would
+# pass identically if the gate were broken open or wired shut.
+beacon_home="$(mktemp -d)/home"
+mkdir -p "${beacon_home}/Developer"
+
+# Sources env.sh under a synthetic HOME and prints the resulting CDPATH.
+# Runs in a fully scrubbed environment (env -i) so the caller's real HOME,
+# CDPATH, or BEACON_WORKDIR cannot leak in and decide the outcome.
+# The probe body lives in its own file rather than an inline -c string: it
+# must be expanded by the inner shell, not this one, and a heredoc-written
+# script says that unambiguously without relying on quoting subtleties.
+beacon_probe="${beacon_home}/probe.sh"
+cat >"${beacon_probe}" <<'PROBE'
+_get_homebrew_root() { echo /opt/homebrew; }
+#shellcheck source=/dev/null
+source "${BASH_CONFIG_DIR}/env.sh" >/dev/null 2>&1
+printf '%s' "${CDPATH:-}"
+PROBE
+
+_cdpath_under_home() {
+  env -i HOME="${beacon_home}" BASH_CONFIG_DIR="${REPO_ROOT}/bash" \
+    PATH="/usr/bin:/bin" bash --norc "${beacon_probe}"
+}
+
+beacon_dir="${beacon_home}/Developer/beacon-biosignals"
+
+# 5a: directory absent — must NOT appear in CDPATH.
+absent_cdpath="$(_cdpath_under_home)"
+if [[ ":${absent_cdpath}:" != *":${beacon_dir}:"* ]]; then
+  echo "PASS: beacon dir absent — not added to CDPATH"
+else
+  echo "FAIL: beacon dir absent but present in CDPATH: '${absent_cdpath}'"
+  fail=1
+fi
+
+# 5b: directory present — must appear, and must be LAST so work repos never
+# shadow a same-named personal repo earlier in CDPATH.
+mkdir -p "${beacon_dir}"
+present_cdpath="$(_cdpath_under_home)"
+if [[ "${present_cdpath}" == *":${beacon_dir}" ]]; then
+  echo "PASS: beacon dir present — appended as the last CDPATH entry"
+else
+  echo "FAIL: expected CDPATH to end with '${beacon_dir}', got: '${present_cdpath}'"
+  fail=1
+fi
+
+rm -rf "$(dirname "${beacon_home}")"
+
 exit "${fail}"

--- a/git/config
+++ b/git/config
@@ -50,6 +50,8 @@
 	conflictstyle = zdiff3
 [pull]
 	rebase = true
+# Literal path required: git config has no variable interpolation, so this
+# cannot reference ${BEACON_WORKDIR} (bash/env.sh). Keep in sync by hand.
 [includeIf "gitdir:~/Developer/beacon-biosignals/"]
 	path = ~/.gitconfig-beacon
 [review]

--- a/git/gitconfig-beacon.example
+++ b/git/gitconfig-beacon.example
@@ -10,8 +10,12 @@
 #       path = ~/.gitconfig-beacon
 #
 # ~/.gitconfig-beacon itself is intentionally NOT tracked by this repo —
-# only this template is. install.sh warns if it's missing while
-# ~/Developer/beacon-biosignals/ exists.
+# only this template is. install.sh warns if it's missing while the work
+# checkout root (${BEACON_WORKDIR}, defined in bash/env.sh) exists.
+#
+# NOTE: git config has no variable interpolation, so the includeIf gitdir
+# above must stay a literal path. If BEACON_WORKDIR ever changes, git/config
+# must be updated by hand to match.
 
 [user]
 	email = your-work-email@example.com

--- a/install.sh
+++ b/install.sh
@@ -449,11 +449,14 @@ else
   failures+=("git-hooksPath")
 fi
 
-# Check per-machine work-identity gitconfig — only relevant if a
-# ~/Developer/beacon-biosignals/ (or similar) workdir exists but its
-# includeIf target is missing, which would silently fall back to the
-# personal git identity.
-BEACON_WORKDIR="${HOME}/Developer/beacon-biosignals"
+# Check per-machine work-identity gitconfig — only relevant if the work
+# (Beacon) workdir exists but its includeIf target is missing, which would
+# silently fall back to the personal git identity.
+#
+# bash/env.sh is the canonical definition of BEACON_WORKDIR, but install.sh
+# never sources it (it configures the shell rather than running under it), so
+# the default is spelled out here as a fallback. Keep the two in sync.
+BEACON_WORKDIR="${BEACON_WORKDIR:-${HOME}/Developer/beacon-biosignals}"
 BEACON_GITCONFIG="${HOME}/.gitconfig-beacon"
 if [[ -d "${BEACON_WORKDIR}" ]]; then
   if [[ -f "${BEACON_GITCONFIG}" ]]; then
@@ -465,10 +468,9 @@ if [[ -d "${BEACON_WORKDIR}" ]]; then
   fi
 fi
 
-# Check per-machine work (Beacon) bash env overrides — only relevant if a
-# ~/Developer/beacon-biosignals/ workdir exists but env.sh's sourced target
-# is missing, which would silently skip work-only env vars (e.g. AWS_PROFILE)
-# with no warning.
+# Check per-machine work (Beacon) bash env overrides — only relevant if the
+# work workdir exists but env.sh's sourced target is missing, which would
+# silently skip work-only env vars (e.g. AWS_PROFILE) with no warning.
 BEACON_BASHENV="${HOME}/.config/bash/beacon.sh"
 if [[ -d "${BEACON_WORKDIR}" ]]; then
   if [[ -f "${BEACON_BASHENV}" ]]; then


### PR DESCRIPTION
## Summary

`BEACON_WORKDIR` was defined inside `install.sh`, with its value hardcoded (in full or in part) in several other places. This promotes it to `bash/env.sh` so any script can consume it, and appends it to `CDPATH` gated on the directory actually existing — so it's active on the work machine and absent everywhere else.

## Changes

- **`bash/env.sh`** — canonical definition. Uses `:=` so an explicit environment override wins, and exports it so subshells inherit it. The `CDPATH` entry is gated on `-d` and **appended last**, so work repos never shadow a same-named personal repo under `~/Developer`.
- **`install.sh`**, **`bash/gh-wrapper.sh`** — now consume the variable.
- **`git/config`** — *cannot* participate; annotated instead (see below).
- **`bash/tests/test-cdpath-echo.sh`** — new Case 5 covering both branches of the gate.

## Design note: the fallbacks are deliberate

`install.sh` and `gh-wrapper.sh` still spell the default themselves via `${BEACON_WORKDIR:-...}`. This is load-bearing, not redundant — both run where `env.sh` was never sourced:

- `install.sh` configures the shell rather than running under it, and never sources `env.sh`
- `gh-wrapper.sh` also runs in standalone-wrapper mode (LaunchAgents/cron/GUI apps with a stripped environment)

Verified on the work machine that with `BEACON_WORKDIR` unset under `env -i`, gh-wrapper still resolves the right path and still detects beacon context. Making it depend solely on `env.sh` would silently produce the **wrong git identity** — the exact bug that code exists to prevent.

## `git/config` is the one site that can't use it

git config has no variable interpolation, so the `includeIf "gitdir:..."` stays a literal path. Overriding `BEACON_WORKDIR` therefore relocates CDPATH, gh-wrapper, and install.sh's checks but *not* the git identity. Flagged at all three plausible touchpoints (`git/config`, `bash/env.sh`, `bash/beacon.sh.example`) per #213.

## Testing

The beacon dir doesn't exist on the personal machine, so a test that only saw the absent case would pass identically with the gate broken open. Case 5 exercises both branches under a synthetic `HOME` with `env -i`, and I mutation-tested it: forcing the gate always-true, and prepending instead of appending, each fail as expected.

**Validated on the work machine** (real beacon dir, different `$HOME` and username):

- `BEACON_WORKDIR` follows *that* machine's `$HOME`, is exported, lands last in `CDPATH`
- bare `cd infra` / `cd beabot` / `cd platform-datastore` all resolve; `cd dotfiles` still hits the personal repo
- a deliberate personal/work name collision resolves to **personal** (probe dirs cleaned up)
- gh-wrapper's explicit-override check correctly reports *not-explicit* for an inherited value — no spurious "configured but missing" warnings
- standalone `env -i` mode still resolves and still detects beacon context
- `install.sh`'s beacon checks report 0 failures; git `includeIf` still yields the work identity

Repo on that machine left untouched (still `main`, clean status); all scratch removed.

9/9 local suites pass; no new shellcheck findings (`env.sh` 8→8, `install.sh` 3→3, new test 0); shfmt clean.

## Note

Filed non-blocking #214 rests on a wrong premise — it claims `_get_homebrew_root` doesn't exist in `env.sh`, but it's called at `bash/env.sh:139` and `:152` and defined in `functions.sh:144`. The probe stubs it precisely because it deliberately doesn't source `functions.sh`. Suggest closing.

https://claude.ai/code/session_01LZnw3weNd76yqJZxYDQp6g
