### PR TITLE
fix(beacon): guard AWS_VAULT against unset in the beacon.sh template

### DIFF
--- a/bash/beacon.sh.example
+++ b/bash/beacon.sh.example
@@ -24,7 +24,12 @@
 
 # AWS defaults (Beacon). Leave AWS_PROFILE unset when aws-vault is managing
 # the session so it doesn't fight with AWS_VAULT-scoped credentials.
-if [[ -z "${AWS_VAULT}" ]]; then
+#
+# ${AWS_VAULT:-} rather than ${AWS_VAULT}: aws-vault only sets this inside a
+# session, so it is normally unset, and a bare reference aborts any caller
+# running under `set -u`. env.sh sources this file, so that would take the
+# whole shell config down, not just this line.
+if [[ -z "${AWS_VAULT:-}" ]]; then
   export AWS_PROFILE=arich
 fi
 export AWS_DEFAULT_REGION="us-east-2"


### PR DESCRIPTION
## The bug

`bash/beacon.sh.example` line 27:

```bash
if [[ -z "${AWS_VAULT}" ]]; then
```

Under `set -u` this aborts with `AWS_VAULT: unbound variable`. aws-vault only sets `AWS_VAULT` inside a session, so **unset is the normal state** — the guard fails in exactly the case it exists to handle.

`env.sh` sources this file, so the failure takes down the whole shell config, not just this line. Fixed with `${AWS_VAULT:-}`; the `-z` test is otherwise identical.

## Correction to what I reported earlier

I previously told @smartwatermelon the work machine's copy "lacks the `${AWS_VAULT}` guard" and "predates the template." Both halves were wrong — the two files are identical here, and **the tracked template has the same bug**. So this isn't a machine that drifted from the template; it's a template defect that the machine faithfully inherited.

That matters for scope: fixing only the machine would leave this to reappear on the next one set up from the template.

## Should `beacon.sh` be tracked? No.

Asked during review. It's deliberately gitignored (`bash/.gitignore:7`), and that's right:

- it's per-machine work configuration, and this repo is public
- its purpose is work-environment settings, so it's the natural place for things that shouldn't be published, even though today's contents (`AWS_PROFILE=arich`) are innocuous

The existing split — track the template, ignore the instance — is the correct one. The machine's untracked copy was fixed in place separately (backed up, verified, backup removed).

## Verification

Both branches under `set -u`:

| Case | Result |
|---|---|
| `AWS_VAULT` unset | `AWS_PROFILE=arich` — no abort |
| `AWS_VAULT` set | `AWS_PROFILE` unset — aws-vault path preserved |

On the work machine, after applying the same fix to its untracked copy, the originally-failing case now succeeds:

```
OK under set -u
BEACON_WORKDIR=/Users/arich/Developer/beacon-biosignals
AWS_PROFILE=arich
AWS_DEFAULT_REGION=us-east-2
```

Normal login shell behavior unchanged. shellcheck 0 findings on both files; 9/9 suites pass.

## Audit

Checked the other machine-local file `env.sh` sources (`secrets.sh`, mode 600 — tested for the failure mode without reading contents): clean, survives `set -u`. Swept `bash/` for the same pattern; the two similar hits (`env.sh:101` `BREW_SHELLENV`, `gh-wrapper.sh:459` `REAL_GH`) assign unconditionally before testing, so they're already safe. `beacon.sh` was the only instance.

https://claude.ai/code/session_01LZnw3weNd76yqJZxYDQp6g
