### PR TITLE
fix(gh-wrapper): resolve the pre-merge review script at call time

### DIFF
--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -560,6 +560,6 @@ else
   # its own body into subshells, not functions it calls. Without exporting
   # these too, gh() would break in any subshell that inherits the exported
   # gh but didn't source this file (e.g. BASH_ENV unset/overridden there).
-  export -f gh sugh _gh_wrapper_block_bypass _gh_wrapper_maybe_review _gh_wrapper_sync_identity _gh_wrapper_find_real_gh _gh_wrapper_resolve_owner _gh_wrapper_force_draft_for_off_org _gh_wrapper_is_beacon_context _gh_wrapper_beacon_dir_is_explicit
+  export -f gh sugh _gh_wrapper_block_bypass _gh_wrapper_maybe_review _gh_wrapper_review_script_path _gh_wrapper_sync_identity _gh_wrapper_find_real_gh _gh_wrapper_resolve_owner _gh_wrapper_force_draft_for_off_org _gh_wrapper_is_beacon_context _gh_wrapper_beacon_dir_is_explicit
   export _gh_wrapper_review_script GH_WRAPPER_BEACON_DIR _GH_WRAPPER_BEACON_DIR_DEFAULT
 fi

--- a/bash/gh-wrapper.sh
+++ b/bash/gh-wrapper.sh
@@ -24,7 +24,28 @@
 # calls `command gh`, which (since ~/.local/bin is early in PATH) finds this
 # same file again in standalone-wrapper mode.
 
-_gh_wrapper_review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
+# Deliberately NOT defaulted from ${HOME} here. This file is sourced once, but
+# ${HOME} at source time is not necessarily ${HOME} at call time: anything that
+# reassigns HOME afterwards -- test harnesses above all -- would still get the
+# sourcing user's path and silently run the REAL hook instead of the mock under
+# test. The variable is also exported below, so a stale value propagates into
+# every child process, including test runners started from an interactive
+# shell. Resolved per call by _gh_wrapper_review_script_path instead; set this
+# variable explicitly to override the location.
+: "${_gh_wrapper_review_script:=}"
+
+# Resolve the pre-merge review script at call time.
+#
+# An explicit non-empty ${_gh_wrapper_review_script} wins, so callers (and
+# tests) can point this anywhere. Otherwise the location is derived from the
+# CURRENT ${HOME}, which is what makes a sandboxed HOME work.
+_gh_wrapper_review_script_path() {
+  if [[ -n "${_gh_wrapper_review_script}" ]]; then
+    printf '%s\n' "${_gh_wrapper_review_script}"
+  else
+    printf '%s\n' "${HOME}/.claude/hooks/pre-merge-review.sh"
+  fi
+}
 
 # Resolves the repo owner a gh invocation is acting on: an explicit -R/--repo
 # target on the command line takes precedence (that's the repo the call
@@ -304,15 +325,17 @@ _gh_wrapper_maybe_review() {
   done
 
   if [[ "${sub}" == "pr" && "${subsub}" == "merge" ]]; then
-    if [[ -x "${_gh_wrapper_review_script}" ]]; then
-      "${_gh_wrapper_review_script}" "$@" || return 1
+    local _review_script
+    _review_script="$(_gh_wrapper_review_script_path)"
+    if [[ -x "${_review_script}" ]]; then
+      "${_review_script}" "$@" || return 1
     elif [[ "${missing_script_mode}" == "strict" ]]; then
-      echo "[gh] ERROR: pre-merge review script not found or not executable: ${_gh_wrapper_review_script}" >&2
+      echo "[gh] ERROR: pre-merge review script not found or not executable: ${_review_script}" >&2
       echo "[gh] Refusing to proceed with an unguarded merge." >&2
       return 1
     else
       echo "[gh] Warning: pre-merge review script not found or not executable" >&2
-      echo "[gh] Expected: ${_gh_wrapper_review_script}" >&2
+      echo "[gh] Expected: ${_review_script}" >&2
       echo "[gh] Proceeding without review..." >&2
     fi
   fi

--- a/bash/tests/test-gh-wrapper-review-script-path.sh
+++ b/bash/tests/test-gh-wrapper-review-script-path.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#shellcheck shell=bash
+# Standalone verification for bash/gh-wrapper.sh's pre-merge review script
+# resolution. Run directly: bash bash/tests/test-gh-wrapper-review-script-path.sh
+#
+# Regression: the location used to be computed once, at source time, from
+# ${HOME}:
+#
+#     _gh_wrapper_review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
+#
+# ${HOME} at source time is not necessarily ${HOME} at call time. Any harness
+# that sandboxes HOME after sourcing -- which is how the wrapper's own tests
+# work -- still got the sourcing user's path, so `gh pr merge` ran the REAL
+# pre-merge hook instead of the mock. The failure surfaced as an unrelated
+# "Claude CLI not found" error from the real hook, which sent the diagnosis in
+# entirely the wrong direction (claude-config#360).
+#
+# The variable is also exported, so a stale value reaches every child process,
+# including a test runner launched from an interactive shell. That is why the
+# cases below run with the variable explicitly unset unless they are testing
+# inheritance: inheriting it would mask the very thing under test.
+#
+# Each case runs in a separate `bash -c` process rather than a subshell, so the
+# HOME and override juggling cannot leak between cases -- and so shellcheck is
+# not left warning about subshell-local modifications that are the entire point.
+set -euo pipefail
+
+unset CDPATH
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="${REPO_ROOT}/bash/gh-wrapper.sh"
+
+SANDBOX="/tmp/gh-wrapper-review-path-test-$$"
+mkdir -p "${SANDBOX}/home/.claude/hooks"
+trap 'rm -rf "${SANDBOX}"' EXIT
+
+fail=0
+actual=""
+
+# Run one scenario in a pristine process and echo the resolved path.
+#   $1 - value for _gh_wrapper_review_script ("" means unset it)
+#   $2 - "before" or "after": whether HOME is set before or after sourcing
+resolve_in_clean_shell() {
+  local override="$1" when="$2" script
+
+  # The child expands SBX/WRAP itself, so they are passed through the
+  # environment rather than interpolated here. printf keeps the deferred
+  # expansion explicit instead of hiding it in a single-quoted literal.
+  local d
+  d="$(printf '%s' '$')"
+  if [[ "${when}" == "before" ]]; then
+    script="export HOME=\"${d}SBX/home\"; . \"${d}WRAP\"; _gh_wrapper_review_script_path"
+  else
+    script=". \"${d}WRAP\"; export HOME=\"${d}SBX/home\"; _gh_wrapper_review_script_path"
+  fi
+
+  if [[ -n "${override}" ]]; then
+    SBX="${SANDBOX}" WRAP="${WRAPPER}" _gh_wrapper_review_script="${override}" \
+      bash --noprofile --norc -c "${script}" 2>/dev/null
+  else
+    env -u _gh_wrapper_review_script \
+      SBX="${SANDBOX}" WRAP="${WRAPPER}" \
+      bash --noprofile --norc -c "${script}" 2>/dev/null
+  fi
+}
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "${actual}" == "${expected}" ]]; then
+    echo "PASS: ${label}"
+  else
+    echo "FAIL: ${label}"
+    echo "      expected: ${expected}"
+    echo "      actual:   ${actual}"
+    fail=1
+  fi
+}
+
+# Case 1: HOME reassigned AFTER sourcing must be honored. This is the
+# regression itself -- under the old code the answer stayed pinned to whatever
+# HOME held while the file was being read.
+actual="$(resolve_in_clean_shell "" after)" || actual="<resolution failed>"
+check "HOME reassigned after sourcing is honored" \
+  "${SANDBOX}/home/.claude/hooks/pre-merge-review.sh" "${actual}"
+
+# Case 2: with no override and HOME already set, the default tracks the active
+# HOME -- the ordinary interactive case must not have changed.
+actual="$(resolve_in_clean_shell "" before)" || actual="<resolution failed>"
+check "default resolves under the active HOME" \
+  "${SANDBOX}/home/.claude/hooks/pre-merge-review.sh" "${actual}"
+
+# Case 3: an explicit (and inherited, since it is exported into the child)
+# override wins over HOME-derived resolution, so a caller can point this
+# anywhere without staging a whole fake home directory. The variable is
+# exported by design; this documents that inheritance is a feature, and tells
+# any future test author why they must unset it to sandbox HOME.
+actual="$(resolve_in_clean_shell "${SANDBOX}/explicit-override.sh" after)" || actual="<resolution failed>"
+check "exported override beats HOME-derived path" \
+  "${SANDBOX}/explicit-override.sh" "${actual}"
+
+# Case 4: the override also wins when HOME was set before sourcing, so
+# precedence does not depend on ordering.
+actual="$(resolve_in_clean_shell "${SANDBOX}/inherited.sh" before)" || actual="<resolution failed>"
+check "override wins regardless of when HOME was set" \
+  "${SANDBOX}/inherited.sh" "${actual}"
+
+echo ""
+if ((fail == 0)); then
+  echo "All review-script-path checks passed."
+else
+  echo "Review-script-path checks FAILED."
+fi
+exit "${fail}"

--- a/bash/tests/test-gh-wrapper-review-script-path.sh
+++ b/bash/tests/test-gh-wrapper-review-script-path.sh
@@ -104,6 +104,27 @@ actual="$(resolve_in_clean_shell "${SANDBOX}/inherited.sh" before)" || actual="<
 check "override wins regardless of when HOME was set" \
   "${SANDBOX}/inherited.sh" "${actual}"
 
+# Case 5: the helper must survive export -f inheritance. _gh_wrapper_maybe_review
+# is exported and calls this function, but an exported function carries only its
+# own body into a subshell -- so a helper left out of the export list fails with
+# "command not found" in any subshell that inherited gh() without re-sourcing
+# this file. That is the documented reason the export list exists, and it is
+# exactly the kind of omission a new helper invites.
+#
+# The check reads the BASH_FUNC_* environment entry directly rather than asking
+# a child shell with `type -t`. A child started from the ambient environment
+# inherits whatever the developer's own shell already exported, so `type -t`
+# reports "function" even when the export list is wrong -- the assertion passes
+# for the wrong reason. Counting the marshalled env entry cannot be fooled that
+# way.
+marker_d="$(printf '%s' '$')"
+marker_script=". \"${marker_d}WRAP\" >/dev/null 2>&1 || true; env | grep -c \"^BASH_FUNC__gh_wrapper_review_script_path\""
+exported_marker="$(
+  env -i PATH="${PATH}" HOME="${HOME}" WRAP="${WRAPPER}" \
+    bash --noprofile --norc -c "${marker_script}" 2>/dev/null
+)" || exported_marker="0"
+check "helper is marshalled into the environment by export -f" "1" "${exported_marker}"
+
 echo ""
 if ((fail == 0)); then
   echo "All review-script-path checks passed."


### PR DESCRIPTION
## The bug

The pre-merge review script's location was computed once, while `gh-wrapper.sh` was being sourced:

```bash
_gh_wrapper_review_script="${HOME}/.claude/hooks/pre-merge-review.sh"
```

`${HOME}` at source time is not necessarily `${HOME}` at call time. Anything that reassigns `HOME` after sourcing — test harnesses above all — still got the sourcing user's path, so `gh pr merge` invoked the **real** pre-merge hook instead of the mock staged in the sandboxed HOME.

The variable is also exported, so a stale value propagates into every child process, including a test runner launched from an interactive shell. Both halves had to be true for the bug to bite, and both were.

## The fix

`_gh_wrapper_review_script_path()` resolves per call: an explicit non-empty `${_gh_wrapper_review_script}` still wins, otherwise the path derives from the **current** `${HOME}`. The variable stays exported, but now as a genuine override rather than a precomputed default — which is what it was always documented to be.

## Why this matters outside this repo

Five tests in `smartwatermelon/claude-config` had been failing with `Claude CLI not found at .../home/.local/bin/claude`. That error comes from the real pre-merge hook, which those tests never intended to run — it was reached only because this path had already resolved against the developer's real HOME.

The message pointed the diagnosis at a missing test stub (claude-config#360) when the actual cause was here. With this change, that suite goes from **5 failures to 0**, verified across three consecutive runs.

## The second commit is the codebase review catching me

`_gh_wrapper_maybe_review` is exported and calls the new helper, but I hadn't added the helper to the `export -f` list. An exported function carries only its own body into a subshell, so any shell inheriting `gh()` without re-sourcing would have failed with `command not found` on every `gh pr merge` — silently dropping the merge guard in exactly the subprocess contexts the comment above that export line already warns about.

**My first version of the regression check for this was vacuous.** It asked a child shell `type -t`, but a child started from the ambient environment inherits whatever the developer's shell already exported — so it reported `function` even with the export deliberately removed. It now counts the marshalled `BASH_FUNC_*` environment entry instead, which cannot be fooled that way.

That is the same class of defect this whole line of work is about: a check that passes for the wrong reason.

## Validation

Validated against known-bad cases in both directions:

- export line reverted → the new check **fails**
- pre-fix wrapper from `main` → **4 of 5** checks fail

The one check that passes in both is the ordinary-default case, which was never broken. A test that cannot fail proves nothing.

| Check | Result |
|---|---|
| `bash/tests/*.sh` | **60 passed, 0 failed** (was 55/0; +5 new) |
| shellcheck -S info | clean on both files, no disable directives |
| claude-config bats | 0 failures, three consecutive runs |

## Coupling

Paired with a claude-config change that unsets the inherited `_gh_wrapper_review_script` in its fixtures. **Neither alone makes those tests pass** — this fixes the resolution, that stops the stale exported value from overriding it.

Refs smartwatermelon/claude-config#360

https://claude.ai/code/session_019iYVzS5S8LvhEeype5C519
