### PR TITLE
fix(path): keep nvm's node priority when .bash_profile is re-sourced

### DIFF
--- a/bash/functions.sh
+++ b/bash/functions.sh
@@ -883,6 +883,16 @@ allup() {
 
   "${HOME}/Developer/dotfiles/install.sh" --sync || return $?
   "${HOME}/Developer/claude-config/install.sh" --sync || return $?
+  # Refresh the calling shell's environment with whatever the two --sync
+  # runs just deployed. allup is a function, not a script, so this affects
+  # the interactive shell that invoked it rather than a subshell.
+  #
+  # Deliberately not `|| return $?`: .bash_profile's exit status is just
+  # that of its last command (an nvm bash_completion probe), not a signal
+  # that the environment loaded correctly. Gating on it would risk
+  # skipping `updates` below after the pulls and installs had already run.
+  #shellcheck source=/dev/null
+  source "${HOME}/.bash_profile"
 
   _UPDATES_ENTRYPOINT=allup updates "$@"
 }

--- a/bash/path.sh
+++ b/bash/path.sh
@@ -66,7 +66,20 @@ fi
 # order, then puts that prefix in front of whatever's left of the old
 # PATH. Array order above IS the resulting PATH order — read top to
 # bottom, no need to simulate anything.
+#
+# NVM_BIN leads the list so re-sourcing .bash_profile is idempotent for
+# node. On a fresh login NVM_BIN is unset here (nvm.sh runs later, from
+# .bash_profile) so the tier is empty and nvm's own prepend puts the
+# active version in front — correct. On a RE-source into an already
+# initialized shell, nvm.sh short-circuits (NVM_DIR is already set) and
+# does NOT re-prepend, so without this tier the rebuild below would strip
+# nvm's directory from the front and leave Homebrew's node shadowing it —
+# silently swapping the active node version mid-session. NVM_BIN is
+# exported by nvm and survives the re-source, so reading it here restores
+# the same priority nvm would have set itself.
+# Regression covered by bash/tests/test-path-order.sh.
 _path_tiers=(
+  "${NVM_BIN:-}"
   "${HOME}/.local/bin"
   "${GEM_EXE_DIR}"
   "${HOME}/.bun/bin"

--- a/bash/tests/test-path-order.sh
+++ b/bash/tests/test-path-order.sh
@@ -14,6 +14,9 @@ export BASH_CONFIG_DIR="${REPO_ROOT}/bash"
 # Isolate from the real environment so the test is deterministic regardless
 # of what's actually installed on the machine running it.
 export HOME="/tmp/path-order-test-home-$$"
+# NVM_BIN is a PATH tier; clear the developer's real value so the baseline
+# assertions below don't depend on whether nvm is loaded in this shell.
+unset NVM_BIN
 mkdir -p "${HOME}/.local/bin" "${HOME}/.bun/bin"
 trap 'rm -rf "${HOME}"' EXIT
 
@@ -80,11 +83,20 @@ case ":${PATH}:" in
 esac
 
 # Run path.sh in a fresh subshell with a given starting PATH, printing the
-# resulting PATH. Used by the two regression checks below, each of which
-# needs its own starting PATH rather than the one already built up above.
+# resulting PATH. Used by the regression checks below, each of which needs
+# its own starting PATH rather than the one already built up above.
+# $2 (optional) sets NVM_BIN for the run; when omitted NVM_BIN is unset.
 _run_with_path() {
   local starting_path="$1"
   (
+    # NVM_BIN is a PATH tier, so it must be controlled by the test rather
+    # than inherited from the developer's own shell (where nvm is loaded).
+    # Callers that exercise the nvm tier set it explicitly on the call.
+    if [[ -n "${2:-}" ]]; then
+      export NVM_BIN="$2"
+    else
+      unset NVM_BIN
+    fi
     #shellcheck source=/dev/null
     source "${BASH_CONFIG_DIR}/functions.sh"
     export PATH="${starting_path}"
@@ -134,6 +146,55 @@ if [[ "${dup_count}" -eq 1 ]]; then
   echo "PASS: duplicate starting-PATH entry collapsed to one occurrence"
 else
   echo "FAIL: expected exactly 1 occurrence of '${HOME}/.local/bin', found ${dup_count}: ${dup_result}"
+  fail=1
+fi
+
+# Regression: re-sourcing .bash_profile into an already-initialized shell
+# must not change which `node` resolves. path.sh rebuilds PATH from its
+# tiers; nvm.sh runs AFTER path.sh on a fresh login and prepends the active
+# version, but on a re-source it short-circuits (NVM_DIR already set) and
+# does not re-prepend. Without an NVM_BIN tier, the rebuild drops nvm's
+# directory behind Homebrew's and the active node version silently changes
+# mid-session. Simulated here rather than driven through a real nvm install
+# so the check runs on any machine.
+nvm_bin="${HOME}/.nvm/versions/node/v20.20.2/bin"
+mkdir -p "${nvm_bin}"
+homebrew_root="$(_get_homebrew_root)"
+
+# The post-login PATH: nvm in front (as nvm.sh left it), tiers behind it.
+post_login_path="${nvm_bin}:${HOME}/.local/bin:${homebrew_root}/bin:/usr/bin:/bin"
+resourced_path="$(_run_with_path "${post_login_path}" "${nvm_bin}")"
+
+first_entry="${resourced_path%%:*}"
+if [[ "${first_entry}" == "${nvm_bin}" ]]; then
+  echo "PASS: nvm bin stays first across a re-source"
+else
+  echo "FAIL: expected nvm bin '${nvm_bin}' first after re-source, got '${first_entry}': ${resourced_path}"
+  fail=1
+fi
+
+# And it must appear exactly once — the tier must not duplicate the entry
+# that was already at the front of the incoming PATH.
+nvm_count=0
+IFS=':' read -ra nvm_parts <<<"${resourced_path}"
+for p in "${nvm_parts[@]}"; do
+  [[ "${p}" == "${nvm_bin}" ]] && ((nvm_count += 1))
+done
+if [[ "${nvm_count}" -eq 1 ]]; then
+  echo "PASS: nvm bin appears exactly once after re-source"
+else
+  echo "FAIL: expected exactly 1 occurrence of '${nvm_bin}', found ${nvm_count}: ${resourced_path}"
+  fail=1
+fi
+
+# Complement: with NVM_BIN unset (fresh login, before nvm.sh runs) the tier
+# is empty and must not leave an empty segment or claim the front slot.
+no_nvm_path="$(_run_with_path "${HOME}/.local/bin:/usr/bin:/bin")"
+assert_no_stray_colons "NVM_BIN unset" "${no_nvm_path}"
+if [[ "${no_nvm_path%%:*}" == "${HOME}/.local/bin" ]]; then
+  echo "PASS: with NVM_BIN unset, .local/bin leads as before"
+else
+  echo "FAIL: expected '${HOME}/.local/bin' first with NVM_BIN unset: ${no_nvm_path}"
   fail=1
 fi
 


### PR DESCRIPTION
## Problem

I added `source ~/.bash_profile` to `allup` so the calling shell picks up whatever the two `install.sh --sync` runs just deployed.

The source itself works — `allup` is a shell function, not a script, so it runs in the interactive shell and the changes persist. But it exposed an ordering bug in `path.sh`: **re-sourcing silently swapped the active node version.**

```
BEFORE re-source: ~/.nvm/versions/node/v20.20.2/bin/node → v20.20.2
AFTER  re-source: /opt/homebrew/bin/node                  → v26.7.0
```

Six major versions, mid-session, with no output.

## Cause

An asymmetry between fresh login and re-source:

- **Fresh login:** `main.sh` sources `path.sh`, which rebuilds `PATH` from `_path_tiers` (nvm not mentioned). `.bash_profile` *then* sources `nvm.sh`, which prepends the active version. nvm runs last, so it wins. Correct.
- **Re-source:** `path.sh` strips nvm's directory while rebuilding — but `nvm.sh` then short-circuits, because `NVM_DIR` is already set, and does **not** re-prepend. nvm's bin lands behind Homebrew's.

Worth noting this defeats the usual `hash -r` remedy for PATH-shim staleness: `PATH` itself genuinely changed, so `which node` reports the new location *correctly*. The location is what's wrong.

## Fix

Added `"${NVM_BIN:-}"` as the top tier in `path.sh`, rather than patching around it in `allup`. That keeps `path.sh` as the documented sole PATH owner and fixes every re-source, including a by-hand one — the `allup`-local version would have left the same landmine for anyone typing `source ~/.bash_profile`.

`NVM_BIN` is exported by nvm and survives a re-source, so reading it restores the priority nvm would have set itself. On a fresh login `NVM_BIN` is unset at that point, the tier is empty, and nvm's own prepend still wins — both paths converge on the same result.

Also in `allup`: quoted `${HOME}` (only unquoted expansion in the function) and dropped `|| return $?`. `.bash_profile`'s exit status is just its last command — an nvm `bash_completion` probe — not a signal the environment loaded. Gating on it risked skipping `updates` after the pulls and installs had already run.

## Tests

Three assertions in `test-path-order.sh`: nvm stays first across a re-source, appears exactly once (the tier must not duplicate an entry already at the front), and an unset `NVM_BIN` leaves ordering unchanged with no empty segment.

**Validated against the pre-fix `path.sh` first** — it fails there with the real symptom (nvm demoted behind Homebrew), so the green result means something.

## Incidental fix

While writing the test I hit a pre-existing isolation leak in it. `_run_with_path` inherited the developer's real environment, so actual `~/.nvm` paths leaked into the sandboxed `/tmp` HOME and produced a spurious failure. `NVM_BIN` is now an explicit `$2` parameter, unset otherwise. That helper was never as hermetic as it looked — any future tier read from the environment would have hit the same trap.

## Verification

- Full suite: 10/10 pass
- `shellcheck -S info`: clean on all three files (4 SC2312 in `path.sh` are pre-existing in the ruby/profiling block; count identical before and after)
- Live end-to-end: `node` stays `v20.20.2` across a re-source. Confirmed `~/.config/bash/path.sh` symlinks to the repo file, so that test hit the change and not a stale copy.

## Known limitation

This ties PATH correctness to nvm continuing to export `NVM_BIN`. If a future nvm renames or stops exporting it, the re-source case regresses silently — the new test catches it, but only when run. Low risk given nvm's stability; flagging it since the dependency is on nvm's export contract rather than anything in this repo.

https://claude.ai/code/session_01FJDTiNkB7umBUoopbdQ32n
