### PR TITLE
docs(pre-push): document the cross-repo review seam and dry-run

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -132,6 +132,8 @@ and check whether any reported findings' line ranges overlap your diff.
 
 **Why**: Ensures CI workflows use same linting rules as local development
 
+**Also runs AI review**: on non-main branches with a diff against `main`, the hook runs `~/.claude/hooks/run-review.sh` in `--mode=full-diff` and `--mode=codebase`. The codebase pass **files its non-blocking findings as GitHub issues in whatever repo you are pushing from** — this hook is global via `core.hooksPath`, so that is not limited to claude-config. To read those findings before they are filed, dry-run the same script with `gh` stubbed: see `claude-config/docs/CHECKLISTS.md` -> "Pre-Push Review Dry-Run" (also reachable as `~/.claude/docs/CHECKLISTS.md`). The reviewer and its procedure live in claude-config; if `run-review.sh` moves, the docs move with it.
+
 ### lint-shell.sh
 
 **Purpose**: Auto-fix shell scripts with shellcheck + shfmt

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -306,6 +306,12 @@ run_reviews() {
   local diff_lines
   diff_lines=$(echo "${full_diff}" | wc -l | tr -d ' ')
 
+  # Runs a whole-codebase review that FILES its non-blocking findings as GitHub
+  # issues, in whatever repo you are pushing from (this hook is global via
+  # core.hooksPath). To read those findings before they are filed, dry-run this
+  # same script with `gh` stubbed first: see claude-config/docs/CHECKLISTS.md ->
+  # "Pre-Push Review Dry-Run". That procedure is authored alongside the reviewer,
+  # not alongside this hook — if run-review.sh ever moves, the docs move with it.
   local REVIEW_SCRIPT="${HOME}/.claude/hooks/run-review.sh"
   if [[ ! -x "${REVIEW_SCRIPT}" ]]; then
     log_warning "run-review.sh not found — skipping reviews"


### PR DESCRIPTION
## What

Comment-only change. No behavior change.

- `git/hooks/pre-push`: added a comment above the `REVIEW_SCRIPT` assignment explaining that `run-review.sh` runs a whole-codebase review that **files its non-blocking findings as GitHub issues in whatever repo you are pushing from** (the hook is global via `core.hooksPath`), and pointing at the dry-run procedure in `claude-config/docs/CHECKLISTS.md` under "Pre-Push Review Dry-Run".
- `git/README.md`: the `### pre-push` section previously documented only the config-hardlink sync, not the AI review step at all. Added an "Also runs AI review" note covering the same cross-repo seam and the dry-run pointer.

Both notes state the coupling direction explicitly: the procedure is authored alongside the reviewer, so if `run-review.sh` ever moves, the docs move with it — not with the hook.

## Verification

- `shellcheck -S info git/hooks/pre-push` — clean
- Full test suite (`bash/tests/*.sh`) — 10/10 pass
- code-reviewer + adversarial-reviewer — both PASS

Closes #223

https://claude.ai/code/session_01QDLrx1fP7kab37VkVQALY2