### PR TITLE
feat(post-checkout): record .claude/ tracking policy on fresh clones

### DIFF
--- a/bash/tests/test-post-checkout-gitignore.sh
+++ b/bash/tests/test-post-checkout-gitignore.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Standalone verification that git/template/hooks/post-checkout records a
+# tracking policy for the .claude/ scaffold it creates, only in repos that are
+# genuinely fresh, and never at the cost of failing the git command that
+# invoked it.
+# Run directly: bash bash/tests/test-post-checkout-gitignore.sh
+#
+# Regression coverage for smartwatermelon/dotfiles#220: the hook used to copy
+# .claude/ into every fresh clone/init while saying nothing about whether the
+# result should be tracked, producing an arbitrary tracked/ignored split across
+# repos. It now records `.claude/` as ignored, subject to four guards:
+#
+#   0. fresh clone/init only  -- post-checkout also fires with $3 == 1 on
+#      `git checkout -b` and on `git worktree add`. prev_head ($1) is the null SHA
+#      on clone/init but a real commit on a branch switch; a linked worktree
+#      also reports the null SHA, so it is excluded by comparing --git-dir
+#      against --git-common-dir.
+#   1. already tracked        -- skip (gitignore does not affect tracked files)
+#   2. already ignored        -- skip, checking .gitignore AND
+#      .git/info/exclude via `git check-ignore`
+#   3. tracked .gitignore     -- write to .git/info/exclude instead, so a
+#      fresh clone is not left holding a modified tracked file
+#
+# Because this hook is global via core.hooksPath and fires on every clone,
+# init and branch switch on this machine, the cases below drive it through
+# REAL git commands (clone, checkout -b, worktree add) wherever the behavior
+# under test is a property of how git invokes the hook, not just of the
+# hook's internal logic. Everything runs in a disposable temp tree under a
+# trap and never touches a real repository.
+set -euo pipefail
+
+unset CDPATH
+
+REPO_ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK_SRC="${REPO_ROOT}/git/template/hooks/post-checkout"
+
+WORKDIR="/tmp/post-checkout-gitignore-test-$$"
+mkdir -p "${WORKDIR}"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+export GIT_CEILING_DIRECTORIES="${WORKDIR}"
+
+# Inherited git environment variables would silently redirect every git call
+# below at the ambient repo instead of the scratch fixtures -- GIT_INDEX_FILE
+# in particular makes `git ls-files` report the caller's staged paths, which
+# fires the already-tracked guard in repos that track nothing.
+unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE GIT_OBJECT_DIRECTORY
+unset GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM
+
+# Minimal stand-in for git/template/.claude-template, so the test never
+# depends on (or writes through symlinks into) the deployed template.
+TEMPLATE_DIR="${WORKDIR}/template"
+mkdir -p "${TEMPLATE_DIR}/.claude-template/hooks/extensions"
+echo "# fixture" >"${TEMPLATE_DIR}/.claude-template/README.md"
+
+# A core.hooksPath dir holding the hook under test, so real git commands
+# resolve it the way they do on this machine.
+HOOKS_DIR="${WORKDIR}/hookspath"
+mkdir -p "${HOOKS_DIR}"
+cp "${HOOK_SRC}" "${HOOKS_DIR}/post-checkout"
+chmod +x "${HOOKS_DIR}/post-checkout"
+
+# Applied to every real git command that should resolve the hook under test.
+GIT_OPTS=(-c "core.hooksPath=${HOOKS_DIR}" -c "init.templateDir=${TEMPLATE_DIR}")
+
+fail=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "${expected}" == "${actual}" ]]; then
+    echo "PASS: ${desc}"
+  else
+    echo "FAIL: ${desc} -- expected '${expected}', got '${actual}'"
+    fail=1
+  fi
+}
+
+# Build an origin repo with one commit. $2, if given, is committed as the
+# repo's .gitignore (making it a *tracked* .gitignore).
+make_origin() {
+  local dir="${WORKDIR}/$1" ignore_line="${2:-}"
+  git -c init.templateDir="" init -q -b main "${dir}"
+  git -C "${dir}" config user.email t@t.com
+  git -C "${dir}" config user.name t
+  if [[ -n "${ignore_line}" ]]; then
+    printf '%s\n' "${ignore_line}" >"${dir}/.gitignore"
+  fi
+  echo hi >"${dir}/a.txt"
+  git -C "${dir}" add -A
+  git -C "${dir}" -c core.hooksPath="" commit -q -m "chore: fixture"
+  printf '%s' "${dir}"
+}
+
+# Count `.claude/` entries in a file (0 when the file is absent).
+count_entries() {
+  local file="$1" n=0
+  [[ -f "${file}" ]] || {
+    printf '0'
+    return 0
+  }
+  n=$(grep -c '^\.claude/$' "${file}") || n=0
+  printf '%s' "${n}"
+}
+
+exists() {
+  local flag="$1" path="$2"
+  if [[ "${flag}" == "-d" && -d "${path}" ]]; then
+    printf 'yes'
+  elif [[ "${flag}" == "-f" && -f "${path}" ]]; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+}
+
+# Invoke the hook directly with git's initial-checkout arguments. Captures and
+# RETURNS the exit code: a post-checkout that exits non-zero makes `git clone`
+# itself fail after the files have landed, so every case asserts on this.
+run_hook() {
+  local dir="$1" prev="${2:-0000000000000000000000000000000000000000}"
+  local rc=0
+  (
+    cd "${dir}"
+    GIT_CONFIG_COUNT=1 \
+      GIT_CONFIG_KEY_0="core.hooksPath" \
+      GIT_CONFIG_VALUE_0="" \
+      "${HOOKS_DIR}/post-checkout" \
+      "${prev}" \
+      1111111111111111111111111111111111111111 \
+      1 >/dev/null 2>&1
+  ) || rc=$?
+  printf '%s' "${rc}"
+}
+
+actual=""
+rc=""
+
+# --- Case A: real `git clone`, origin without a tracked .gitignore ---------
+# The baseline case the issue is about: a fresh clone records the policy.
+origin_a="$(make_origin origin-a)"
+clone_a="${WORKDIR}/clone-a"
+rc=0
+git "${GIT_OPTS[@]}" clone -q "${origin_a}" "${clone_a}" >/dev/null 2>&1 || rc=$?
+assert_eq "real clone: git clone itself succeeds" "0" "${rc}"
+actual="$(exists -d "${clone_a}/.claude")"
+assert_eq "real clone: .claude/ scaffolded" "yes" "${actual}"
+actual="$(count_entries "${clone_a}/.gitignore")"
+assert_eq "real clone: .gitignore gains exactly one .claude/ entry" "1" "${actual}"
+
+# --- Case B: real `git clone`, origin WITH a tracked .gitignore -----------
+# Rewriting a committed .gitignore would leave every clone holding a modified
+# tracked file. The entry goes to .git/info/exclude instead and the clone
+# stays clean, while .claude/ still ends up ignored.
+origin_b="$(make_origin origin-b "node_modules/")"
+clone_b="${WORKDIR}/clone-b"
+rc=0
+git "${GIT_OPTS[@]}" clone -q "${origin_b}" "${clone_b}" >/dev/null 2>&1 || rc=$?
+assert_eq "tracked .gitignore: git clone itself succeeds" "0" "${rc}"
+actual="$(count_entries "${clone_b}/.gitignore")"
+assert_eq "tracked .gitignore: committed file left untouched" "0" "${actual}"
+actual="$(count_entries "${clone_b}/.git/info/exclude")"
+assert_eq "tracked .gitignore: entry lands in .git/info/exclude" "1" "${actual}"
+actual="$(git -C "${clone_b}" status --porcelain)"
+assert_eq "tracked .gitignore: clone left with a clean tree" "" "${actual}"
+rc=0
+git -C "${clone_b}" check-ignore -q ".claude/" || rc=$?
+assert_eq "tracked .gitignore: .claude/ is genuinely ignored" "0" "${rc}"
+
+# --- Case C: `git checkout -b` in an established repo ---------------------
+# Guard 0a. prev_head is a real commit here, so the hook must not write --
+# this repo already had its chance to decide.
+origin_c="$(make_origin origin-c "node_modules/")"
+rc=0
+git -C "${origin_c}" "${GIT_OPTS[@]}" checkout -q -b feature >/dev/null 2>&1 || rc=$?
+assert_eq "branch switch: git checkout itself succeeds" "0" "${rc}"
+actual="$(count_entries "${origin_c}/.gitignore")"
+assert_eq "branch switch: established repo's .gitignore untouched" "0" "${actual}"
+actual="$(git -C "${origin_c}" status --porcelain -- .gitignore)"
+assert_eq "branch switch: .gitignore not left modified" "" "${actual}"
+actual="$(count_entries "${origin_c}/.git/info/exclude")"
+assert_eq "branch switch: nothing written to .git/info/exclude either" "0" "${actual}"
+
+# --- Case D: a new linked worktree of an established repo -----------------
+# Guard 0b. A linked worktree reports the null SHA just like a clone, and its
+# .claude/ is absent because the parent repo ignores it -- so without the
+# git-dir/common-dir comparison the hook would rewrite a real repo's tracked,
+# committed .gitignore.
+worktree_parent="${clone_b}"
+mkdir -p "${worktree_parent}/.claude/worktrees"
+rc=0
+git -C "${worktree_parent}" "${GIT_OPTS[@]}" \
+  worktree add -q ".claude/worktrees/wt1" -b wt1 >/dev/null 2>&1 || rc=$?
+assert_eq "linked worktree: the git command itself succeeds" "0" "${rc}"
+wt1="${worktree_parent}/.claude/worktrees/wt1"
+actual="$(count_entries "${wt1}/.gitignore")"
+assert_eq "linked worktree: parent repo's tracked .gitignore untouched" "0" "${actual}"
+actual="$(git -C "${wt1}" status --porcelain -- .gitignore)"
+assert_eq "linked worktree: .gitignore not left modified" "" "${actual}"
+# The worktree's excludes live in the parent repo's common git dir; Case B
+# already put exactly one entry there, so a write here would make it two.
+actual="$(count_entries "${worktree_parent}/.git/info/exclude")"
+assert_eq "linked worktree: parent's .git/info/exclude not appended to" "1" "${actual}"
+
+# --- Case D2: worktree of an established repo with NO .claude/ policy ------
+# Guard 0b in isolation. In Case D the parent (a clone) already carried an
+# info/exclude entry, so guard 2 would have caught the worktree anyway. The
+# case guard 0b uniquely covers is an established repo that predates this
+# hook and has no .claude/ policy at all -- the majority of the 27 surveyed
+# repos. Without guard 0b, adding a worktree there silently writes an ignore
+# entry into a repo that never asked for one.
+origin_d2="$(make_origin origin-d2 "node_modules/")"
+mkdir -p "${origin_d2}/.claude/worktrees"
+rc=0
+git -C "${origin_d2}" "${GIT_OPTS[@]}" \
+  worktree add -q ".claude/worktrees/wt2" -b wt2 >/dev/null 2>&1 || rc=$?
+assert_eq "worktree of established repo: the git command succeeds" "0" "${rc}"
+actual="$(count_entries "${origin_d2}/.git/info/exclude")"
+assert_eq "worktree of established repo: nothing written to info/exclude" "0" "${actual}"
+actual="$(count_entries "${origin_d2}/.gitignore")"
+assert_eq "worktree of established repo: tracked .gitignore untouched" "0" "${actual}"
+
+# --- Case E: already-tracked .claude/ is left alone ------------------------
+# Guard 1. gitignore has no effect on tracked files, so writing the line here
+# would make the repo claim a policy it isn't following.
+repo_e="${WORKDIR}/repo-e"
+git -c init.templateDir="" init -q -b main "${repo_e}"
+git -C "${repo_e}" config init.templateDir "${TEMPLATE_DIR}"
+git -C "${repo_e}" config user.email t@t.com
+git -C "${repo_e}" config user.name t
+mkdir -p "${repo_e}/.claude"
+echo tracked >"${repo_e}/.claude/settings.json"
+git -C "${repo_e}" add .claude/settings.json
+# The hook no-ops when .claude/ exists, so drop the working copy while leaving
+# the index entry: the guard must key on the index, not on the directory.
+rm -rf "${repo_e:?}/.claude"
+rc="$(run_hook "${repo_e}")"
+assert_eq "already tracked: hook exits 0" "0" "${rc}"
+actual="$(count_entries "${repo_e}/.gitignore")"
+assert_eq "already tracked: no .claude/ entry written" "0" "${actual}"
+actual="$(exists -f "${repo_e}/.gitignore")"
+assert_eq "already tracked: no .gitignore created" "no" "${actual}"
+
+# --- Case F: already ignored via .gitignore --------------------------------
+# Guard 2, .gitignore arm.
+repo_f="${WORKDIR}/repo-f"
+git -c init.templateDir="" init -q -b main "${repo_f}"
+git -C "${repo_f}" config init.templateDir "${TEMPLATE_DIR}"
+printf '.claude/\n' >"${repo_f}/.gitignore"
+rc="$(run_hook "${repo_f}")"
+assert_eq "already ignored via .gitignore: hook exits 0" "0" "${rc}"
+actual="$(count_entries "${repo_f}/.gitignore")"
+assert_eq "already ignored via .gitignore: entry not duplicated" "1" "${actual}"
+
+# --- Case G: already ignored via .git/info/exclude -------------------------
+# Guard 2, info/exclude arm. The live case (smartwatermelon/homebrew-tap): a
+# repo that deliberately kept the decision local. Appending to .gitignore here
+# would promote a private hold to a shared committed policy, and grepping
+# .gitignore alone would miss it and do exactly that.
+repo_g="${WORKDIR}/repo-g"
+git -c init.templateDir="" init -q -b main "${repo_g}"
+git -C "${repo_g}" config init.templateDir "${TEMPLATE_DIR}"
+mkdir -p "${repo_g}/.git/info"
+printf '.claude/\n' >>"${repo_g}/.git/info/exclude"
+rc="$(run_hook "${repo_g}")"
+assert_eq "already ignored via info/exclude: hook exits 0" "0" "${rc}"
+actual="$(exists -f "${repo_g}/.gitignore")"
+assert_eq "already ignored via info/exclude: no .gitignore created" "no" "${actual}"
+
+# --- Case H: running twice does not duplicate the entry --------------------
+repo_h="${WORKDIR}/repo-h"
+git -c init.templateDir="" init -q -b main "${repo_h}"
+git -C "${repo_h}" config init.templateDir "${TEMPLATE_DIR}"
+run_hook "${repo_h}" >/dev/null
+rm -rf "${repo_h:?}/.claude"
+rc="$(run_hook "${repo_h}")"
+assert_eq "second run: hook exits 0" "0" "${rc}"
+actual="$(count_entries "${repo_h}/.gitignore")"
+assert_eq "second run: still exactly one .claude/ entry" "1" "${actual}"
+
+# --- Case I: existing .gitignore with no trailing newline ------------------
+# A blind append would splice .claude/ onto the end of the last entry,
+# silently changing an unrelated pattern.
+repo_i="${WORKDIR}/repo-i"
+git -c init.templateDir="" init -q -b main "${repo_i}"
+git -C "${repo_i}" config init.templateDir "${TEMPLATE_DIR}"
+printf 'node_modules/' >"${repo_i}/.gitignore"
+rc="$(run_hook "${repo_i}")"
+assert_eq "no trailing newline: hook exits 0" "0" "${rc}"
+actual="$(count_entries "${repo_i}/.gitignore")"
+assert_eq "no trailing newline: .claude/ lands on its own line" "1" "${actual}"
+actual=0
+actual=$(grep -c '^node_modules/$' "${repo_i}/.gitignore") || actual=0
+assert_eq "no trailing newline: existing entry not corrupted" "1" "${actual}"
+
+# --- Case J: unwritable .gitignore does not fail the hook ------------------
+# A non-zero post-checkout makes `git clone` exit 1 *after* the files have
+# landed, so an un-writable target must be skipped, not fatal.
+repo_j="${WORKDIR}/repo-j"
+git -c init.templateDir="" init -q -b main "${repo_j}"
+git -C "${repo_j}" config init.templateDir "${TEMPLATE_DIR}"
+printf 'node_modules/\n' >"${repo_j}/.gitignore"
+chmod 0444 "${repo_j}/.gitignore"
+rc="$(run_hook "${repo_j}")"
+chmod 0644 "${repo_j}/.gitignore"
+assert_eq "read-only .gitignore: hook still exits 0" "0" "${rc}"
+actual="$(count_entries "${repo_j}/.gitignore")"
+assert_eq "read-only .gitignore: left untouched" "0" "${actual}"
+
+# --- Case K: dangling .gitignore symlink does not fail the hook ------------
+# -e follows symlinks, so a dangling link reports neither -e nor -w; without
+# an explicit -L check the append is attempted and aborts under `set -e`.
+repo_k="${WORKDIR}/repo-k"
+git -c init.templateDir="" init -q -b main "${repo_k}"
+git -C "${repo_k}" config init.templateDir "${TEMPLATE_DIR}"
+ln -s "${WORKDIR}/definitely-not-here" "${repo_k}/.gitignore"
+rc="$(run_hook "${repo_k}")"
+assert_eq "dangling .gitignore symlink: hook still exits 0" "0" "${rc}"
+actual="$(exists -f "${repo_k}/.gitignore")"
+assert_eq "dangling .gitignore symlink: not materialized" "no" "${actual}"
+
+# --- Case L: an unwritable target must not fail the git command ------------
+# Exercises the `|| return 0` on the writes themselves: with a read-only
+# .git/info/exclude and a tracked .gitignore, there is nowhere to write, and
+# the hook must still exit 0 rather than abort under `set -e` and take the
+# whole `git clone` down with it.
+origin_l="$(make_origin origin-l "node_modules/")"
+repo_l="${WORKDIR}/repo-l"
+git -c init.templateDir="" -c core.hooksPath="" clone -q "${origin_l}" "${repo_l}" >/dev/null 2>&1
+git -C "${repo_l}" config init.templateDir "${TEMPLATE_DIR}"
+rm -rf "${repo_l:?}/.claude"
+mkdir -p "${repo_l}/.git/info"
+: >"${repo_l}/.git/info/exclude"
+chmod 0444 "${repo_l}/.git/info/exclude"
+rc="$(run_hook "${repo_l}")"
+chmod 0644 "${repo_l}/.git/info/exclude"
+assert_eq "unwritable info/exclude: hook still exits 0" "0" "${rc}"
+actual="$(count_entries "${repo_l}/.git/info/exclude")"
+assert_eq "unwritable info/exclude: nothing written" "0" "${actual}"
+actual="$(count_entries "${repo_l}/.gitignore")"
+assert_eq "unwritable info/exclude: tracked .gitignore untouched" "0" "${actual}"
+
+if [[ "${fail}" -eq 1 ]]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "All post-checkout gitignore tests passed"

--- a/git/README.md
+++ b/git/README.md
@@ -20,7 +20,12 @@ git/
 │   ├── lint-shell.sh   # Shell script linting with auto-fix
 │   ├── pre-commit      # Pre-commit hook (delegates to repo or global)
 │   ├── commit-msg      # Commit-msg hook (conventional-commits validation + AI review)
+│   ├── post-checkout   # Post-checkout hook (delegates to the template hook)
 │   └── pre-push        # Pre-push hook (syncs configs to GitHub repos)
+├── template/           # init.templateDir contents
+│   ├── .claude-template/  # .claude/ scaffold copied into new repos
+│   └── hooks/
+│       └── post-checkout  # Canonical .claude/ scaffolder + gitignore policy
 └── README.md           # This file
 ```
 
@@ -133,6 +138,48 @@ and check whether any reported findings' line ranges overlap your diff.
 **Why**: Ensures CI workflows use same linting rules as local development
 
 **Also runs AI review**: on non-main branches with a diff against `main`, the hook runs `~/.claude/hooks/run-review.sh` in `--mode=full-diff` and `--mode=codebase`. The codebase pass **files its non-blocking findings as GitHub issues in whatever repo you are pushing from** — this hook is global via `core.hooksPath`, so that is not limited to claude-config. To read those findings before they are filed, dry-run the same script with `gh` stubbed: see `claude-config/docs/CHECKLISTS.md` -> "Pre-Push Review Dry-Run" (also reachable as `~/.claude/docs/CHECKLISTS.md`). The reviewer and its procedure live in claude-config; if `run-review.sh` moves, the docs move with it.
+
+### post-checkout
+
+**Purpose**: Scaffolds `.claude/` infrastructure into newly created repos, and records a tracking policy for what it created
+**Files**: `hooks/post-checkout` (thin delegate resolved via `core.hooksPath`) -> `template/hooks/post-checkout` (the canonical hook)
+
+**Behavior**:
+
+1. Exits unless git reports a branch checkout (`$3 == 1`)
+2. Exits if `.claude/` already exists
+3. Copies `template/.claude-template/` to `.claude/`, creates `hooks/extensions/`, disables the example extension
+4. Records `.claude/` as ignored, subject to the guards below
+
+**Why ignore by default**: the scaffold is generated content the hook can reproduce on demand, and the other common inhabitant of `.claude/` (`settings.local.json`) is machine-local by Claude Code's own `.local.` naming convention. Without a recorded decision, each repo's `.claude/` ended up tracked or ignored by whoever touched it next — a survey of 27 repos found 14 tracking it, 12 ignoring it, and 1 doing neither, all holding byte-identical content (smartwatermelon/dotfiles#220).
+
+**Where the entry goes**:
+
+- **`.gitignore`** normally — the shared, committed policy.
+- **`.git/info/exclude`** when `.gitignore` is already tracked. Rewriting a committed `.gitignore` would leave every fresh clone holding a *modified tracked file*, which breaks `git diff --exit-code` checks, `git describe --dirty`, and any `git commit -a` that would sweep the line into an unrelated commit. Writing to `info/exclude` has the same effect on `.claude/`, stays local to that clone, and leaves the tree clean.
+
+**Guards — the hook writes only into a genuinely fresh repo that hasn't already decided**:
+
+- **Fresh clone/init only.** `post-checkout` also fires with `$3 == 1` on `git checkout -b` and on `git worktree add`. Two signals separate those from a real clone or init:
+  - `prev_head` (`$1`) is the null SHA on clone and init, but the commit you moved away from on a branch switch — that rules out `git checkout -b`.
+  - A *linked worktree* also reports the null SHA, so `prev_head` alone is not enough. A linked worktree's `--git-dir` (`<repo>/.git/worktrees/<name>`) differs from its `--git-common-dir`, whereas a main work tree's two agree. This matters because a new worktree's `.claude/` is absent — the parent repo ignores it, so it never materializes — which means the "does `.claude/` exist" no-op does *not* fire, and without this check the hook would write into an established repo.
+- **Already tracked.** If any path under `.claude/` is in the index, the hook writes nothing. `.gitignore` has no effect on already-tracked files, so adding the line would leave the repo claiming a policy it isn't following.
+- **Already ignored.** Checked with `git check-ignore -q .claude/`, which consults `.gitignore`, `.git/info/exclude`, and any global `core.excludesFile` in one call. Grepping `.gitignore` alone would miss the `info/exclude` case and promote someone's deliberate private hold to a shared committed policy.
+- **Non-regular target.** A `.gitignore` that is a symlink or directory is skipped. `-e` follows symlinks, so a dangling link reports neither `-e` nor `-w`; the hook tests `-L` explicitly rather than walking into a failing write.
+
+**Failure tolerance**: every write is `|| return 0`, and the whole step is called with `|| true`. A `post-checkout` that exits non-zero makes `git clone` itself exit 1 *after* the files have already landed — a far worse outcome than skipping the ignore line. Because this hook is global via `core.hooksPath` and fires on every clone, init, and branch switch on this machine, it does nothing rather than write whenever the state is ambiguous.
+
+**Sharing part of `.claude/`**: negate the specific paths.
+
+```gitignore
+.claude/
+!.claude/skills/
+!.claude/pre-launch.sh
+```
+
+**Diagnosing an existing repo**: `git check-ignore -v .claude/` prints the source file and line, which distinguishes a `.gitignore` entry from a `.git/info/exclude` one.
+
+**Tests**: `bash/tests/test-post-checkout-gitignore.sh` drives real `git clone`, `git checkout -b`, and worktree creation through the hook and asserts each guard plus the exit code; `bash/tests/test-post-checkout-hookspath.sh` covers delegate resolution via `core.hooksPath`.
 
 ### lint-shell.sh
 

--- a/git/template/.claude-template/README.md
+++ b/git/template/.claude-template/README.md
@@ -21,6 +21,26 @@ The `.claude/` directory provides project-specific configuration and extensions 
         └── example.sh.disabled  # Example extension (disabled by default)
 ```
 
+## Is this directory tracked?
+
+By default, **no**. The hook that created this directory also recorded `.claude/` as ignored — normally in the repo's `.gitignore`, or in `.git/info/exclude` when `.gitignore` is already tracked (so your clone isn't left holding a modified committed file).
+
+The scaffold is generated content the hook can reproduce on demand, and `settings.local.json` — the other common inhabitant — is machine-local by Claude Code's own `.local.` naming convention.
+
+The hook only writes into a genuinely fresh clone or init that hasn't already decided. If `.claude/` was already tracked, or already ignored by any mechanism, it leaves that decision alone.
+
+If part of this directory *is* meant to be shared with the team — a `skills/` directory, a `pre-launch.sh`, a secrets template — negate those specific paths and commit them:
+
+```gitignore
+.claude/
+!.claude/skills/
+!.claude/pre-launch.sh
+```
+
+To track the whole directory instead, remove the `.claude/` line and `git add .claude`.
+
+Run `git check-ignore -v .claude/` to see which file and line is doing the ignoring.
+
 ## Quick Start
 
 ### Option 1: No Additional Configuration Needed

--- a/git/template/hooks/post-checkout
+++ b/git/template/hooks/post-checkout
@@ -12,7 +12,7 @@
 set -euo pipefail
 
 # Hook parameters from git
-_prev_head=$1 # Unused - we only care about branch_checkout
+_prev_head=$1 # Null SHA on clone/init; a real commit on a branch switch
 _new_head=$2  # Unused - we only care about branch_checkout
 branch_checkout=$3
 
@@ -60,6 +60,126 @@ mkdir -p ".claude/hooks/extensions"
 if [[ -f ".claude/hooks/extensions/example.sh.disabled" ]]; then
   chmod -x ".claude/hooks/extensions/example.sh.disabled"
 fi
+
+# Record the tracking policy for the scaffold we just created.
+#
+# The scaffold is generated content this hook can reproduce on demand, and
+# the other common inhabitant of .claude/ (settings.local.json) is
+# machine-local by Claude Code's own naming convention -- so "ignored" is the
+# right default. Without this, each repo's .claude/ ends up arbitrarily
+# tracked or ignored by whoever touches it next (smartwatermelon/dotfiles#220).
+#
+# This hook is global via core.hooksPath and fires on every clone, init, AND
+# branch switch on this machine, so it is deliberately reluctant to write.
+# Four guards, in order of what they rule out:
+#
+#   0. Not a fresh clone/init -- post-checkout also fires with $3 == 1 on
+#      `git checkout -b` and on `git worktree add`, and in both of those the repo
+#      already had its chance to decide. Two signals separate them:
+#        - prev_head ($1) is the null SHA on clone and init, but a real
+#          commit on a branch switch, so it rules out `git checkout -b`.
+#        - a *linked* worktree also reports the null SHA, so prev_head alone
+#          is not enough. A linked worktree's --git-dir differs from its
+#          --git-common-dir (it lives at <repo>/.git/worktrees/<name>),
+#          whereas a main work tree's two agree. Its .claude/ is absent
+#          because the parent repo ignores it, so the "does .claude/ exist"
+#          no-op above does not fire, and without this check we would rewrite
+#          an established repo's committed, *tracked* .gitignore.
+#   1. Already tracked -- if any path under .claude/ is in the index, the repo
+#      chose to track it. Adding an ignore line there would be actively wrong:
+#      gitignore does not affect already-tracked files, so the repo would
+#      claim a policy it isn't following.
+#   2. Already ignored -- checked via `git check-ignore`, which consults BOTH
+#      .gitignore (committed, shared) and .git/info/exclude (local, never
+#      committed), plus any global core.excludesFile. Grepping .gitignore
+#      alone would miss the info/exclude case and convert someone's
+#      deliberate private hold into a shared committed policy.
+#   3. A tracked .gitignore -- the repo committed that file, and rewriting it
+#      would leave every fresh clone with a *modified tracked file*, which
+#      breaks `git diff --exit-code` checks, `git describe --dirty`, and any
+#      `git commit -a` that would sweep the line into an unrelated commit. In
+#      that case the entry goes to .git/info/exclude instead: same effect,
+#      local to this clone, never committed, and the clone stays clean.
+#      A non-regular .gitignore (symlink, directory) is skipped outright.
+#
+# Every write is failure-tolerant: a post-checkout that exits non-zero makes
+# `git clone` itself exit 1 *after* the files have already landed, which is a
+# far worse outcome than skipping the ignore line. Hence `|| return 0` on the
+# writes and `|| true` on the call.
+#
+# Projects that do want to share part of .claude/ can negate specific paths:
+#   .claude/
+#   !.claude/skills/
+add_claude_gitignore_entry() {
+  # Not a work tree (or git is unhappy) -- do nothing.
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+  # Guard 0a: prev_head is the null SHA only on a fresh clone or init; a
+  # branch switch passes the commit it moved away from.
+  if [[ ! "${_prev_head}" =~ ^0+$ ]]; then
+    return 0
+  fi
+
+  # Guard 0b: a linked worktree also reports the null SHA, so exclude it by
+  # comparing its own git dir against the shared one -- they differ only for
+  # a linked worktree.
+  local git_dir="" common_dir=""
+  git_dir=$(git rev-parse --absolute-git-dir 2>/dev/null) || return 0
+  common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
+  if [[ "${git_dir}" != "${common_dir}" ]]; then
+    return 0
+  fi
+
+  # Guard 1: any path under .claude/ already tracked in the index.
+  local tracked=""
+  tracked=$(git ls-files -- .claude 2>/dev/null) || tracked=""
+  if [[ -n "${tracked}" ]]; then
+    return 0
+  fi
+
+  # Guard 2: already ignored via .gitignore, .git/info/exclude, or a global
+  # core.excludesFile.
+  if git check-ignore -q ".claude/" 2>/dev/null; then
+    return 0
+  fi
+
+  # Guard 3: if .gitignore is tracked, write to .git/info/exclude instead so
+  # the clone is not left holding a modified tracked file.
+  local target=".gitignore" label=".gitignore"
+  local tracked_ignore=""
+  tracked_ignore=$(git ls-files -- .gitignore 2>/dev/null) || tracked_ignore=""
+  if [[ -n "${tracked_ignore}" ]]; then
+    local common_git_dir=""
+    common_git_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
+    [[ -d "${common_git_dir}/info" ]] || mkdir -p "${common_git_dir}/info" 2>/dev/null || return 0
+    target="${common_git_dir}/info/exclude"
+    label=".git/info/exclude"
+  fi
+
+  # Refuse anything that is not a plain writable file. -e follows symlinks, so
+  # a dangling symlink reports neither -e nor -w and would slip past a naive
+  # check straight into a failing append.
+  if [[ -L "${target}" ]]; then
+    return 0
+  fi
+  if [[ -e "${target}" ]]; then
+    [[ -f "${target}" && -w "${target}" ]] || return 0
+  fi
+
+  # Append, creating the file if absent and keeping a trailing newline even
+  # when the existing file lacks one. Every write tolerates failure.
+  local last_byte=""
+  if [[ -s "${target}" ]]; then
+    last_byte=$(tail -c 1 "${target}" 2>/dev/null) || last_byte=""
+    if [[ -n "${last_byte}" ]]; then
+      printf '\n' >>"${target}" 2>/dev/null || return 0
+    fi
+  fi
+  printf '.claude/\n' >>"${target}" 2>/dev/null || return 0
+  echo "📝 Added .claude/ to ${label}"
+}
+
+add_claude_gitignore_entry || true
 
 echo "✅ Claude Code infrastructure created in .claude/"
 echo ""


### PR DESCRIPTION
## Problem

`git/template/hooks/post-checkout` copies the `.claude/` template into every newly cloned/init'd repo but says nothing about whether the result should be tracked. A survey of 27 repos found **14 tracking it, 12 ignoring it, and 1 doing neither** — all holding byte-identical content. That isn't two policies, it's the absence of one.

## Change

The hook now records `.claude/` as ignored for the scaffold it just created.

**Where the entry goes** depends on what the repo already committed:

| Repo state | Target | Why |
|---|---|---|
| No tracked `.gitignore` | `.gitignore` | The shared, committed policy |
| `.gitignore` already tracked | `.git/info/exclude` | Rewriting a committed file would leave every fresh clone holding a **modified tracked file**, breaking `git diff --exit-code`, `git describe --dirty`, and any `git commit -a` that would sweep the line into an unrelated commit |

## Guards

The hook is global via `core.hooksPath` and fires on every clone, init **and branch switch** on this machine, so it's deliberately reluctant to write.

**0. Fresh clone/init only.** `post-checkout` also fires with `$3 == 1` on `git checkout -b` and on adding a linked worktree — in both, the repo already had its chance to decide.
- `prev_head` (`$1`) is the null SHA on clone/init but a real commit on a branch switch, ruling out `checkout -b`.
- A linked worktree **also** reports the null SHA, so `prev_head` alone is insufficient. It's excluded by comparing `--git-dir` against `--git-common-dir`. This matters because a new worktree's `.claude/` is absent (the parent ignores it, so it never materializes), which means the pre-existing "does `.claude/` exist" no-op does *not* fire — without this check the hook would rewrite an established repo's committed `.gitignore`.

**1. Already tracked.** If any path under `.claude/` is in the index, write nothing. `.gitignore` doesn't affect tracked files, so the line would leave the repo claiming a policy it isn't following.

**2. Already ignored.** `git check-ignore -q .claude/` consults `.gitignore`, `.git/info/exclude`, and any global `core.excludesFile` in one call. Grepping `.gitignore` alone would miss the `info/exclude` case and promote a deliberate private hold to a shared committed policy — `smartwatermelon/homebrew-tap` is a live instance of exactly that.

**3. Non-regular target.** A `.gitignore` that is a symlink or directory is skipped. `-e` follows symlinks, so a dangling link reports neither `-e` nor `-w`; the hook tests `-L` explicitly rather than walking into a failing write.

**Failure tolerance.** Every write is `|| return 0` and the step is called with `|| true`. A `post-checkout` that exits non-zero makes `git clone` itself exit 1 *after* the files have landed — far worse than skipping the ignore line.

The pre-existing no-op when `.claude/` already exists is preserved.

## Testing

New `bash/tests/test-post-checkout-gitignore.sh` — **38 assertions**. It drives **real `git clone`, `git checkout -b`, and worktree creation** through the hook rather than only calling it with synthetic arguments, because the guards are properties of how git invokes it (cwd, `$3`, `prev_head`, tree cleanliness). Every case asserts the **exit code** as well as the file state.

Coverage: fresh clone writes the entry · tracked `.gitignore` routes to `info/exclude` and leaves the clone clean · `checkout -b` in an established repo writes nothing · a worktree of an established repo writes nothing · already-tracked left alone · already-ignored via `.gitignore` left alone · already-ignored via `.git/info/exclude` left alone · running twice doesn't duplicate · unterminated `.gitignore` isn't corrupted · read-only target, unwritable `info/exclude`, and dangling symlink all exit 0.

**Known-bad validation** — every guard was removed or broken one at a time and the suite confirmed to fail, then restored:

| Mutation | Suite result |
|---|---|
| Feature removed entirely | FAIL (7 assertions) |
| Guard 0a removed (`prev_head`) | FAIL |
| Guard 0b removed (worktree detection) | FAIL |
| Guard 1 removed (already tracked) | FAIL |
| Guard 2 weakened to `grep .gitignore` | FAIL |
| Guard 3 removed (tracked `.gitignore`) | FAIL |
| Dangling-symlink check removed | FAIL |
| Trailing-newline handling removed | FAIL |

Restored hook: 38/38 pass. Three of these mutations initially *survived*, which is what prompted adding the worktree-of-established-repo case and the `info/exclude` assertions to Cases C/D — the assertions that now catch them.

One deliberate gap, reported rather than papered over: the `|| return 0` on the final write is unreachable by any deterministic test, because the `-L`/`-f`/`-w` stat checks catch every case that precedes it. It's kept as defense-in-depth against races and exotic filesystems, but the suite cannot distinguish its presence.

`shellcheck -S info` clean on both the hook and the test, with no `disable` directives.

## Docs

- `git/README.md` — the `post-checkout` hook was previously undocumented; adds a full section covering both delegate and canonical hook, the two write targets, every guard with its rationale, failure tolerance, the negation pattern for sharing part of `.claude/`, and `git check-ignore -v` for diagnosing an existing repo. Structure block updated.
- `git/template/.claude-template/README.md` — adds "Is this directory tracked?" explaining the default, both write targets, and how to share specific paths or track the whole directory.

Closes #220

https://claude.ai/code/session_01QDLrx1fP7kab37VkVQALY2
