### PR TITLE
docs(bash): align documented bash floor with the runner's 4.4 guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,17 @@ This repo uses global git hooks from `~/.config/git/hooks/`. See `git/README.md`
 Regression tests for the shell config and git hooks live in `bash/tests/`:
 
 ```bash
-bash bash/tests/run-tests.sh          # whole suite
-bash bash/tests/run-tests.sh path-order   # one test, by name substring
+# Invoke with an explicit modern bash: a bare `bash` resolves through PATH,
+# which on macOS can still find the 3.2 at /bin/bash.
+"$(brew --prefix)/bin/bash" bash/tests/run-tests.sh              # whole suite
+"$(brew --prefix)/bin/bash" bash/tests/run-tests.sh path-order   # one test, by substring
 ```
 
 The runner discovers every `bash/tests/test-*.sh` automatically. It runs on
 push via `.ralph/pre-push` and in CI via `.github/workflows/bash-tests.yml`
 (on a macOS runner — the tests assert macOS-specific behavior). Requires
-bash 5. See `bash/README.md` for the conventions for adding a test.
+bash 4.4 or newer, which on macOS means a Homebrew bash rather than the 3.2
+at `/bin/bash`. See `bash/README.md` for the conventions for adding a test.
 
 ## Setup on a new machine
 

--- a/bash/README.md
+++ b/bash/README.md
@@ -50,7 +50,7 @@ up after itself, and reports via its exit code.
 Run the whole suite:
 
 ```bash
-bash bash/tests/run-tests.sh
+"$(brew --prefix)/bin/bash" bash/tests/run-tests.sh
 ```
 
 The runner discovers every `bash/tests/test-*.sh` automatically, prints each
@@ -60,19 +60,32 @@ sync when a test is added.
 Run a single test, by passing a substring of its name:
 
 ```bash
-bash bash/tests/run-tests.sh path-order      # runs test-path-order.sh
+"$(brew --prefix)/bin/bash" bash/tests/run-tests.sh path-order   # runs test-path-order.sh
 ```
 
 Or invoke the file directly:
 
 ```bash
-bash bash/tests/test-path-order.sh
+"$(brew --prefix)/bin/bash" bash/tests/test-path-order.sh
 ```
 
-**Bash 5 is required.** Some tests use `mapfile -d` (bash 4.4+), which the
-bash 3.2 that macOS ships at `/bin/bash` does not have. The runner checks the
-version and refuses to run on anything older rather than letting those tests
-quietly produce empty results and appear to pass.
+**Bash 4.4 or newer is required.** Some tests use `mapfile -d`, and the `-d`
+option arrived in bash 4.4 — the bash 3.2 that macOS ships at `/bin/bash` has
+no `mapfile` builtin at all. The runner checks the version and refuses to run
+on anything older rather than letting those tests quietly produce empty
+results and appear to pass.
+
+Invoke the runner with an explicit modern bash rather than a bare `bash`,
+which resolves through `PATH` and on macOS can still find 3.2:
+
+```bash
+"$(brew --prefix)/bin/bash" bash/tests/run-tests.sh
+```
+
+The runner passes its own interpreter down to each child test, so whichever
+bash you start it with is the one every test runs under. On macOS, Homebrew
+is how you get a modern bash; it installs bash 5, comfortably above the 4.4
+floor.
 
 ### When these run automatically
 
@@ -109,7 +122,7 @@ Follow the conventions the existing tests share:
 ## Requirements
 
 - macOS
-- Bash 5 (installable via Homebrew)
+- Bash 4.4 or newer (macOS ships 3.2; `brew install bash` gets you 5)
 
 ## License
 

--- a/bash/tests/run-tests.sh
+++ b/bash/tests/run-tests.sh
@@ -82,6 +82,18 @@ for test in "${tests[@]}"; do
   # with "mapfile: command not found" despite the guard having passed. $BASH is
   # set by bash to the full path of the running interpreter, so the vetted one
   # propagates to every child.
+  #
+  # The contract this places on the CALLER: whichever bash you invoke this
+  # runner with is the bash every test runs under. The guard above only
+  # establishes a 4.4 floor, not that you got the interpreter you meant — so
+  # invoke the runner explicitly:
+  #
+  #   "$(brew --prefix)/bin/bash" bash/tests/run-tests.sh
+  #
+  # rather than a bare `bash run-tests.sh`, whose PATH lookup could land on any
+  # 4.4+ bash that happens to come first. Both current callers do this:
+  # `.ralph/pre-push` resolves a Homebrew bash before exec'ing the runner, and
+  # `.github/workflows/bash-tests.yml` installs bash 5 and invokes it by path.
   if "${BASH}" "${test}"; then
     passed+=("${name}")
     echo "--> PASS ${name}"


### PR DESCRIPTION
Two verified non-blocking review findings, both documentation-focused. No behavior change.

## 1. Bash version floor mismatch (#237)

`bash/tests/run-tests.sh` guards on **bash 4.4+**, but the docs claimed **bash 5**. A contributor on 4.4 was told they were unsupported while the runner happily accepted them. `bash/README.md` also contradicted itself — "Bash 5 is required" followed parenthetically by "(bash 4.4+)".

Fixed by aligning the **docs down to 4.4**, not the guard up to 5, because 4.4 is the real technical floor.

**Verified rather than assumed**, since the fix direction depends on it:

- `mapfile -d` is the only version-sensitive construct any test uses (only `test-gh-wrapper-draft-off-org.sh`).
- Upstream `NEWS` (bash 5.3.15, section "new features added to bash-4.4 since the release of bash-4.3") records: *"The `mapfile' builtin now has a -d option to use an arbitrary character as the record delimiter."* So `-d` is a 4.4 feature.
- Grepped every test for bash-5-only constructs (`EPOCHSECONDS`, `EPOCHREALTIME`, `SRANDOM`, `BASH_ARGV0`, `wait -n`, `${var@U}` case-transforms, `globasciiranges`). **No hits.** Nothing needs 5, so raising the guard would have been the wrong direction.

Worth noting the failure mode the guard prevents is real: on bash 3.2 `mapfile` is simply absent, so the array silently stays empty rather than erroring — tests would "pass" without testing anything.

The practical guidance that macOS ships 3.2 and Homebrew is how you get a modern bash is kept; it just no longer states a 5 floor.

## 2. Implicit `${BASH}` contract (item 2 of #236)

`run-tests.sh` propagates `${BASH}` to each child test. That is correct only because every current caller invokes the runner with an explicit modern bash — `.ralph/pre-push` resolves a Homebrew bash and `exec`s it, and `.github/workflows/bash-tests.yml` installs bash 5 and invokes it by path. Nothing stated that contract, so `bash run-tests.sh` with any bare `bash` satisfying the guard would silently run the whole suite under that interpreter.

Added a comment near the `${BASH}` propagation making the caller-side expectation explicit, and updated the docs' invocation examples to the explicit form rather than a bare `bash`.

## Verification

- `shellcheck -S info bash/tests/run-tests.sh` — clean, exit 0. No `# shellcheck disable` added.
- Full suite: **12 passed, 0 failed, 12 total.**
- `markdownlint` — no new violations in any edited line range (remaining findings are pre-existing, in untouched lines).
- Pre-push reviewer dry-run with `gh` stubbed (stub verified as intercepting first): **0 `NON_BLOCKING_ISSUE:` findings, VERDICT: PASS** — so this PR files no follow-up noise issues. The reviewer independently confirmed the 4.4 claim and both caller claims.

One note on how the suite was run: in a git worktree `.git` is a file, not a directory, so `install.sh`'s `[[ -d .git ]]` check rejects `--sync` and `test-allup-continue-state.sh` fails there. That failure is pre-existing and worktree-caused. Confirmed by running that test on pristine `main` in a real clone (passes), then re-running the full suite with the modified runner in that clone — 12/12.

Closes #237

https://claude.ai/code/session_01QDLrx1fP7kab37VkVQALY2
