### PR TITLE
test(git): guard against fixture values leaking into .git/config

### DIFF
--- a/bash/README.md
+++ b/bash/README.md
@@ -96,6 +96,23 @@ floor.
   macOS assumptions (Homebrew-rooted PATH tiers, macOS-only paths in `env.sh`),
   so a Linux runner would fail for reasons that say nothing about the code.
 
+### The one test that inspects the real repo
+
+`tests/test-git-config-hygiene.sh` is the exception to the isolation rule
+below: it deliberately asserts against this checkout's own `.git/config`
+rather than a scratch fixture, because that is the thing it guards.
+
+It fails if the local config picks up a `user.email` / `user.name` override,
+an empty `core.hooksPath`, or any remote besides `origin` — all states this
+repo has actually been found in (see #239). It never writes; it only reads.
+
+The `core.hooksPath` case is the one worth knowing about independently: an
+empty value does **not** mean "unset". Git resolves it to `./`, the repo
+root, where the `pre-commit/` *directory* satisfies an `[[ -x ]]` check while
+git still finds no executable file to run — so every hook silently stops
+firing, and local review stops with it. The test therefore checks that a
+`pre-commit` regular file actually resolves, not merely that the key is unset.
+
 ### Adding a test
 
 Name the file `tests/test-<subject>.sh` and make it executable — that is the

--- a/bash/README.md
+++ b/bash/README.md
@@ -113,6 +113,14 @@ git still finds no executable file to run — so every hook silently stops
 firing, and local review stops with it. The test therefore checks that a
 `pre-commit` regular file actually resolves, not merely that the key is unset.
 
+That last check is machine-local, and it is skipped where no global
+`core.hooksPath` is configured — a CI runner, or a machine that has not run
+`install.sh` yet. The precondition is the absence of a global hooks setting
+rather than `$CI`, so it states the real dependency. The config-hygiene
+assertions are portable and always run; the empty-`hooksPath` bug is still
+caught in a skipping environment, because that is a config check rather than
+a resolution check.
+
 ### Adding a test
 
 Name the file `tests/test-<subject>.sh` and make it executable — that is the

--- a/bash/tests/test-git-config-hygiene.sh
+++ b/bash/tests/test-git-config-hygiene.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#shellcheck shell=bash
+# Guard against test-fixture values leaking into this checkout's real
+# .git/config. Run directly:
+# bash bash/tests/test-git-config-hygiene.sh
+#
+# Regression coverage for smartwatermelon/dotfiles#239: on 2026-08-24 this
+# repo's .git/config was found holding `core.hooksPath=` (empty),
+# `user.email=test@example.com`, and `user.name=Test`. The cause was never
+# identified — the obvious suspects (test-pre-push-stale-ci.sh's setup_repo,
+# and `git worktree remove`) were both tested and ruled out. A separate,
+# confirmed escape had already put a `beacon-biosignals/forked-tool` remote
+# in this repo via test-gh-wrapper-identity.sh before that test sandboxed
+# HOME.
+#
+# Because the mechanism is unknown, this test detects rather than prevents:
+# it asserts the checkout's local config is clean, so the next occurrence
+# fails loudly in the suite (which runs on every push via .ralph/pre-push
+# and in CI) no matter what writes it.
+#
+# The empty-hooksPath case is the one that actually mattered. An empty
+# value does not mean "unset": git resolves it to `./`, the repo root. This
+# repo has a `pre-commit/` *directory* there, so `[[ -x ./pre-commit ]]`
+# succeeds while git still finds no executable file to run — Protocol 4's
+# automatic review silently did not fire in this checkout.
+set -euo pipefail
+
+REPO_ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail=0
+
+_pass() { echo "  PASS: $1"; }
+_fail() {
+  echo "  FAIL: $1" >&2
+  fail=1
+}
+
+# Read a local-scope value; empty output covers both "unset" and "set to
+# empty", so the two are distinguished via --get-regexp where it matters.
+_local_get() {
+  git -C "${REPO_ROOT}" config --local --get "$1" 2>/dev/null || true
+}
+
+# True when the key exists in local scope at all, whatever its value. This
+# is the check that catches `hooksPath = ` (present, empty) — `--get`
+# returns nothing for it, which is indistinguishable from absent.
+_local_has_key() {
+  git -C "${REPO_ROOT}" config --local --get-regexp "^$1\$" >/dev/null 2>&1
+}
+
+echo "Case: no local git identity overrides"
+
+# A local user.email/user.name in this repo is always wrong — identity comes
+# from the global config. Fixture values are the specific worry, but any
+# local override is worth failing on, since it silently re-authors commits.
+if _local_has_key "user\.email"; then
+  _bad_value=$(_local_get user.email)
+  _fail "local user.email is set (${_bad_value}) — identity must come from global config"
+else
+  _pass "no local user.email"
+fi
+
+if _local_has_key "user\.name"; then
+  _bad_value=$(_local_get user.name)
+  _fail "local user.name is set (${_bad_value}) — identity must come from global config"
+else
+  _pass "no local user.name"
+fi
+
+echo "Case: core.hooksPath is not locally overridden"
+
+# The #239 failure. An empty local value shadows the global hooks dir and
+# resolves to the repo root, which disables every hook without erroring.
+if _local_has_key "core\.hooksPath"; then
+  _bad_value=$(_local_get core.hooksPath)
+  _fail "local core.hooksPath is set ('${_bad_value}') — shadows the global hooks dir; unset it"
+else
+  _pass "no local core.hooksPath override"
+fi
+
+echo "Case: hooks actually resolve to an executable pre-commit"
+
+# Resolving the key is not the same as the hook being runnable — a
+# same-named *directory* satisfies `[[ -x ]]`. Check for a regular file.
+hooks_dir="$(git -C "${REPO_ROOT}" rev-parse --git-path hooks)"
+case "${hooks_dir}" in
+  /*) resolved_hooks="${hooks_dir}" ;;
+  *) resolved_hooks="${REPO_ROOT}/${hooks_dir}" ;;
+esac
+
+if [[ -f "${resolved_hooks}/pre-commit" && -x "${resolved_hooks}/pre-commit" ]]; then
+  _pass "pre-commit resolves to an executable file (${resolved_hooks})"
+else
+  _fail "no executable pre-commit file at resolved hooks dir '${resolved_hooks}' — local review will not run"
+fi
+
+echo "Case: no unexpected remotes"
+
+# test-gh-wrapper-identity.sh once added a beacon-biosignals/forked-tool
+# `upstream` here. Only origin belongs in this repo.
+while read -r remote; do
+  [[ -z "${remote}" ]] && continue
+  if [[ "${remote}" != "origin" ]]; then
+    remote_url=$(git -C "${REPO_ROOT}" remote get-url "${remote}" 2>/dev/null || true)
+    _fail "unexpected remote '${remote}' -> ${remote_url}"
+  fi
+done < <(git -C "${REPO_ROOT}" remote || true)
+
+if git -C "${REPO_ROOT}" remote | grep -qx "origin"; then
+  _pass "origin is present"
+else
+  _fail "origin remote is missing"
+fi
+
+# The loop above fails per offending remote; this reports the clean case so
+# a passing run shows the assertion actually ran.
+unexpected_count=$(git -C "${REPO_ROOT}" remote | grep -cvx "origin" || true)
+if [[ "${unexpected_count}" -eq 0 ]]; then
+  _pass "no remotes other than origin"
+else
+  _fail "${unexpected_count} unexpected remote(s) present"
+fi
+
+echo
+if [[ "${fail}" -eq 0 ]]; then
+  echo "ALL CHECKS PASSED"
+  exit 0
+fi
+echo "SOME CHECKS FAILED" >&2
+exit 1

--- a/bash/tests/test-git-config-hygiene.sh
+++ b/bash/tests/test-git-config-hygiene.sh
@@ -80,18 +80,34 @@ fi
 
 echo "Case: hooks actually resolve to an executable pre-commit"
 
-# Resolving the key is not the same as the hook being runnable — a
-# same-named *directory* satisfies `[[ -x ]]`. Check for a regular file.
-hooks_dir="$(git -C "${REPO_ROOT}" rev-parse --git-path hooks)"
-case "${hooks_dir}" in
-  /*) resolved_hooks="${hooks_dir}" ;;
-  *) resolved_hooks="${REPO_ROOT}/${hooks_dir}" ;;
-esac
+# This assertion is machine-local, unlike the config checks above. It is
+# meaningful only where this machine's shared hooks are actually deployed
+# (via a global core.hooksPath). A CI runner has a fresh clone, no global
+# git config, and no ~/.config/git/hooks — so .git/hooks holds only samples
+# and there is nothing to assert. Skip there rather than fail, following
+# the pattern test-path-order.sh uses for Homebrew-dependent checks.
+#
+# The precondition is "a global core.hooksPath is configured", not "$CI is
+# set": that states the actual dependency, and it stays correct on a
+# developer machine that has not run install.sh yet.
+global_hooks_path="$(git config --global --get core.hooksPath 2>/dev/null || true)"
 
-if [[ -f "${resolved_hooks}/pre-commit" && -x "${resolved_hooks}/pre-commit" ]]; then
-  _pass "pre-commit resolves to an executable file (${resolved_hooks})"
+if [[ -z "${global_hooks_path}" ]]; then
+  echo "  SKIP: no global core.hooksPath configured; shared hooks are not deployed here"
 else
-  _fail "no executable pre-commit file at resolved hooks dir '${resolved_hooks}' — local review will not run"
+  # Resolving the key is not the same as the hook being runnable — a
+  # same-named *directory* satisfies `[[ -x ]]`. Check for a regular file.
+  hooks_dir="$(git -C "${REPO_ROOT}" rev-parse --git-path hooks)"
+  case "${hooks_dir}" in
+    /*) resolved_hooks="${hooks_dir}" ;;
+    *) resolved_hooks="${REPO_ROOT}/${hooks_dir}" ;;
+  esac
+
+  if [[ -f "${resolved_hooks}/pre-commit" && -x "${resolved_hooks}/pre-commit" ]]; then
+    _pass "pre-commit resolves to an executable file (${resolved_hooks})"
+  else
+    _fail "no executable pre-commit file at resolved hooks dir '${resolved_hooks}' — local review will not run"
+  fi
 fi
 
 echo "Case: no unexpected remotes"


### PR DESCRIPTION
Closes #239

## What

Adds `bash/tests/test-git-config-hygiene.sh`, which asserts this checkout's own `.git/config` is free of test-fixture contamination.

## Why

On 2026-08-24 the working checkout was found holding:

```
core.bare       = true              (repo is not bare)
core.hooksPath  =                   (empty — shadows the global setting)
user.email      = test@example.com
user.name       = Test
```

The empty `core.hooksPath` was the consequential one. Git resolves an empty value to `./` — the repo root — not to `.git/hooks` and not to the global path. This repo has a `pre-commit/` **directory** there, so `[[ -x ./pre-commit ]]` succeeds while git still finds no executable *file* to run.

Net effect: **no git hooks fired in this checkout**, so Protocol 4's automatic local review silently stopped running. Linked worktrees inherited the same override. Fresh clones were unaffected, which is why the problem stayed invisible — the agent work that day happened in worktrees and clones.

## Cause: not identified, hence a detector rather than a fix

Two hypotheses were investigated and **both ruled out with evidence**:

- **A test leaked in.** `bash/tests/test-pre-push-stale-ci.sh:42-44` is the only place in the repo setting those three values, making it the obvious suspect. Its `setup_repo()` guards every mutation inside a subshell with `cd "${dir}" || exit 1`. That guard was tested against an uncreatable directory (contained), the real test was run from the repo root (exit 0, no leak), and `git log -S` shows the guard present since the file was created — so there is no window in which it was missing.
- **`git worktree remove` corrupted it.** Config was snapshotted before and after a real `worktree remove --force` on this repo; the two are byte-identical.

An audit of every `git config` / `git remote` / `git init` call in `bash/tests/` found no unguarded mutation — all are `git -C`-scoped or inside a guarded `cd` subshell. That is a clean result, but it should be read as "no leak path found by this method", not proof none exists.

Since the mechanism is unknown, detection beats prevention: this catches the next occurrence whatever writes it, in a suite that runs on every push via `.ralph/pre-push` and in CI.

## What it checks

| Assertion | Rationale |
|---|---|
| No local `user.email` / `user.name` | Identity must come from global config; a local override silently re-authors commits |
| No local `core.hooksPath` | An empty value disables every hook without erroring |
| `pre-commit` resolves to an executable **file** | Resolving the key is not the same as the hook being runnable — a same-named directory satisfies `[[ -x ]]` |
| No remote besides `origin` | `test-gh-wrapper-identity.sh:160` once left a `beacon-biosignals/forked-tool` upstream here (a confirmed, separate escape, since fixed by sandboxing `HOME`) |

## Known-bad validation

Every assertion was injected as the real bad state, confirmed to fail, then reverted green — a guard that has never been shown to fail proves nothing:

```
hooksPath="" → FAIL: local core.hooksPath is set ('') — shadows the global hooks dir
             → FAIL: no executable pre-commit file at resolved hooks dir '.../.'
user.email   → FAIL: local user.email is set (test@example.com)
user.name    → FAIL: local user.name is set (Test)
upstream     → FAIL: unexpected remote 'upstream' -> git@github.com:beacon-biosignals/forked-tool.git
```

All four revert to green.

## Verification

- Full suite: **13 passed, 0 failed, 13 total**
- `shellcheck -S info` clean, no `disable` directives
- Pre-commit reviewers both PASS — and notably they *ran*, which they could not do before the config was repaired

## Dry-run

Ran the pre-push reviewer with `gh` stubbed before pushing (stub validated to intercept first). It surfaced one finding about a redundant remote-count branch; that is fixed in this PR rather than left to become a tracking issue. Re-validated the known-bad case afterwards.

## Docs

`bash/README.md` gains a short section explaining that this is the one test that deliberately inspects the real repo rather than a fixture, and documenting the empty-`hooksPath` behavior, which is worth knowing independently of this incident.

https://claude.ai/code/session_01QDLrx1fP7kab37VkVQALY2