### PR TITLE
fix(symlinks): exclude nested test dirs; tidy hygiene test output

### DIFF
--- a/bash/tests/test-git-config-hygiene.sh
+++ b/bash/tests/test-git-config-hygiene.sh
@@ -25,6 +25,13 @@
 # automatic review silently did not fire in this checkout.
 set -euo pipefail
 
+# Suite convention (bash/README.md, "Adding a test"): CDPATH makes `cd` echo
+# its resolved path to stdout, which corrupts command substitution. Unset it
+# once here so any `cd` added later is protected without per-call-site
+# reasoning; the inline `CDPATH=''` below stays as a local belt-and-braces
+# guard, matching test-allup-continue-state.sh and run-tests.sh.
+unset CDPATH
+
 REPO_ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 fail=0
@@ -128,13 +135,19 @@ else
   _fail "origin remote is missing"
 fi
 
-# The loop above fails per offending remote; this reports the clean case so
-# a passing run shows the assertion actually ran.
+# The loop above already fails once per offending remote, naming it and its
+# URL. This block exists only to report the CLEAN case, so a passing run shows
+# the assertion actually ran rather than skipping a zero-iteration loop. It
+# deliberately does not _fail on a dirty run: a summary count adds a second
+# FAIL line for a condition the loop has already reported in more useful
+# detail (smartwatermelon/dotfiles#242).
+#
+# The `|| true` is load-bearing, not defensive habit: `grep -c` exits 1 when
+# the count is zero — the clean case — which `set -e` would otherwise treat
+# as a fatal error.
 unexpected_count=$(git -C "${REPO_ROOT}" remote | grep -cvx "origin" || true)
 if [[ "${unexpected_count}" -eq 0 ]]; then
   _pass "no remotes other than origin"
-else
-  _fail "${unexpected_count} unexpected remote(s) present"
 fi
 
 echo

--- a/bash/tests/test-symlink-exclusions-shared.sh
+++ b/bash/tests/test-symlink-exclusions-shared.sh
@@ -168,6 +168,43 @@ for pattern in "${must_include[@]}"; do
 done
 ((overreach == 0)) && _pass "real config paths are still symlinked"
 
+# --- Case 7: nested test directories are excluded ------------------------
+# A bash `case` glob does not cross directory levels, so `tests/*` matches
+# only at the repo root. Before #227 that let every file under bash/tests/
+# get symlinked into ~/.config/bash/tests. These cases pin the `*/tests/*`
+# and `*/test/*` patterns that close it.
+echo "Case: nested test directories are excluded"
+nested_missing=0
+nested_must_exclude=(
+  "bash/tests/test-foo.sh"
+  "bash/tests/run-tests.sh"
+  "git/test/helper.sh"
+  "a/b/tests/deep.sh"
+)
+for pattern in "${nested_must_exclude[@]}"; do
+  if ! _symlink_is_excluded "${pattern}"; then
+    _fail "nested test path '${pattern}' is not excluded — it would be symlinked into ~/.config"
+    nested_missing=1
+  fi
+done
+((nested_missing == 0)) && _pass "all ${#nested_must_exclude[@]} nested test paths excluded"
+
+# The patterns must not swallow config that merely has "test" in a path
+# segment — only a directory named exactly `test` or `tests` counts.
+nested_overreach=0
+nested_must_include=(
+  "bash/testing-utils.sh"
+  "git/latest/config"
+  "bash/tests.sh"
+)
+for pattern in "${nested_must_include[@]}"; do
+  if _symlink_is_excluded "${pattern}"; then
+    _fail "nested test patterns wrongly exclude real config '${pattern}'"
+    nested_overreach=1
+  fi
+done
+((nested_overreach == 0)) && _pass "paths merely containing 'test' are still symlinked"
+
 echo ""
 if ((fail != 0)); then
   echo "test-symlink-exclusions-shared: SOME CHECKS FAILED" >&2

--- a/git/hooks/lib-symlink-exclusions.sh
+++ b/git/hooks/lib-symlink-exclusions.sh
@@ -57,6 +57,12 @@ _symlink_is_excluded() {
     *.bats) return 0 ;;
     tests/*) return 0 ;;
     test/*) return 0 ;;
+    # Nested test dirs (e.g. bash/tests/). A bash `case` glob does not cross
+    # directory levels, so `tests/*` matches only at the repo root — without
+    # these, bash/tests/* was symlinked into ~/.config/bash/tests
+    # (smartwatermelon/dotfiles#227).
+    */tests/*) return 0 ;;
+    */test/*) return 0 ;;
     # Copy-and-edit templates — meant to be copied by hand, not symlinked
     *.example) return 0 ;;
     # Project-local hook extension (runs the bash test suite before push).


### PR DESCRIPTION
Three small, independent fixes batched into one push. Each push runs the
whole-codebase reviewer, which files its non-blocking findings as issues, so
bundling keeps the issue count going down rather than up three times.

Closes #240
Closes #242
Closes #227

## #227 — test scripts symlinked into ~/.config

`git/hooks/lib-symlink-exclusions.sh` excluded `tests/*` and `test/*`, but a
bash `case` glob does not cross directory levels, so those matched only at the
repo root. Everything under `bash/tests/` passed the check and was symlinked
into `~/.config/bash/tests`. Adds `*/tests/*` and `*/test/*`.

This removes deployed symlinks — a real behavior change, and the reason #225
deliberately left it alone. `install.sh` refuses to run from a worktree
(it checks `[[ -d .git ]]`, and `.git` is a file there), so this was verified
in a fresh clone, comparing `install.sh --sync --dry-run` before and after:

```
intended ~/.config symlinks before: 57
intended ~/.config symlinks after:  43
delta: 14 removed, 0 added — all 14 under bash/tests/
```

The 14 are every tracked file in `bash/tests/`; only 10 currently have a live
symlink, the other 4 postdate the last sync. Nothing outside `bash/tests/`
moves in either direction. `~/.config/iterm2/AppSupport` shows up as a live
link that install.sh does not manage — it is absent from the intended set both
before and after, so it is unaffected. Confirmed no consumer reads the tests by
their `~/.config` path.

Adds Case 7 to `test-symlink-exclusions-shared.sh`: four nested paths that must
be excluded, plus three (`bash/testing-utils.sh`, `git/latest/config`,
`bash/tests.sh`) that must NOT be, so the pattern cannot later be widened into
swallowing real config.

## #240 — missing `unset CDPATH`

The suite convention, documented in `bash/README.md`'s "Adding a test", is
`unset CDPATH` after the `set` line; this test used only an inline
`CDPATH='' cd`. Equivalent today because there is exactly one `cd`, but the
convention exists so a `cd` added later is protected without per-call-site
reasoning. Keeps the inline guard as belt-and-braces, matching
`test-allup-continue-state.sh` and `run-tests.sh`.

## #242 — duplicate FAIL output for unexpected remotes

An unexpected remote produced two FAIL lines: one from the per-remote loop
naming the remote and its URL, and a redundant "N unexpected remote(s) present"
summary. Drops the summary `_fail`; the loop's message is strictly more
informative and still sets the failure flag. The clean-run PASS is kept, since
that is what proves the assertion ran rather than skipping a zero-iteration
loop.

## Verification

Known-bad first for all three — a test never shown to fail proves nothing:

- Reverting the exclusion patterns fails Case 7 with 4 FAILs and exit 1;
  restoring them returns it to green.
- The dirty-remote case emits 2 FAIL lines before the change and 1 after,
  still exiting 1, with the clean-run PASS intact.
- A CDPATH probe reproduces the corrupted two-line capture and shows
  `unset CDPATH` closing it.
- The `|| true` on `grep -c` was verified load-bearing: without it, `set -e`
  kills the script on the zero-match (clean) case.

Full suite is **13 passed, 0 failed** on this exact commit in a pristine clone.
`shellcheck -S info` clean on all three files. The pre-push reviewer was run
ahead of time with `gh` stubbed (stub verified to intercept: `gh issue create`
exits 1) and reported zero non-blocking findings, so this push should file no
new issues.

https://claude.ai/code/session_01QDLrx1fP7kab37VkVQALY2
