### PR TITLE
test(symlinks): pin that substring-"test" directories stay symlinked

### DIFF
--- a/bash/tests/test-symlink-exclusions-shared.sh
+++ b/bash/tests/test-symlink-exclusions-shared.sh
@@ -200,8 +200,11 @@ nested_must_include=(
   # is not a test dir. `*/tests/*` correctly won't match these, but nothing
   # pinned that until now — a future edit widening the glob to `*test*/*`
   # would silently stop symlinking real config, and no test would catch it
-  # (smartwatermelon/dotfiles#245). Each case below was verified to fail
-  # against that widened glob, so these assert behavior rather than assume it.
+  # (smartwatermelon/dotfiles#245). Each case below was checked by hand
+  # against that widened glob when it was added — all three matched it, so
+  # each would fail here if the glob were widened. That check was author-time,
+  # not an assertion in this file; what protects the behavior from here on is
+  # the loop below.
   "bash/testing/config.sh"
   "a/test-utils/b.sh"
   "bash/contest/c.sh"

--- a/bash/tests/test-symlink-exclusions-shared.sh
+++ b/bash/tests/test-symlink-exclusions-shared.sh
@@ -196,6 +196,15 @@ nested_must_include=(
   "bash/testing-utils.sh"
   "git/latest/config"
   "bash/tests.sh"
+  # Directory-segment cases: a *directory* whose name merely contains "test"
+  # is not a test dir. `*/tests/*` correctly won't match these, but nothing
+  # pinned that until now — a future edit widening the glob to `*test*/*`
+  # would silently stop symlinking real config, and no test would catch it
+  # (smartwatermelon/dotfiles#245). Each case below was verified to fail
+  # against that widened glob, so these assert behavior rather than assume it.
+  "bash/testing/config.sh"
+  "a/test-utils/b.sh"
+  "bash/contest/c.sh"
 )
 for pattern in "${nested_must_include[@]}"; do
   if _symlink_is_excluded "${pattern}"; then


### PR DESCRIPTION
Closes #245.

## What

`nested_must_include` in `bash/tests/test-symlink-exclusions-shared.sh` guards against the exclusion globs over-matching. It tested three paths that merely contain "test" — a file with "test" in its name, a path with no "test" at all, and a file named `tests.sh` — but none covered the case the globs are actually anchored against: a **directory** whose name contains "test" as a substring without being exactly `test` or `tests`.

Adds three: `bash/testing/config.sh`, `a/test-utils/b.sh`, `bash/contest/c.sh`.

## Why it's safe

This pins existing behavior rather than changing it. `*/tests/*` and `*/test/*` already fall through correctly for all three, verified before the test was written. The risk it closes is a future edit widening the glob to something like `*test*/*`, which would silently stop symlinking real config with no test failing.

## Verification

Each case was checked against that widened glob before being committed — all three match it, so each would fail if the glob were widened. That check was author-time; the loop is what protects the behavior from here on. The second commit rewords the comment to say so, after the pre-push reviewer correctly noted the original phrasing implied the test mechanized the check.

- Full suite: 13/13 pass
- `shellcheck -S info`: clean
- Pre-push codebase dry-run: PASS

## Note on the remaining dry-run finding

The final dry-run flagged `((missing == 0)) && _pass ...` as failing silently under `set -e`. That is incorrect — `((...))` on the left of `&&` is a tested condition, which `set -e` exempts; verified by probe. It is also pre-existing code on four lines this PR does not touch. No change made.