### PR TITLE
fix(tests): isolate git repo-selection env in fixture tests (#239)

### DIFF
--- a/bash/README.md
+++ b/bash/README.md
@@ -121,6 +121,49 @@ assertions are portable and always run; the empty-`hooksPath` bug is still
 caught in a skipping environment, because that is a config check rather than
 a resolution check.
 
+### Git environment isolation (#239)
+
+A test that creates fixture repositories must clear git's
+repository-selection environment first. `tests/lib/git-env-isolation.sh`
+does this:
+
+```bash
+_tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/git-env-isolation.sh
+source "${_tests_dir}/lib/git-env-isolation.sh"
+isolate_git_env "${WORKDIR}"
+```
+
+**Why `cd` and `-C` are not enough.** `GIT_DIR` outranks both the process
+working directory and `git -C`:
+
+```
+GIT_DIR=/elsewhere/.git git -C /tmp/scratch config user.email x@y.z
+  -> writes to /elsewhere/.git/config, not /tmp/scratch
+```
+
+**Where the inherited value came from.** Git exports `GIT_DIR` into a hook's
+environment when — and only when — the hook runs from a linked worktree.
+`.project-hooks/pre-push` execs `tests/run-tests.sh`, so every test inherited
+it, and fixture writes landed in the worktree's administrative git directory.
+Linked worktrees share the common `.git/config`, so the real checkout was
+contaminated with `core.hooksPath=` (empty), `core.bare=true`, a fake
+identity, and a bogus `upstream` remote.
+
+This is why the bug looked intermittent and survived three investigations: a
+test run by hand has no hook, therefore no `GIT_DIR`, therefore no
+contamination. Only a hook-invoked run from a worktree reproduces it.
+`tests/test-git-env-isolation.sh` injects that condition deliberately, and
+keeps a control case that must contaminate — otherwise the guarded assertions
+would pass vacuously if the injection ever stopped working.
+
+The helper derives its unset list from `git rev-parse --local-env-vars`
+rather than hardcoding one, unioned with a fallback for older git. It
+deliberately leaves `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` alone: those
+are not repository-selection variables, and several tests set them on purpose
+to point git at a sandboxed global config. Call `isolate_git_env` *before*
+exporting those.
+
 ### Adding a test
 
 Name the file `tests/test-<subject>.sh` and make it executable — that is the
@@ -137,6 +180,10 @@ Follow the conventions the existing tests share:
 - Isolate from the real machine: scratch `$HOME` or `mktemp -d`, with a
   `trap 'rm -rf ...' EXIT` for cleanup. Never touch real git remotes, real
   `gh` auth, or the developer's actual config.
+- **If the test creates or mutates a git repository, source
+  `tests/lib/git-env-isolation.sh` and call `isolate_git_env "${WORKDIR}"`
+  before the first git call.** A scratch directory is not a scratch repository
+  when `GIT_DIR` is already set — see the section below.
 - Print `PASS: <case>` / `FAIL: <case>` per assertion, track a `fail` variable,
   and `exit "${fail}"` at the end.
 - Prove a stub or mock is actually intercepting before relying on it — a clean

--- a/bash/tests/lib/git-env-isolation.sh
+++ b/bash/tests/lib/git-env-isolation.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Clear the git environment variables that select which repository a git
+# command acts on, so a test's scratch fixtures cannot be redirected at the
+# caller's real checkout.
+#
+# Source this, do not execute it:
+#
+#   # shellcheck source=lib/git-env-isolation.sh
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env-isolation.sh"
+#   isolate_git_env "${WORKDIR}"
+#
+# WHY THIS EXISTS (smartwatermelon/dotfiles#239)
+#
+# Git exports GIT_DIR into a hook's environment when — and only when — the hook
+# runs from a linked worktree. `.project-hooks/pre-push` execs
+# `bash/tests/run-tests.sh`, so every test inherited that GIT_DIR and wrote its
+# fixtures into the worktree's administrative git directory. Linked worktrees
+# share the common config, so the real checkout was contaminated with
+# `core.hooksPath=` (empty), `core.bare=true`, a fake identity, and a bogus
+# `upstream` remote.
+#
+# GIT_DIR takes precedence over BOTH the process working directory AND `git -C`.
+# That is the part that makes this a trap rather than an ordinary cwd bug:
+#
+#   GIT_DIR=/elsewhere/.git git -C /tmp/scratch config user.email x@y.z
+#     -> writes to /elsewhere/.git/config, NOT /tmp/scratch
+#
+# So `cd`-guarding and adding `-C` are both insufficient. The environment has to
+# be cleared, and it has to be cleared before the first git call.
+#
+# WHAT THIS DOES NOT TOUCH
+#
+# GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM are deliberately left alone. They are
+# not repository-selection variables — they are how a test points git at a
+# sandboxed global config, which several tests here do on purpose
+# (test-gh-wrapper-identity.sh sets both). Clearing them would silently
+# un-isolate those tests against the developer's real ~/.gitconfig.
+#
+# Consequence for callers: source this and call isolate_git_env BEFORE exporting
+# your own GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM / HOME sandbox. Order matters
+# in one direction only — this function never overwrites them, but a caller that
+# sets them first and isolates second is relying on that, which is a fragile
+# thing to rely on.
+
+# Variables that redirect repository-local state. Git knows its own list, so ask
+# it rather than hardcoding one that silently rots as git versions change:
+# `git rev-parse --local-env-vars` is the authoritative enumeration.
+#
+# The fallback below is NOT a duplicate of that list kept in sync by hand — it
+# is a floor for the case where `git rev-parse` is unavailable or fails. It
+# deliberately includes GIT_QUARANTINE_PATH and GIT_INTERNAL_SUPER_PREFIX, which
+# are NOT in git 2.50's --local-env-vars output but do redirect state in the
+# contexts where git sets them (quarantine during receive-pack, super-prefix
+# during recursive submodule operations). Union, never intersection: an extra
+# unset of a variable this test was never going to use is free, whereas a
+# missing one is the bug this file exists to prevent.
+readonly _GIT_ENV_FALLBACK=(
+  GIT_ALTERNATE_OBJECT_DIRECTORIES
+  GIT_COMMON_DIR
+  GIT_CONFIG
+  GIT_CONFIG_COUNT
+  GIT_CONFIG_PARAMETERS
+  GIT_DIR
+  GIT_GRAFT_FILE
+  GIT_IMPLICIT_WORK_TREE
+  GIT_INDEX_FILE
+  GIT_INTERNAL_SUPER_PREFIX
+  GIT_NO_REPLACE_OBJECTS
+  GIT_OBJECT_DIRECTORY
+  GIT_PREFIX
+  GIT_QUARANTINE_PATH
+  GIT_REPLACE_REF_BASE
+  GIT_SHALLOW_FILE
+  GIT_WORK_TREE
+)
+
+# isolate_git_env [ceiling_dir]
+#
+# Unsets every repository-selection variable. If ceiling_dir is given, also sets
+# GIT_CEILING_DIRECTORIES so that a git command run from a scratch directory
+# cannot walk UP out of it and discover the real repo — which is the other half
+# of the containment, and the failure mode that survives even a fully cleared
+# environment (a bare `git config` in a directory that is not a repo searches
+# parent directories).
+isolate_git_env() {
+  local ceiling="${1:-}"
+  local var
+  local -a to_unset=("${_GIT_ENV_FALLBACK[@]}")
+
+  # Ask git for its own list and add anything the fallback missed. Failure here
+  # is not fatal: the fallback already covers every variable implicated in #239.
+  local git_reported
+  if git_reported="$(git rev-parse --local-env-vars 2>/dev/null)"; then
+    while IFS= read -r var; do
+      [[ -n "${var}" ]] || continue
+      to_unset+=("${var}")
+    done <<<"${git_reported}"
+  fi
+
+  # GIT_CONFIG_KEY_<n> / GIT_CONFIG_VALUE_<n> carry `-c` overrides alongside
+  # GIT_CONFIG_COUNT. They are inert once the count is gone, but leaving a
+  # partial set behind means a test that later sets its own count inherits
+  # someone else's keys. Clear the whole family.
+  for var in $(compgen -v 2>/dev/null | grep -E '^GIT_CONFIG_(KEY|VALUE)_[0-9]+$' || true); do
+    to_unset+=("${var}")
+  done
+
+  unset "${to_unset[@]}"
+
+  if [[ -n "${ceiling}" ]]; then
+    export GIT_CEILING_DIRECTORIES="${ceiling}"
+  fi
+}

--- a/bash/tests/lib/git-env-isolation.sh
+++ b/bash/tests/lib/git-env-isolation.sh
@@ -42,6 +42,16 @@
 # sets them first and isolates second is relying on that, which is a fragile
 # thing to rely on.
 
+# Include guard. The array below is `readonly`, so a second source in the same
+# process would abort with "readonly variable" — fatal under `set -e`. Today
+# every test is dispatched as its own subprocess by run-tests.sh, so that cannot
+# happen; the guard means a future caller that sources a test inline does not
+# discover this the hard way.
+if [[ -n "${_GIT_ENV_ISOLATION_LOADED:-}" ]]; then
+  return 0
+fi
+readonly _GIT_ENV_ISOLATION_LOADED=1
+
 # Variables that redirect repository-local state. Git knows its own list, so ask
 # it rather than hardcoding one that silently rots as git versions change:
 # `git rev-parse --local-env-vars` is the authoritative enumeration.

--- a/bash/tests/run-tests.sh
+++ b/bash/tests/run-tests.sh
@@ -23,6 +23,24 @@ set -uo pipefail
 # command substitution below.
 unset CDPATH
 
+# Clear inherited git repository-selection state before running any test.
+#
+# This is the PRIMARY chokepoint for smartwatermelon/dotfiles#239, not merely
+# defense in depth. `.project-hooks/pre-push` execs this runner from inside a git
+# hook, and git exports GIT_DIR into a hook's environment when the hook runs from
+# a linked worktree. Every test then inherited it, and GIT_DIR outranks both the
+# working directory and `git -C`, so fixture writes landed in the worktree's
+# administrative git directory — which shares the common config with the real
+# checkout.
+#
+# The individual tests isolate themselves too, which is what protects a test run
+# directly rather than through this runner. Clearing it here as well means a test
+# added later without that guard is still contained.
+_tests_dir_for_isolation="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/git-env-isolation.sh
+source "${_tests_dir_for_isolation}/lib/git-env-isolation.sh"
+isolate_git_env
+
 TESTS_DIR="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if ((BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 4))); then

--- a/bash/tests/test-gh-wrapper-draft-off-org.sh
+++ b/bash/tests/test-gh-wrapper-draft-off-org.sh
@@ -11,6 +11,15 @@ set -euo pipefail
 unset CDPATH
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Clear inherited git repository-selection state before touching any fixture.
+# A hook invoked from a linked worktree exports GIT_DIR, which outranks both the
+# working directory and `git -C`, so without this the scratch repos below are
+# silently redirected at the real checkout (smartwatermelon/dotfiles#239).
+_tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/git-env-isolation.sh
+source "${_tests_dir}/lib/git-env-isolation.sh"
+isolate_git_env
+
 export BASH_CONFIG_DIR="${REPO_ROOT}/bash"
 
 # Sourcing (not executing) the file puts it in function-definition mode,

--- a/bash/tests/test-gh-wrapper-identity.sh
+++ b/bash/tests/test-gh-wrapper-identity.sh
@@ -16,6 +16,15 @@ unset CDPATH
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export BASH_CONFIG_DIR="${REPO_ROOT}/bash"
 
+# Clear inherited git repository-selection state before touching any fixture.
+# A hook invoked from a linked worktree exports GIT_DIR, which outranks both the
+# working directory and `git -C`, so without this the scratch repos below are
+# silently redirected at the real checkout (smartwatermelon/dotfiles#239).
+_tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/git-env-isolation.sh
+source "${_tests_dir}/lib/git-env-isolation.sh"
+isolate_git_env
+
 export HOME="/tmp/gh-wrapper-identity-test-home-$$"
 mkdir -p "${HOME}/.config/gh"
 

--- a/bash/tests/test-git-config-hygiene.sh
+++ b/bash/tests/test-git-config-hygiene.sh
@@ -32,6 +32,18 @@ set -euo pipefail
 # guard, matching test-allup-continue-state.sh and run-tests.sh.
 unset CDPATH
 
+# Clear inherited git repository-selection state. This detector inspects the
+# REAL checkout via `git -C "${REPO_ROOT}"`, and an inherited GIT_DIR outranks
+# `-C` — so without this the detector can report on a different repository than
+# the one it names, which is a false PASS (smartwatermelon/dotfiles#239).
+#
+# No GIT_CEILING_DIRECTORIES here, unlike the fixture tests: this test must be
+# able to resolve the real repo it is auditing.
+_tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/git-env-isolation.sh
+source "${_tests_dir}/lib/git-env-isolation.sh"
+isolate_git_env
+
 REPO_ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 fail=0
@@ -148,6 +160,28 @@ fi
 unexpected_count=$(git -C "${REPO_ROOT}" remote | grep -cvx "origin" || true)
 if [[ "${unexpected_count}" -eq 0 ]]; then
   _pass "no remotes other than origin"
+fi
+
+# Case: the repo is not falsely marked bare.
+#
+# This assertion exists because a green detector run was NOT sufficient evidence
+# that the config was sound. On 2026-08-24 the four values above were cleaned,
+# this test reported ALL CHECKS PASSED, and `git status` still failed with
+# "fatal: this operation must be run in a work tree" because core.bare=true
+# remained (smartwatermelon/dotfiles#239).
+#
+# core.bare=true comes from a `git init` that ran with an inherited GIT_DIR but
+# no GIT_WORK_TREE — the linked-worktree shape specifically; pointing GIT_DIR at
+# an ordinary .git leaves bare=false. It breaks every work-tree operation:
+# status, add, commit.
+#
+# An absent key is cleanest, but an explicit `false` is equally safe, so only
+# `true` fails here.
+bare_value="$(_local_get core.bare)"
+if [[ "${bare_value}" == "true" ]]; then
+  _fail "core.bare is true, but this repo has a work tree"
+else
+  _pass "core.bare is not true"
 fi
 
 echo

--- a/bash/tests/test-git-env-isolation.sh
+++ b/bash/tests/test-git-env-isolation.sh
@@ -163,7 +163,6 @@ echo "Case: real fixture tests run clean under an inherited GIT_DIR"
 # test joins this list automatically rather than silently falling out of
 # coverage. test-git-env-isolation.sh (this file) is excluded: it invokes the
 # others, and probing itself would recurse.
-guarded_list=""
 guarded_list="$(grep -l 'isolate_git_env' "${TESTS_DIR}"/test-*.sh | sort || true)"
 self_name="${BASH_SOURCE[0]##*/}"
 guarded_tests=()

--- a/bash/tests/test-git-env-isolation.sh
+++ b/bash/tests/test-git-env-isolation.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Regression test for smartwatermelon/dotfiles#239: fixture tests must not write
+# to the caller's repository when git repository-selection state is inherited.
+#
+# WHY THIS TEST INJECTS ITS OWN FAILURE CONDITION
+#
+# Three separate investigations ran the whole suite, and every individual test,
+# from both a main checkout and a linked worktree, and found nothing. The bug
+# needs a condition none of those runs produced: an inherited GIT_DIR. Git
+# exports GIT_DIR into a hook's environment ONLY when the hook runs from a linked
+# worktree, and `.project-hooks/pre-push` execs run-tests.sh — so the suite saw
+# it in production and never under audit.
+#
+# A version of this test that merely ran the suite normally would reproduce that
+# false negative. It therefore builds a throwaway repo with a linked worktree,
+# exports GIT_DIR pointing at the worktree's administrative directory, and runs
+# the real fixture tests as subprocesses under that condition.
+#
+# WHAT MAKES THE ASSERTION MEANINGFUL
+#
+# The control case below runs the same unguarded operation WITHOUT the isolation
+# helper and requires it to contaminate. A test that only checks the guarded path
+# would pass just as happily if the injection stopped working, which is how a
+# guard rots into decoration.
+set -uo pipefail
+
+unset CDPATH
+
+TESTS_DIR="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+WORKDIR="/tmp/git-env-isolation-test-$$"
+mkdir -p "${WORKDIR}"
+trap 'chflags -R nouchg "${WORKDIR}" 2>/dev/null || true; rm -rf "${WORKDIR}"' EXIT
+
+fail=0
+_pass() { echo "  PASS: $1"; }
+_fail() {
+  echo "  FAIL: $1" >&2
+  fail=1
+}
+
+# Real git, bypassing this repo's PATH wrapper: the wrapper enforces
+# branch-protection rules that are correct for real work and wrong for a scratch
+# fixture, and it mis-parses `init -b <branch>`.
+GIT=/usr/bin/git
+
+# Build a disposable repo with a linked worktree, and echo the worktree's
+# administrative git directory — the value git would export as GIT_DIR.
+#
+# `-c core.hooksPath=` and `-c init.templateDir=` keep this machine's global
+# hooks and templates out of the fixture; without them the developer's real
+# commit-msg / pre-commit enforcement runs against scratch commits.
+make_fixture() {
+  local root="$1"
+  mkdir -p "${root}"
+  "${GIT}" -c core.hooksPath= -c init.templateDir= -C "${root}" init -q -b trunk
+  "${GIT}" -C "${root}" -c user.email=fixture@example.invalid \
+    -c user.name=Fixture -c core.hooksPath= \
+    commit -q --allow-empty -m "fixture base"
+  # The worktree lives inside the fixture, so cleanup is a single rm -rf and the
+  # sanctioned-path worktree policy is not involved.
+  "${GIT}" -C "${root}" -c core.hooksPath= worktree add -q --detach \
+    "${root}/linked" >/dev/null 2>&1
+  sed 's/^gitdir: //' "${root}/linked/.git"
+}
+
+config_fingerprint() {
+  # The COMMON config, which linked worktrees share — this is the file that was
+  # contaminated in the incident.
+  md5 -q "$1/.git/config" 2>/dev/null || echo "MISSING"
+}
+
+# --------------------------------------------------------------------------
+echo "Case: control — an unguarded fixture write DOES contaminate"
+# --------------------------------------------------------------------------
+# Establishes that the injected condition is real. If this stops contaminating,
+# every assertion below becomes vacuous and this test must fail loudly rather
+# than reporting green.
+control_root="${WORKDIR}/control"
+control_gitdir="$(make_fixture "${control_root}")"
+control_before="$(config_fingerprint "${control_root}")"
+mkdir -p "${WORKDIR}/control-scratch"
+# Run the unguarded sequence in a child with GIT_DIR set in its environment
+# only. `env VAR=x cmd` scopes the variable to that one process, which is what
+# the incident looked like, and keeps it out of this script's own environment.
+cat >"${WORKDIR}/control.sh" <<'CONTROL'
+set -u
+cd "$1" || exit 1
+/usr/bin/git -c core.hooksPath= -c init.templateDir= init -q -b main
+/usr/bin/git config core.hooksPath ""
+/usr/bin/git config user.email "test@example.com"
+CONTROL
+env GIT_DIR="${control_gitdir}" "${BASH}" "${WORKDIR}/control.sh" \
+  "${WORKDIR}/control-scratch" >/dev/null 2>&1
+control_after="$(config_fingerprint "${control_root}")"
+
+if [[ "${control_before}" == "${control_after}" ]]; then
+  _fail "control did not contaminate — the injected GIT_DIR condition is no longer reproducing, so the guarded cases below prove nothing"
+else
+  _pass "control contaminates as expected (injection is live)"
+fi
+
+# --------------------------------------------------------------------------
+echo "Case: the isolation helper contains the same write"
+# --------------------------------------------------------------------------
+guard_root="${WORKDIR}/guarded"
+guard_gitdir="$(make_fixture "${guard_root}")"
+guard_before="$(config_fingerprint "${guard_root}")"
+guard_scratch="${WORKDIR}/guarded-scratch"
+mkdir -p "${guard_scratch}"
+# Same sequence, same injected GIT_DIR, but sourcing the helper first.
+cat >"${WORKDIR}/guarded.sh" <<'GUARDED'
+set -u
+# shellcheck source=/dev/null
+source "$2"
+isolate_git_env "$1"
+cd "$1" || exit 1
+/usr/bin/git -c core.hooksPath= -c init.templateDir= init -q -b main
+/usr/bin/git config core.hooksPath ""
+/usr/bin/git config user.email "test@example.com"
+/usr/bin/git config user.name "Test"
+GUARDED
+env GIT_DIR="${guard_gitdir}" "${BASH}" "${WORKDIR}/guarded.sh" \
+  "${guard_scratch}" "${TESTS_DIR}/lib/git-env-isolation.sh" >/dev/null 2>&1
+guard_after="$(config_fingerprint "${guard_root}")"
+
+if [[ "${guard_before}" == "${guard_after}" ]]; then
+  _pass "common config byte-identical with the helper applied"
+else
+  _fail "helper did not contain the write; config changed"
+fi
+
+# The fixture values must still land SOMEWHERE — isolation that also breaks the
+# test's purpose is not a fix.
+scratch_email="$("${GIT}" -C "${guard_scratch}" config --local --get user.email 2>/dev/null || true)"
+if [[ "${scratch_email}" == "test@example.com" ]]; then
+  _pass "fixture values landed in the scratch repo, where they belong"
+else
+  _fail "scratch repo did not receive its own fixture config"
+fi
+
+# --------------------------------------------------------------------------
+echo "Case: real fixture tests run clean under an inherited GIT_DIR"
+# --------------------------------------------------------------------------
+# The end-to-end assertion: invoke the actual tests that caused the incident,
+# under the actual triggering condition, and require the shared config to be
+# untouched.
+for test_name in test-pre-push-stale-ci.sh test-gh-wrapper-identity.sh; do
+  test_path="${TESTS_DIR}/${test_name}"
+  if [[ ! -f "${test_path}" ]]; then
+    _fail "${test_name}: not found"
+    continue
+  fi
+
+  probe_root="${WORKDIR}/probe-${test_name%.sh}"
+  probe_gitdir="$(make_fixture "${probe_root}")"
+  before="$(config_fingerprint "${probe_root}")"
+  head_before="$("${GIT}" -C "${probe_root}" rev-parse HEAD 2>/dev/null || echo none)"
+
+  # Subprocess, so the test's own `set -e` and traps stay contained.
+  GIT_DIR="${probe_gitdir}" "${BASH}" "${test_path}" >/dev/null 2>&1
+  test_status=$?
+
+  after="$(config_fingerprint "${probe_root}")"
+  head_after="$("${GIT}" -C "${probe_root}" rev-parse HEAD 2>/dev/null || echo none)"
+
+  if [[ "${before}" == "${after}" ]]; then
+    _pass "${test_name}: shared config unchanged"
+  else
+    _fail "${test_name}: shared config was modified"
+    "${GIT}" -C "${probe_root}" config --local --list 2>/dev/null | sed 's/^/      /' >&2
+  fi
+
+  # core.bare=true is the contaminant the old detector missed entirely.
+  probe_bare="$("${GIT}" -C "${probe_root}" config --local --get core.bare 2>/dev/null || true)"
+  if [[ "${probe_bare}" == "true" ]]; then
+    _fail "${test_name}: set core.bare=true on the fixture repo"
+  else
+    _pass "${test_name}: core.bare not set to true"
+  fi
+
+  if "${GIT}" -C "${probe_root}" remote 2>/dev/null | grep -qx upstream; then
+    _fail "${test_name}: added an 'upstream' remote to the fixture repo"
+  else
+    _pass "${test_name}: no stray upstream remote"
+  fi
+
+  # The incident also left fixture commits in the worktree's reflog and detached
+  # its HEAD.
+  if [[ "${head_before}" == "${head_after}" ]]; then
+    _pass "${test_name}: fixture HEAD unchanged"
+  else
+    _fail "${test_name}: moved the fixture repo's HEAD (${head_before} -> ${head_after})"
+  fi
+
+  # The test must still pass under isolation — a guard that breaks the test it
+  # protects has traded one failure for another.
+  if [[ "${test_status}" -eq 0 ]]; then
+    _pass "${test_name}: still passes with GIT_DIR inherited"
+  else
+    _fail "${test_name}: failed (exit ${test_status}) under an inherited GIT_DIR"
+  fi
+done
+
+echo
+if [[ "${fail}" -eq 0 ]]; then
+  echo "ALL CHECKS PASSED"
+  exit 0
+fi
+echo "FAILURES PRESENT" >&2
+exit 1

--- a/bash/tests/test-git-env-isolation.sh
+++ b/bash/tests/test-git-env-isolation.sh
@@ -61,7 +61,16 @@ make_fixture() {
   # sanctioned-path worktree policy is not involved.
   "${GIT}" -C "${root}" -c core.hooksPath= worktree add -q --detach \
     "${root}/linked" >/dev/null 2>&1
-  sed 's/^gitdir: //' "${root}/linked/.git"
+  # A linked worktree's .git is a file reading `gitdir: <admin dir>`. Parse it
+  # strictly: a malformed file would otherwise yield a wrong path and cascade
+  # into a confusing assertion failure somewhere else entirely.
+  local admin_dir
+  admin_dir="$(sed -n 's/^gitdir: //p' "${root}/linked/.git")"
+  if [[ -z "${admin_dir}" || ! -d "${admin_dir}" ]]; then
+    echo "make_fixture: could not resolve worktree admin dir from ${root}/linked/.git" >&2
+    return 1
+  fi
+  printf '%s\n' "${admin_dir}"
 }
 
 config_fingerprint() {

--- a/bash/tests/test-git-env-isolation.sh
+++ b/bash/tests/test-git-env-isolation.sh
@@ -154,7 +154,30 @@ echo "Case: real fixture tests run clean under an inherited GIT_DIR"
 # The end-to-end assertion: invoke the actual tests that caused the incident,
 # under the actual triggering condition, and require the shared config to be
 # untouched.
-for test_name in test-pre-push-stale-ci.sh test-gh-wrapper-identity.sh; do
+# Every test that creates or mutates a git fixture, not only the two that were
+# the incident's confirmed sources. A guard that regresses in any of them
+# reintroduces the same failure, and the runner-level clear in run-tests.sh does
+# not protect a test invoked directly.
+#
+# Derived from the tests that source the isolation helper, so a newly guarded
+# test joins this list automatically rather than silently falling out of
+# coverage. test-git-env-isolation.sh (this file) is excluded: it invokes the
+# others, and probing itself would recurse.
+guarded_list=""
+guarded_list="$(grep -l 'isolate_git_env' "${TESTS_DIR}"/test-*.sh | sort || true)"
+self_name="${BASH_SOURCE[0]##*/}"
+guarded_tests=()
+while IFS= read -r candidate; do
+  [[ -n "${candidate}" ]] || continue
+  [[ "${candidate##*/}" == "${self_name}" ]] && continue
+  guarded_tests+=("${candidate##*/}")
+done <<<"${guarded_list}"
+
+if ((${#guarded_tests[@]} == 0)); then
+  _fail "no guarded tests discovered — the probe set is empty, so the loop below proves nothing"
+fi
+
+for test_name in "${guarded_tests[@]}"; do
   test_path="${TESTS_DIR}/${test_name}"
   if [[ ! -f "${test_path}" ]]; then
     _fail "${test_name}: not found"

--- a/bash/tests/test-git-wrapper-init-hook.sh
+++ b/bash/tests/test-git-wrapper-init-hook.sh
@@ -21,10 +21,20 @@ WORKDIR="/tmp/git-wrapper-init-hook-test-$$"
 mkdir -p "${WORKDIR}"
 trap 'rm -rf "${WORKDIR}"' EXIT
 
+# Clear inherited git repository-selection state before touching any fixture.
+# A hook invoked from a linked worktree exports GIT_DIR, which outranks both the
+# working directory and `git -C`, so without this the scratch repos below are
+# silently redirected at the real checkout (smartwatermelon/dotfiles#239).
+_tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/git-env-isolation.sh
+source "${_tests_dir}/lib/git-env-isolation.sh"
+isolate_git_env "${WORKDIR}"
+
 # Reset the wrapper guard to ensure clean test environment
 unset _GIT_WRAPPER_ACTIVE
 # Isolate test repos from any ambient git context
-export GIT_CEILING_DIRECTORIES="${WORKDIR}"
+# GIT_CEILING_DIRECTORIES is set by isolate_git_env above, which receives
+# WORKDIR as its ceiling argument.
 
 # Disable the global init.templateDir for every `git init` this test runs.
 # On a machine with init.templateDir configured (this repo's own install.sh

--- a/bash/tests/test-gpush-wrapper-guard.sh
+++ b/bash/tests/test-gpush-wrapper-guard.sh
@@ -11,6 +11,15 @@ set -uo pipefail
 unset CDPATH
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Clear inherited git repository-selection state before touching any fixture.
+# A hook invoked from a linked worktree exports GIT_DIR, which outranks both the
+# working directory and `git -C`, so without this the scratch repos below are
+# silently redirected at the real checkout (smartwatermelon/dotfiles#239).
+_tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/git-env-isolation.sh
+source "${_tests_dir}/lib/git-env-isolation.sh"
+isolate_git_env
+
 export BASH_CONFIG_DIR="${REPO_ROOT}/bash"
 
 #shellcheck source=/dev/null

--- a/bash/tests/test-post-checkout-gitignore.sh
+++ b/bash/tests/test-post-checkout-gitignore.sh
@@ -39,13 +39,23 @@ WORKDIR="/tmp/post-checkout-gitignore-test-$$"
 mkdir -p "${WORKDIR}"
 trap 'rm -rf "${WORKDIR}"' EXIT
 
-export GIT_CEILING_DIRECTORIES="${WORKDIR}"
-
 # Inherited git environment variables would silently redirect every git call
 # below at the ambient repo instead of the scratch fixtures -- GIT_INDEX_FILE
 # in particular makes `git ls-files` report the caller's staged paths, which
 # fires the already-tracked guard in repos that track nothing.
-unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE GIT_OBJECT_DIRECTORY
+#
+# This test's hand-rolled unset list predates the shared helper and was the
+# precedent for it (smartwatermelon/dotfiles#239). It now delegates, so the list
+# is maintained in one place and derived from `git rev-parse --local-env-vars`
+# rather than hardcoded here.
+_tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/git-env-isolation.sh
+source "${_tests_dir}/lib/git-env-isolation.sh"
+isolate_git_env "${WORKDIR}"
+
+# GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM are NOT repository-selection variables,
+# so the helper deliberately leaves them alone. This test wants them gone as
+# well, to keep the developer's real ~/.gitconfig out of the fixtures.
 unset GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM
 
 # Minimal stand-in for git/template/.claude-template, so the test never

--- a/bash/tests/test-post-checkout-hookspath.sh
+++ b/bash/tests/test-post-checkout-hookspath.sh
@@ -25,6 +25,15 @@ WORKDIR="/tmp/post-checkout-hookspath-test-$$"
 mkdir -p "${WORKDIR}"
 trap 'rm -rf "${WORKDIR}"' EXIT
 
+# Clear inherited git repository-selection state before touching any fixture.
+# A hook invoked from a linked worktree exports GIT_DIR, which outranks both the
+# working directory and `git -C`, so without this the scratch repos below are
+# silently redirected at the real checkout (smartwatermelon/dotfiles#239).
+_tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/git-env-isolation.sh
+source "${_tests_dir}/lib/git-env-isolation.sh"
+isolate_git_env "${WORKDIR}"
+
 fail=0
 
 # --- Case 1: delegate execs the canonical hook with args intact -----------

--- a/bash/tests/test-pre-push-stale-ci.sh
+++ b/bash/tests/test-pre-push-stale-ci.sh
@@ -30,6 +30,15 @@ WORKDIR="/tmp/pre-push-stale-ci-test-$$"
 mkdir -p "${WORKDIR}"
 trap 'rm -rf "${WORKDIR}"' EXIT
 
+# Clear inherited git repository-selection state before touching any fixture.
+# A hook invoked from a linked worktree exports GIT_DIR, which outranks both the
+# working directory and `git -C`, so without this the scratch repos below are
+# silently redirected at the real checkout (smartwatermelon/dotfiles#239).
+_tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/git-env-isolation.sh
+source "${_tests_dir}/lib/git-env-isolation.sh"
+isolate_git_env "${WORKDIR}"
+
 # Isolate from this machine's global git hooks/templates (this repo sets
 # core.hooksPath / init.templateDir globally) — scratch test repos must not
 # inherit real commit-msg / pre-commit enforcement.


### PR DESCRIPTION
Fixes the `.git/config` contamination in #239. Root cause identified and
reproduced end to end; this is a fix, not another detector.

## Root cause

Git exports `GIT_DIR` into a hook's environment when — and only when — the hook
runs from a **linked worktree**. `.project-hooks/pre-push` execs
`bash/tests/run-tests.sh`, so every test inherited it. `GIT_DIR` outranks both
the process working directory **and** `git -C`:

```
GIT_DIR=/elsewhere/.git git -C /tmp/scratch config user.email x@y.z
  -> writes to /elsewhere/.git/config, not /tmp/scratch
```

So fixture writes landed in the worktree's administrative git directory, and
linked worktrees share the common config — contaminating the real checkout with
`core.hooksPath=` (empty), `core.bare=true`, `user.email=test@example.com`,
`user.name=Test`, and the `beacon-biosignals/forked-tool` upstream remote.

Empty `core.hooksPath` is the consequential one: git resolves it to `./`, so
every hook silently stops firing and Protocol 4's automatic review stops with
it — including the pre-push detector that would have reported the
contamination. The bug conceals itself.

**Why three investigations found nothing:** a test run by hand has no hook,
therefore no `GIT_DIR`, therefore no contamination. Only a hook-invoked run from
a worktree reproduces it. Every prior audit ran tests directly or from a normal
checkout.

**Why it appeared when it did.** The defect was latent in the tests since
2026-08-06 and 2026-08-13, but unreachable until two changes landed:
`#350` (2026-08-19) allowed path-scoped worktree creation, and `#230`
(2026-08-24) wired the suite into pre-push. Neither alone is sufficient — before
`#230` the suite ran only when invoked directly, which never sets `GIT_DIR`. The
first contamination followed `#230` by hours.

## Changes

**`bash/tests/lib/git-env-isolation.sh`** (new) — derives its unset list from
`git rev-parse --local-env-vars` rather than hardcoding one, unioned with a
fallback for older git, plus the `GIT_CONFIG_KEY_*`/`VALUE_*` family. Sets
`GIT_CEILING_DIRECTORIES` so a bare git call cannot walk *up* into the real repo
either. Deliberately leaves `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` alone —
those are not repository-selection variables, and several tests set them on
purpose to sandbox a global config.

**Applied to all 8 git-mutating tests**, and `test-post-checkout-gitignore.sh`
migrated from its hand-rolled unset list (the precedent for the helper) so the
list lives in one place.

**`run-tests.sh` isolates too** — the primary chokepoint, not defense in depth,
since the hook that invokes the runner is the exporter. Per-test isolation still
matters for a test run directly.

**`core.bare` assertion** added to `test-git-config-hygiene.sh`. On 2026-08-24
the four known values were cleaned, the detector reported ALL CHECKS PASSED, and
`git status` still failed because `core.bare=true` remained. A green detector
was not a clean bill of health.

**`bash/tests/test-git-env-isolation.sh`** (new) — injects the real condition
(linked worktree + inherited `GIT_DIR`) and keeps a **control case that must
contaminate**, so the guarded assertions cannot pass vacuously if the injection
ever stops reproducing. Its probe set is derived by grepping for the helper, so
a newly guarded test joins coverage automatically.

## Verification

- Full suite: **14/14**
- Suite run from a **linked worktree**: `.git/config` byte-identical before and
  after
- Detector passes on the real repo, including the new `core.bare` check
- `shellcheck -S info` clean on every changed file, **no `disable` directives**
- Pre-push codebase review dry-run: PASS (its two non-blocking findings are
  fixed in this branch, not deferred)

The regression test caught a real bug in this branch's own first draft: three
tests referenced `${WORKDIR}` as the isolation ceiling before it was assigned.
Standalone runs tolerated it; under the injected condition they failed with
`unbound variable`.

## Follow-ups, not in this PR

- **#251** — `run-tests.sh` hangs from a linked worktree because the pre-push
  hook's Semgrep scan blocks. Pre-existing and unrelated; verified against
  pristine `main` copies of the runner and test, which hang identically. It
  blocks #239 verification criterion 2 (full suite from a worktree); every test
  up to the hanging one passes and the config stays byte-identical, so the
  substantive half is met.
- **The `chflags uchg` tripwire on `.git/config` stays armed** until this
  merges. Lifting it is a deliberate separate step. It fired during the push for
  this PR — blocking git's branch-tracking config write — which is it working as
  designed.

Closes #239

https://claude.ai/code/session_01Pq2ERcYCFL887LU8nmYFWf
