### PR TITLE
fix(tests): stop gpush guard temp-file leak; correct post-checkout init claim

### DIFF
--- a/bash/tests/test-gpush-wrapper-guard.sh
+++ b/bash/tests/test-gpush-wrapper-guard.sh
@@ -42,30 +42,35 @@ assert_fails() {
 # Case 1: unknown flag rejected
 assert_fails "gpush --bogus-flag rejected" gpush --bogus-flag
 
-# Case 3: refuses to run on main — use real git repo and real main branch
+# Case 2: refuses to run on main — use real git repo and real main branch
 WORKDIR="/tmp/gpush-wrapper-guard-test-$$"
 mkdir -p "${WORKDIR}"
 trap 'rm -rf "${WORKDIR}"' EXIT
 (cd "${WORKDIR}" && /usr/bin/git init -q -b main && /usr/bin/git commit -q --allow-empty -m init)
 
+# The capture file lives INSIDE WORKDIR rather than in /tmp under its own
+# "$$". The subshell below expands "$$" to the SUBSHELL's pid, so a /tmp path
+# built there could never be named by the outer shell's cleanup — that
+# mismatch leaked a file per run. Keeping it under WORKDIR means the existing
+# EXIT trap removes it, whatever pid produced it.
+main_out_file="${WORKDIR}/gpush-main-output"
+
 main_test_output=$(/bin/bash -c '
   cd "'"${WORKDIR}"'" || exit 1
+  out_file="'"${main_out_file}"'"
   #shellcheck source=/dev/null
   source "'"${BASH_CONFIG_DIR}"'/gpush-wrapper.sh"
-  if gpush >/tmp/gpush-test-main-$$ 2>&1; then
+  if gpush >"${out_file}" 2>&1; then
     echo "FAIL: gpush on main branch — expected non-zero exit, got 0"
     exit 1
-  else
-    if grep -q "Refusing to run on main" /tmp/gpush-test-main-$$; then
-      echo "PASS: gpush on main branch refuses with expected message"
-      exit 0
-    else
-      echo "FAIL: gpush on main branch — wrong error message"
-      cat /tmp/gpush-test-main-$$
-      exit 1
-    fi
   fi
-  rm -f "/tmp/gpush-test-main-$$"
+  if grep -q "Refusing to run on main" "${out_file}"; then
+    echo "PASS: gpush on main branch refuses with expected message"
+    exit 0
+  fi
+  echo "FAIL: gpush on main branch — wrong error message"
+  cat "${out_file}"
+  exit 1
 ' 2>&1)
 
 main_exit=$?
@@ -73,9 +78,8 @@ echo "${main_test_output}"
 if [[ ${main_exit} -ne 0 ]]; then
   fail=1
 fi
-rm -f "/tmp/gpush-test-main-$$"
 
-# Case 4: refuses to run on detached HEAD — use real git repo and real detached HEAD
+# Case 3: refuses to run on detached HEAD — use real git repo and real detached HEAD
 # Use a separate temp directory to avoid interference from main repo's git wrappers
 detached_test_output=$(/bin/bash -c '
   tmpwork=$(mktemp -d)

--- a/bash/tests/test-gpush-wrapper-guard.sh
+++ b/bash/tests/test-gpush-wrapper-guard.sh
@@ -30,13 +30,18 @@ fail=0
 assert_fails() {
   local desc="$1"
   shift
-  if "$@" >/tmp/gpush-test-out-$$ 2>&1; then
+  local out_file
+  out_file="$(mktemp "${TMPDIR:-/tmp}/gpush-test-out.XXXXXX")"
+  if "$@" >"${out_file}" 2>&1; then
     echo "FAIL: ${desc} — expected non-zero exit, got 0"
+    # Print what the command actually emitted; without this the diagnostic
+    # for an unexpected success is silently dropped.
+    sed 's/^/    /' "${out_file}"
     fail=1
   else
     echo "PASS: ${desc}"
   fi
-  rm -f "/tmp/gpush-test-out-$$"
+  rm -f "${out_file}"
 }
 
 # Case 1: unknown flag rejected

--- a/git/template/hooks/post-checkout
+++ b/git/template/hooks/post-checkout
@@ -3,23 +3,35 @@
 # Creates .claude/ infrastructure in new repositories
 #
 # This hook runs after:
-# - git init (if template configured)
-# - git clone (always)
-# - git checkout (when switching branches)
+# - git clone (always — during clone's internal initial checkout)
+# - git checkout / git checkout -b (when switching branches)
+# - git init, but ONLY via bash/git-wrapper.sh (see below)
+#
+# On `git init`, git itself never fires post-checkout: init performs no
+# checkout, and init.templateDir only COPIES this file into .git/hooks/. Under
+# a bare `/usr/bin/git init` the hook is installed but never runs. This repo
+# closes that gap in bash/git-wrapper.sh, which — after a successful `git
+# init` — invokes .git/hooks/post-checkout directly by path with synthesized
+# arguments: null prev/new SHAs and branch_checkout=1.
+#
+# So an init-time code path here is reachable, but only through the wrapper,
+# and only with those synthesized values. It is NOT reachable when git is
+# called by absolute path or from a shell without the wrapper.
 #
 # We only want to run on initial checkout, not on every branch switch.
 
 set -euo pipefail
 
 # Hook parameters from git
-_prev_head=$1 # Null SHA on clone/init; a real commit on a branch switch
-_new_head=$2  # Unused - we only care about branch_checkout
+# _prev_head: null SHA on clone's initial checkout and on the wrapper's
+# synthesized init call; a real commit on a branch switch.
+_prev_head=$1
+_new_head=$2 # Unused - we only care about branch_checkout
 branch_checkout=$3
 
-# Only run on initial checkout (git init or git clone)
-# branch_checkout == 1 means checking out a branch (not just updating files)
-# For git init, prev_head is all zeros (0000000...)
-# For git clone, this runs on the initial checkout
+# Only run on a branch checkout: clone's initial checkout, a branch switch, or
+# the init call synthesized by bash/git-wrapper.sh.
+# branch_checkout == 1 means checking out a branch (not just updating files).
 if [[ "${branch_checkout}" != "1" ]]; then
   exit 0
 fi


### PR DESCRIPTION
Two commits from 2026-08-24 that were reviewed and finished but never pushed —
the session that wrote them was the one that hit the #239 contamination.
Rebased onto current `main`; no conflicts with #253's isolation work.

## `ded7224` → three fixes from the recovered review batch (#247)

**Temp-file leak in `test-gpush-wrapper-guard.sh`.** The Case 2 subshell wrote
to `/tmp/gpush-test-main-$$`, where `$$` sat inside a single-quoted `bash -c`
string — so it expanded to the *subshell's* pid at runtime. The outer shell's
cleanup expanded `$$` to its *own* pid, naming a file that never existed. The
in-subshell `rm` was unreachable as well, placed after every `exit` branch. One
leaked file per run. Fixed by moving the capture inside `WORKDIR`, which already
has an EXIT trap, so cleanup no longer depends on two shells agreeing about a
pid.

**Case renumbering.** Cases ran 1, 3, 4, implying a Case 2 that was never
written. Renumbered contiguously rather than inventing one — the obvious
candidate (rejecting extra positional args) would pass for the wrong reason,
since `gpush` only inspects `$1`.

**Corrected a false comment in `git/template/hooks/post-checkout`.** The header
claimed the hook "runs after git init (if template configured)". Plain git does
no such thing: `init` performs no checkout, and `init.templateDir` only copies
the file into `.git/hooks/`. Rather than deleting the comment, the commit
established the fuller picture: `bash/git-wrapper.sh` invokes the hook by path
after a successful init with synthesized null SHAs, so an init-time path *is*
reachable — but only through the wrapper. The comment now states both halves,
so a maintainer neither adds a path believing plain init fires it nor deletes
one believing it can never run.

## `1317438` → evidence on failure

When `gpush` exits 0 in a case expecting refusal, the helper printed only
`expected non-zero exit, got 0` and discarded the captured output — the one
piece of evidence showing why the guard did not fire. It now prints it. Also
replaces a fixed `/tmp/gpush-test-out-$$` path with `mktemp`, same leak class as
above.

## Verification

- Full suite: **14/14** after rebase
- Leak fix verified empirically: 13 stale `/tmp/gpush-test-*` files from the old
  bug, **zero new ones** after a full run
- `shellcheck -S info` clean on both changed files
- Pre-push codebase review dry-run: PASS

No behavior change in either file.

## Found while verifying, filed rather than fixed here

**Case 3 (detached HEAD) passes for the wrong reason.** It has no hook
isolation, so its `git commit` calls are subject to the machine's global
`core.hooksPath`. On a machine whose global pre-commit blocks commits to `main`
— which this repo's own install configures — no commit is created,
`git rev-list --max-parents=0 HEAD` returns empty, and
`git checkout --detach ""` fails with `fatal: empty string is not a valid
pathspec`. HEAD stays on `main`, and `gpush` refuses with "Refusing to run on
main" rather than the detached-HEAD message the case is testing for. The grep is
loose enough that the case still reports PASS.

Out of scope for this rebase, and it wants the same `-c core.hooksPath=` /
`-c init.templateDir=` treatment the other fixture tests use. Filing separately
rather than expanding this PR.

Advances #247

https://claude.ai/code/session_01Pq2ERcYCFL887LU8nmYFWf
