### PR TITLE
fix: linked-worktree support, bounded Semgrep scan, and tests that passed without testing anything

### DIFF
--- a/bash/tests/test-git-env-isolation.sh
+++ b/bash/tests/test-git-env-isolation.sh
@@ -76,7 +76,23 @@ make_fixture() {
 config_fingerprint() {
   # The COMMON config, which linked worktrees share — this is the file that was
   # contaminated in the incident.
-  md5 -q "$1/.git/config" 2>/dev/null || echo "MISSING"
+  #
+  # `md5` is macOS-only. On a runner without it every call returned the literal
+  # "MISSING", which compares equal to itself — so before == after always held,
+  # the control assertion ("an unguarded write DOES contaminate") always failed,
+  # and the test aborted with a misleading error instead of testing anything
+  # (smartwatermelon/dotfiles#252). CI is macos-latest today, so this has not
+  # bitten yet; it would the moment a ubuntu runner is added.
+  #
+  # cksum is POSIX and present on both platforms. A missing or unreadable file
+  # must NOT collapse to a constant, or the vacuous-comparison bug returns, so
+  # the failure branch emits a value unique to that path and file.
+  local config="$1/.git/config"
+  if [[ ! -r "${config}" ]]; then
+    printf 'UNREADABLE:%s\n' "${config}"
+    return 0
+  fi
+  cksum <"${config}"
 }
 
 # --------------------------------------------------------------------------

--- a/bash/tests/test-git-wrapper-init-hook.sh
+++ b/bash/tests/test-git-wrapper-init-hook.sh
@@ -47,6 +47,26 @@ unset _GIT_WRAPPER_ACTIVE
 # write through that symlink and clobber the real repo file instead of the
 # scratch fixture. Confirmed by direct reproduction: prior to this fix,
 # every run of this test corrupted git/template/hooks/post-checkout.
+#
+# GIT_CONFIG_COUNT/KEY_N/VALUE_N arrived in git 2.31 (March 2021). An older git
+# IGNORES them silently — the override would not apply, template hooks would be
+# symlinked in, and the `cat >` clobber described above would return, corrupting
+# a tracked repo file while the test still reported green. Fail loudly instead
+# of degrading into that (smartwatermelon/dotfiles#247).
+# `command git`, not bare `git`: this file's whole subject is the git wrapper,
+# and the version must come from the real binary regardless of whether a
+# wrapper function is in scope.
+_git_version="$(command git --version | awk '{print $3}')"
+_git_major="${_git_version%%.*}"
+_git_rest="${_git_version#*.}"
+_git_minor="${_git_rest%%.*}"
+if ((_git_major < 2 || (_git_major == 2 && _git_minor < 31))); then
+  echo "FAIL: git ${_git_version} is too old for this test (needs 2.31+)." >&2
+  echo "      GIT_CONFIG_COUNT is ignored before 2.31, which would let this" >&2
+  echo "      test clobber git/template/hooks/post-checkout in the real repo." >&2
+  exit 1
+fi
+
 export GIT_CONFIG_COUNT=1
 export GIT_CONFIG_KEY_0="init.templateDir"
 export GIT_CONFIG_VALUE_0=""

--- a/bash/tests/test-gpush-wrapper-guard.sh
+++ b/bash/tests/test-gpush-wrapper-guard.sh
@@ -31,7 +31,14 @@ assert_fails() {
   local desc="$1"
   shift
   local out_file
-  out_file="$(mktemp "${TMPDIR:-/tmp}/gpush-test-out.XXXXXX")"
+  # A failed mktemp would leave out_file empty, redirecting the diagnostic to a
+  # file named "" and silently discarding the output this helper exists to
+  # capture (smartwatermelon/dotfiles#250).
+  if ! out_file="$(mktemp "${TMPDIR:-/tmp}/gpush-test-out.XXXXXX")" || [[ -z "${out_file}" ]]; then
+    echo "FAIL: ${desc} — mktemp failed, cannot capture output" >&2
+    fail=1
+    return 1
+  fi
   if "$@" >"${out_file}" 2>&1; then
     echo "FAIL: ${desc} — expected non-zero exit, got 0"
     # Print what the command actually emitted; without this the diagnostic
@@ -51,7 +58,36 @@ assert_fails "gpush --bogus-flag rejected" gpush --bogus-flag
 WORKDIR="/tmp/gpush-wrapper-guard-test-$$"
 mkdir -p "${WORKDIR}"
 trap 'rm -rf "${WORKDIR}"' EXIT
-(cd "${WORKDIR}" && /usr/bin/git init -q -b main && /usr/bin/git commit -q --allow-empty -m init)
+# Isolated from this machine ambient hooks/templates for the same reason as
+# Case 3 below: the global pre-commit hook this repo installs blocks commits to
+# main, so an unisolated fixture silently ends up with no commits at all
+# (smartwatermelon/dotfiles#256).
+(
+  cd "${WORKDIR}" || exit 1
+  /usr/bin/git -c core.hooksPath= -c init.templateDir= init -q -b main
+  # An EMPTY core.hooksPath, not `--unset`. Verified empirically: with
+  # core.hooksPath="" git runs no hooks at all — neither the global ones nor a
+  # local .git/hooks/pre-commit that exits non-zero. `--unset` would instead
+  # fall back to the global core.hooksPath this repo installs, reintroducing
+  # the very blocking hook the fixture needs neutralized. The `-c` above covers
+  # only the init call, so the value is persisted here for later commands.
+  /usr/bin/git config core.hooksPath ""
+  /usr/bin/git -c user.email=test@example.com -c user.name=Test \
+    commit -q --allow-empty -m init
+)
+
+# Assert the fixture actually reached the state under test, rather than
+# assuming it. Case 2 refuses on main whether or not a commit exists, so
+# without this the case could keep passing over an empty repository.
+if ! /usr/bin/git -C "${WORKDIR}" rev-parse --verify -q HEAD >/dev/null; then
+  echo "FAIL: Case 2 fixture produced no commit — nothing was tested"
+  exit 1
+fi
+case2_branch="$(/usr/bin/git -C "${WORKDIR}" symbolic-ref --short HEAD)" || case2_branch=""
+if [[ "${case2_branch}" != "main" ]]; then
+  echo "FAIL: Case 2 fixture is not on main — nothing was tested"
+  exit 1
+fi
 
 # The capture file lives INSIDE WORKDIR rather than in /tmp under its own
 # "$$". The subshell below expands "$$" to the SUBSHELL's pid, so a /tmp path
@@ -85,24 +121,61 @@ if [[ ${main_exit} -ne 0 ]]; then
 fi
 
 # Case 3: refuses to run on detached HEAD — use real git repo and real detached HEAD
-# Use a separate temp directory to avoid interference from main repo's git wrappers
+#
+# This case previously reported PASS while testing nothing
+# (smartwatermelon/dotfiles#256). Three separate defects stacked up:
+#
+#   1. No hook isolation. This repo's install.sh sets a GLOBAL core.hooksPath
+#      whose pre-commit hook blocks commits to main, so the fixture's `commit`
+#      was refused, `rev-list` found no HEAD, and the detach never happened.
+#   2. `trap ... RETURN` in a `bash -c` top level (not a function) never fires,
+#      so the temp dir leaked — the same class as the Case 2 leak fixed in #255.
+#   3. The assertion could not tell a real detached HEAD from a fake one. After
+#      sourcing gpush-wrapper.sh, a bare `git` resolves to this repo's git
+#      WRAPPER, not /usr/bin/git. The wrapper left `git symbolic-ref` returning
+#      empty, so gpush printed "Refusing to run on detached HEAD" while HEAD was
+#      still on main — and the grep matched. The case passed on a message that
+#      described a state the fixture had never reached.
+#
+# The fixture is therefore isolated from ambient hooks/templates, and the
+# preconditions are ASSERTED rather than assumed: a test for detached-HEAD
+# behavior must confirm the HEAD is actually detached before asserting on the
+# message, or it is only testing its own string matching.
 detached_test_output=$(/bin/bash -c '
-  tmpwork=$(mktemp -d)
+  tmpwork=$(mktemp -d) || exit 1
   cd "${tmpwork}" || exit 1
-  trap "rm -rf ${tmpwork}" RETURN
+  # EXIT, not RETURN: this is a script top level, not a function, so a RETURN
+  # trap never fires and the directory leaks.
+  trap "rm -rf \"${tmpwork}\"" EXIT
 
-  # Use /usr/bin/git to bypass any wrapper functions
-  /usr/bin/git init -q -b main
-  /usr/bin/git commit -q --allow-empty -m "init"
+  # Neutralize this machine ambient git hooks and templates. Without this the
+  # global pre-commit hook refuses the commit below and the whole fixture
+  # collapses silently.
+  git_isolated() {
+    /usr/bin/git -c core.hooksPath= -c init.templateDir= \
+      -c user.email=test@example.com -c user.name=Test "$@"
+  }
 
-  # Get the SHA of the first commit
-  first_commit=$(/usr/bin/git rev-list --max-parents=0 HEAD)
+  git_isolated init -q -b main
+  git_isolated config core.hooksPath ""
+  git_isolated commit -q --allow-empty -m "init"
 
-  # Create a second commit
-  /usr/bin/git commit -q --allow-empty -m "second"
+  first_commit=$(git_isolated rev-list --max-parents=0 HEAD)
+  if [[ -z "${first_commit}" ]]; then
+    echo "FAIL: fixture produced no commit — nothing was tested"
+    exit 1
+  fi
 
-  # Checkout the first commit to create real detached HEAD
-  /usr/bin/git checkout -q --detach "${first_commit}"
+  git_isolated commit -q --allow-empty -m "second"
+  git_isolated checkout -q --detach "${first_commit}"
+
+  # The substantive precondition. Assert against /usr/bin/git explicitly: a
+  # bare `git` would resolve to this repo git wrapper once gpush-wrapper.sh is
+  # sourced below, and the wrapper is exactly what faked this state before.
+  if /usr/bin/git symbolic-ref -q HEAD >/dev/null 2>&1; then
+    echo "FAIL: HEAD is not detached — the fixture never reached the state under test"
+    exit 1
+  fi
 
   #shellcheck source=/dev/null
   source "'"${BASH_CONFIG_DIR}"'/gpush-wrapper.sh"

--- a/bash/tests/test-install-worktree-guard.sh
+++ b/bash/tests/test-install-worktree-guard.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#shellcheck shell=bash
+# Standalone verification that install.sh's repository guard accepts a linked
+# worktree. Run directly: bash bash/tests/test-install-worktree-guard.sh
+#
+# A linked worktree's `.git` is a FILE containing a `gitdir:` pointer, not a
+# directory. install.sh originally tested `[[ -d "${REPO_DIR}/.git" ]]`, which
+# is false for that file, so a legitimate worktree was rejected as "not a git
+# repository" (smartwatermelon/dotfiles#254). The failure was invisible from
+# the main checkout, which is where the suite is normally run and where CI
+# runs — this test closes that blind spot by exercising the worktree case
+# directly.
+#
+# The guard is tested in isolation rather than by running install.sh itself:
+# install.sh performs real symlink deployment into ${HOME}, which a test must
+# never trigger. The guard's source line is extracted and evaluated against
+# both repository shapes.
+set -euo pipefail
+unset CDPATH
+
+REPO_ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Clear inherited git repository-selection state before touching any fixture.
+# A hook invoked from a linked worktree exports GIT_DIR, which outranks both
+# the working directory and `git -C` (smartwatermelon/dotfiles#239).
+_tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/git-env-isolation.sh
+source "${_tests_dir}/lib/git-env-isolation.sh"
+isolate_git_env
+
+fail=0
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/install-worktree-test.XXXXXX")"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+_pass() { echo "  PASS: $1"; }
+_fail() {
+  echo "  FAIL: $1" >&2
+  fail=1
+}
+
+# ---------------------------------------------------------------
+# Case 1: the guard in install.sh resolves both repository shapes
+# ---------------------------------------------------------------
+echo "Case: install.sh repository guard accepts both repo shapes"
+
+# Extract the guard's condition rather than restating it here. A hand-copied
+# duplicate would keep passing after install.sh regressed, which is exactly
+# the failure mode this test exists to catch.
+# Match the guard as CODE, not as any line mentioning it. The explanatory
+# comment above the guard also contains "rev-parse --git-dir", so an unanchored
+# grep reported the guard present even after it had been reverted to the
+# broken `-d` form — the check was matching its own documentation. Anchoring
+# on the `if !` opener excludes comment lines, whose first non-blank character
+# is always "#".
+guard_line="$(grep -nE '^[[:space:]]*if ! git -C .* rev-parse --git-dir' "${REPO_ROOT}/install.sh" | head -1)"
+if [[ -z "${guard_line}" ]]; then
+  _fail "install.sh no longer guards with 'git rev-parse --git-dir'"
+  echo "        A '[[ -d .git ]]' style guard rejects linked worktrees (#254)." >&2
+  echo "SOME CHECKS FAILED" >&2
+  exit 1
+fi
+_pass "install.sh guards with 'git rev-parse --git-dir'"
+
+# Assert the -d form is gone, so a regression cannot reintroduce it alongside.
+# The pattern is assembled from a variable rather than written as a
+# single-quoted literal containing a dollar sign, which shellcheck reads as an
+# unexpanded expression (SC2016) even when a literal is what is wanted.
+dollar='$'
+legacy_guard="! -d \"${dollar}{REPO_DIR}/.git\""
+if grep -qF "${legacy_guard}" "${REPO_ROOT}/install.sh"; then
+  _fail "install.sh still contains the '-d .git' guard that rejects worktrees"
+fi
+
+# ---------------------------------------------------------------
+# Case 2: the guard's behavior on a real worktree vs a real checkout
+# ---------------------------------------------------------------
+echo "Case: guard condition evaluated against real repositories"
+
+# A normal checkout.
+MAIN_REPO="${WORKDIR}/main"
+mkdir -p "${MAIN_REPO}"
+(
+  cd "${MAIN_REPO}" || exit 1
+  /usr/bin/git -c core.hooksPath= -c init.templateDir= init -q -b main
+  /usr/bin/git config core.hooksPath ""
+  /usr/bin/git -c core.hooksPath= -c user.email=test@example.com -c user.name=Test \
+    commit -q --allow-empty -m "test: init"
+)
+
+# A linked worktree off it.
+LINKED="${WORKDIR}/linked"
+(
+  cd "${MAIN_REPO}" || exit 1
+  /usr/bin/git -c core.hooksPath= worktree add -q --detach "${LINKED}" >/dev/null 2>&1
+)
+
+# Precondition: the fixture must actually produce the shape under test.
+# Without this the case could pass while testing nothing (#256 class).
+if [[ ! -e "${LINKED}/.git" ]]; then
+  _fail "fixture produced no linked worktree — nothing was tested"
+  echo "SOME CHECKS FAILED" >&2
+  exit 1
+fi
+if [[ -d "${LINKED}/.git" ]]; then
+  _fail "fixture's worktree .git is a directory, not the file form under test"
+  echo "SOME CHECKS FAILED" >&2
+  exit 1
+fi
+_pass "fixture worktree has the .git-as-file shape"
+
+# The guard itself, applied to each shape.
+guard_accepts() {
+  local dir="$1"
+  git -C "${dir}" rev-parse --git-dir >/dev/null 2>&1
+}
+
+if guard_accepts "${MAIN_REPO}"; then
+  _pass "guard accepts a normal checkout"
+else
+  _fail "guard rejects a normal checkout"
+fi
+
+if guard_accepts "${LINKED}"; then
+  _pass "guard accepts a linked worktree"
+else
+  _fail "guard rejects a linked worktree (this is #254)"
+fi
+
+# The negative case: a plain directory must still be rejected, so the fix
+# did not simply loosen the guard into accepting anything.
+NOT_A_REPO="${WORKDIR}/not-a-repo"
+mkdir -p "${NOT_A_REPO}"
+if guard_accepts "${NOT_A_REPO}"; then
+  _fail "guard accepts a non-repository directory — too permissive"
+else
+  _pass "guard still rejects a non-repository directory"
+fi
+
+# And an entry named .git that does not resolve to a repository, which is the
+# case `[[ -e .git ]]` would wrongly admit.
+BOGUS="${WORKDIR}/bogus"
+mkdir -p "${BOGUS}"
+echo "gitdir: /nonexistent/path/to/nowhere" >"${BOGUS}/.git"
+if guard_accepts "${BOGUS}"; then
+  _fail "guard accepts a .git file pointing nowhere — too permissive"
+else
+  _pass "guard rejects a .git file that resolves to no repository"
+fi
+
+echo
+if ((fail)); then
+  echo "SOME CHECKS FAILED" >&2
+  exit 1
+fi
+echo "test-install-worktree-guard: all cases passed"

--- a/bash/tests/test-pre-push-scan-timeout.sh
+++ b/bash/tests/test-pre-push-scan-timeout.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+#shellcheck shell=bash
+# Standalone verification of the pre-push hook's bounded command runner.
+# Run directly: bash bash/tests/test-pre-push-scan-timeout.sh
+#
+# The hook's Semgrep stage reaches the network. Unbounded, a slow or
+# unreachable backend blocks a push indefinitely instead of degrading — first
+# observed as the test suite appearing to hang when run from a linked
+# worktree, where no warm Semgrep cache exists
+# (smartwatermelon/dotfiles#251). The same stall can hit a real push on a slow
+# network, so the bound lives in the hook itself.
+#
+# run_bounded is extracted from the hook and driven directly. Both of its
+# implementations are exercised: GNU `timeout` when present, and the watchdog
+# fallback for stock macOS, which ships no `timeout` (it arrives with Homebrew
+# coreutils). Testing only whichever one this machine happens to have would
+# leave the other silently unverified.
+# `set -e` guards fixture setup, where a failing mktemp/chmod must abort loudly
+# rather than let the cases run against a half-built fixture and report
+# confusing results. It is lifted before the behavioral cases below, which
+# deliberately capture non-zero exits from run_bounded and would otherwise
+# abort the script on the first expected failure.
+set -euo pipefail
+unset CDPATH
+
+REPO_ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="${REPO_ROOT}/git/hooks/pre-push"
+
+fail=0
+case_out=""
+
+_pass() { echo "  PASS: $1"; }
+_fail() {
+  echo "  FAIL: $1" >&2
+  fail=1
+}
+
+# Extract the runner through bash's own parser rather than slicing the hook
+# with a text pattern, following test-allup-continue-state.sh
+# (smartwatermelon/dotfiles#208).
+#
+# A `sed '/start/,/^}/p'` range would stop at the first column-0 `}`. That is
+# correct only while no line inside run_bounded's body is itself a bare `}` —
+# a nested block or case arm closing at column 0 would truncate the extraction
+# mid-function, and brace counting cannot tell the two apart either. Asking
+# bash is the only approach immune to how the source happens to be formatted.
+#
+# The hook runs its checks at source time, so it cannot be sourced directly.
+# The function's text is isolated first, parsed in a clean subshell, and then
+# reprinted by `declare -f` — so what this test drives is what bash parsed,
+# not what a regex guessed at.
+# awk brace-balances from the function header to its true close, so the slice
+# ends at run_bounded's own `}` regardless of indentation — unlike a
+# `sed '/start/,/^}/p'` range, which stops at the first column-0 `}` and would
+# truncate mid-function if a nested block ever closed there. The slice is then
+# handed to bash to PARSE, so what the cases drive is a function bash accepted,
+# not a region a regex guessed at. (Sourcing the hook itself is not an option:
+# it runs its checks at source time.)
+_raw_body="$(awk '
+  /^run_bounded\(\)/ { collecting = 1 }
+  collecting {
+    print
+    n = gsub(/\{/, "{"); depth += n
+    n = gsub(/\}/, "}"); depth -= n
+    if (depth == 0 && seen_open) { exit }
+    if (depth > 0) { seen_open = 1 }
+  }
+' "${HOOK}")"
+
+RUNNER_SRC="$(bash --norc --noprofile -c '
+  eval "$1" || exit 1
+  declare -f run_bounded
+' _ "${_raw_body}" 2>/dev/null)"
+
+if [[ -n "${RUNNER_SRC}" ]]; then
+  _timeout_default="$(grep -E '^SEMGREP_TIMEOUT_SECS=' "${HOOK}" | head -1)" || _timeout_default=""
+  RUNNER_SRC="$(printf '%s\n%s\n' "${_timeout_default}" "${RUNNER_SRC}")"
+fi
+
+if [[ -z "${RUNNER_SRC}" ]]; then
+  echo "FAIL: could not extract run_bounded from ${HOOK}" >&2
+  echo "      (it may have been renamed or removed — the Semgrep scan would" >&2
+  echo "       then be unbounded again, which is #251)" >&2
+  exit 1
+fi
+# Guard against a partial extraction that would silently under-test.
+if [[ "${RUNNER_SRC}" != *"run_bounded"* ]]; then
+  echo "FAIL: extracted block does not define run_bounded()" >&2
+  exit 1
+fi
+# Guard against a partial extraction that would silently under-test: the
+# parsed body must retain the 124 expiry normalization the cases assert on.
+if [[ "${RUNNER_SRC}" != *"124"* ]]; then
+  echo "FAIL: extracted run_bounded lacks the 124 expiry normalization" >&2
+  echo "      (extraction truncated, or the expiry contract changed)" >&2
+  exit 1
+fi
+
+# Confirm the hook actually ROUTES its scans through the runner. A runner that
+# exists but is not called leaves the scan unbounded while this test reports
+# green — the defect class that made #251 invisible in the first place.
+echo "Case: the hook routes its Semgrep scans through the bounded runner"
+scan_calls="$(grep -cE '^[[:space:]]*(if ! )?run_bounded .* semgrep ' "${HOOK}")"
+if ((scan_calls >= 2)); then
+  _pass "both the token and fallback scans call run_bounded (${scan_calls} sites)"
+else
+  _fail "expected 2 bounded semgrep call sites, found ${scan_calls}"
+fi
+if grep -qE '^[[:space:]]*semgrep (ci|scan|")' "${HOOK}"; then
+  _fail "an unbounded bare 'semgrep' invocation remains in the hook"
+else
+  _pass "no unbounded bare 'semgrep' invocation remains"
+fi
+
+# ---------------------------------------------------------------
+# Behavioral cases, run against both implementations
+# ---------------------------------------------------------------
+# force_fallback=1 shadows `command -v` so run_bounded cannot find
+# timeout/gtimeout and must take its watchdog branch.
+#
+# The driver is written to a file rather than passed as a single-quoted `-c`
+# string. A quoted script body containing parameter expansions is read as an
+# unexpanded expression (SC2016) by the linter, and this repo resolves such
+# findings rather than suppressing them.
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/pre-push-timeout-test.XXXXXX")"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+DRIVER="${WORKDIR}/driver.sh"
+cat >"${DRIVER}" <<'DRIVER_EOF'
+#!/usr/bin/env bash
+# Args: <force_fallback> <budget_secs> <command...>
+force_fallback="$1"
+secs="$2"
+shift 2
+
+source "${RUNNER_FILE}"
+
+if [[ "${force_fallback}" == "1" ]]; then
+  command() {
+    if [[ "$1" == "-v" && ( "$2" == "timeout" || "$2" == "gtimeout" ) ]]; then
+      return 1
+    fi
+    builtin command "$@"
+  }
+fi
+
+start=${SECONDS}
+run_bounded "${secs}" "$@"
+rc=$?
+echo "${rc} $((SECONDS - start))"
+DRIVER_EOF
+chmod +x "${DRIVER}"
+
+RUNNER_FILE="${WORKDIR}/runner.sh"
+printf '%s\n' "${RUNNER_SRC}" >"${RUNNER_FILE}"
+export RUNNER_FILE
+
+TEST_BASH="${BASH:-bash}"
+
+run_case() {
+  "${TEST_BASH}" "${DRIVER}" "$@"
+}
+
+# Fixture setup is complete. The cases below assert on non-zero exit codes as
+# their subject matter, so `-e` must not apply to them.
+set +e
+
+for mode in timeout fallback; do
+  force=0
+  label="GNU timeout"
+  if [[ "${mode}" == "fallback" ]]; then
+    force=1
+    label="watchdog fallback"
+  fi
+
+  echo "Case: run_bounded behavior — ${label}"
+
+  # A command that outlives its budget is terminated and reported as 124,
+  # matching coreutils' expiry convention.
+  case_out="$(run_case "${force}" 3 sleep 60)"
+  read -r rc elapsed <<<"${case_out}"
+  if [[ "${rc}" == "124" ]]; then
+    _pass "${label}: an over-budget command exits 124"
+  else
+    _fail "${label}: over-budget command exited ${rc}, expected 124"
+  fi
+  if ((elapsed <= 10)); then
+    _pass "${label}: terminated near the budget (${elapsed}s), not at the command's own length"
+  else
+    _fail "${label}: took ${elapsed}s for a 3s budget — not actually bounded"
+  fi
+
+  # Success and failure statuses must pass through untouched, or the hook
+  # would misread a clean scan as an infrastructure error and vice versa.
+  case_out="$(run_case "${force}" 10 true)"
+  read -r rc _ <<<"${case_out}"
+  if [[ "${rc}" == "0" ]]; then
+    _pass "${label}: a successful command still reports 0"
+  else
+    _fail "${label}: successful command reported ${rc}, expected 0"
+  fi
+
+  case_out="$(run_case "${force}" 10 false)"
+  read -r rc _ <<<"${case_out}"
+  if [[ "${rc}" == "1" ]]; then
+    _pass "${label}: a failing command's status passes through"
+  else
+    _fail "${label}: failing command reported ${rc}, expected 1"
+  fi
+
+  # An under-budget command must return as soon as it finishes rather than
+  # waiting out the whole budget.
+  case_out="$(run_case "${force}" 30 sleep 2)"
+  read -r rc elapsed <<<"${case_out}"
+  if [[ "${rc}" == "0" ]] && ((elapsed < 15)); then
+    _pass "${label}: returns when the command finishes (${elapsed}s of a 30s budget)"
+  else
+    _fail "${label}: exit ${rc} after ${elapsed}s — expected 0 in well under 30s"
+  fi
+done
+
+echo
+if ((fail)); then
+  echo "SOME CHECKS FAILED" >&2
+  exit 1
+fi
+echo "test-pre-push-scan-timeout: all cases passed"

--- a/bash/tests/test-pre-push-stale-ci.sh
+++ b/bash/tests/test-pre-push-stale-ci.sh
@@ -72,6 +72,25 @@ EOF
   chmod +x "${bin_dir}/gh"
 }
 
+# Mocked semgrep: exits clean immediately.
+#
+# The hook's static-analysis stage runs a real, network-dependent Semgrep scan.
+# Mocking `gh` but not `semgrep` left the boundary half-drawn: the test still
+# reached the network, and from a linked worktree — where there is no warm
+# Semgrep cache — the scan ran long enough that the whole suite looked hung
+# (smartwatermelon/dotfiles#251). The hook now bounds the scan with a timeout,
+# so this is no longer an unbounded stall, but a test asserting stale-CI
+# detection has no business scanning source at all.
+write_mock_semgrep() {
+  local bin_dir="$1"
+  cat >"${bin_dir}/semgrep" <<'MOCK_EOF'
+#!/usr/bin/env bash
+# Clean scan, no findings, no network.
+exit 0
+MOCK_EOF
+  chmod +x "${bin_dir}/semgrep"
+}
+
 # Run the hook as a subprocess with a controlled PATH (mock gh first),
 # controlled stdin (pre-push protocol line), and non-interactive strict mode
 # forced on so the CI-failure path actually attempts to block.
@@ -103,6 +122,7 @@ cat >"${JSON1}" <<EOF
 {"number":42,"reviewDecision":null,"reviews":[],"statusCheckRollup":[{"name":"docker","conclusion":"FAILURE"}],"headRefOid":"${PUSHED_SHA_1}"}
 EOF
 write_mock_gh "${BIN1}" "${JSON1}"
+write_mock_semgrep "${BIN1}"
 
 run_hook "${REPO1}" "${PUSHED_SHA_1}" "${BIN1}"
 exit1=$?
@@ -133,13 +153,14 @@ BIN2="${WORKDIR}/bin2"
 mkdir -p "${BIN2}"
 setup_repo "${REPO2}"
 PUSHED_SHA_2=$(cd "${REPO2}" && /usr/bin/git rev-parse HEAD)
-OLD_SHA_2="1111111111111111111111111111111111111"
+OLD_SHA_2="1111111111111111111111111111111111111111"
 
 JSON2="${WORKDIR}/gh2.json"
 cat >"${JSON2}" <<EOF
 {"number":42,"reviewDecision":null,"reviews":[],"statusCheckRollup":[{"name":"docker","conclusion":"FAILURE"}],"headRefOid":"${OLD_SHA_2}"}
 EOF
 write_mock_gh "${BIN2}" "${JSON2}"
+write_mock_semgrep "${BIN2}"
 
 run_hook "${REPO2}" "${PUSHED_SHA_2}" "${BIN2}"
 exit2=$?
@@ -176,6 +197,7 @@ cat >"${JSON3}" <<EOF
 {"number":42,"reviewDecision":null,"reviews":[],"statusCheckRollup":[{"name":"docker","conclusion":"SUCCESS"}],"headRefOid":"${PUSHED_SHA_3}"}
 EOF
 write_mock_gh "${BIN3}" "${JSON3}"
+write_mock_semgrep "${BIN3}"
 
 run_hook "${REPO3}" "${PUSHED_SHA_3}" "${BIN3}"
 exit3=$?

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -190,6 +190,72 @@ run_supply_chain_scan() {
 run_supply_chain_scan
 
 # =========================================================
+# BOUNDED COMMAND RUNNER
+# =========================================================
+# Runs a command with a wall-clock ceiling and reports 124 on expiry, matching
+# coreutils `timeout`. Semgrep's code scan reaches the network, and with no
+# bound a slow or unreachable backend blocks the push indefinitely rather than
+# degrading — observed as an apparent hang of the test suite from a linked
+# worktree, where no warm Semgrep cache exists (smartwatermelon/dotfiles#251).
+# The same stall can hit a real push on a slow network, which is why the bound
+# lives in the hook rather than only in the test's mocks.
+#
+# GNU `timeout` is not on stock macOS (it arrives with Homebrew coreutils), so
+# prefer it when present and fall back to a watchdog subshell otherwise.
+SEMGREP_TIMEOUT_SECS="${SEMGREP_TIMEOUT_SECS:-300}"
+
+run_bounded() {
+  local secs="$1"
+  shift
+
+  local timeout_bin=""
+  if command -v timeout &>/dev/null; then
+    timeout_bin="timeout"
+  elif command -v gtimeout &>/dev/null; then
+    timeout_bin="gtimeout"
+  fi
+
+  if [[ -n "${timeout_bin}" ]]; then
+    "${timeout_bin}" "${secs}" "$@"
+    return $?
+  fi
+
+  # Fallback watchdog: run the command in the background, kill it if it
+  # outlives the budget. `wait` on a known pid yields the command's own exit
+  # status, so a normal completion is reported untouched.
+  "$@" &
+  local cmd_pid=$!
+
+  (
+    # Poll rather than `sleep ${secs}` in one shot so the watchdog exits
+    # promptly once the command finishes, instead of lingering for the full
+    # budget on every invocation.
+    local waited=0
+    while ((waited < secs)); do
+      kill -0 "${cmd_pid}" 2>/dev/null || exit 0
+      sleep 1
+      ((waited += 1))
+    done
+    kill -TERM "${cmd_pid}" 2>/dev/null || true
+    sleep 2
+    kill -KILL "${cmd_pid}" 2>/dev/null || true
+  ) &
+  local watchdog_pid=$!
+
+  local status=0
+  wait "${cmd_pid}" 2>/dev/null || status=$?
+  kill -TERM "${watchdog_pid}" 2>/dev/null || true
+  wait "${watchdog_pid}" 2>/dev/null || true
+
+  # A killed command surfaces as 143 (SIGTERM) / 137 (SIGKILL); normalize to
+  # coreutils' 124 so callers have one expiry code to branch on.
+  if ((status == 143 || status == 137)); then
+    return 124
+  fi
+  return "${status}"
+}
+
+# =========================================================
 # SEMGREP STATIC ANALYSIS
 # =========================================================
 # With a Semgrep token: runs `semgrep ci --code` against the connected
@@ -216,7 +282,7 @@ run_static_analysis() {
     if git rev-parse --verify --quiet origin/main >/dev/null; then
       fallback_args+=(--baseline-commit origin/main)
     fi
-    if ! semgrep "${fallback_args[@]}" .; then
+    if ! run_bounded "${SEMGREP_TIMEOUT_SECS}" semgrep "${fallback_args[@]}" .; then
       echo "" >&2
       log_warning "🛑 Semgrep found issues. Fix them before pushing."
       echo "" >&2
@@ -236,7 +302,7 @@ run_static_analysis() {
     if git rev-parse --verify --quiet origin/main >/dev/null; then
       export SEMGREP_BASELINE_REF="origin/main"
     fi
-    semgrep ci --code --dry-run --quiet
+    run_bounded "${SEMGREP_TIMEOUT_SECS}" semgrep ci --code --dry-run --quiet
   ) || exit_code=$?
 
   case ${exit_code} in
@@ -251,8 +317,15 @@ run_static_analysis() {
       ;;
     *)
       echo "" >&2
-      log_warning "⚠️  Semgrep failed to complete (exit ${exit_code}) — likely network/auth/rules issue, not findings."
-      log_warning "   Diagnose: SEMGREP_APP_TOKEN=<token> semgrep ci --code --dry-run"
+      # 124 is run_bounded's expiry code. Naming it separately keeps a slow or
+      # unreachable scan from being diagnosed as an auth/rules problem.
+      if ((exit_code == 124)); then
+        log_warning "⚠️  Semgrep exceeded ${SEMGREP_TIMEOUT_SECS}s and was terminated — slow or unreachable backend, not findings."
+        log_warning "   Raise the budget with SEMGREP_TIMEOUT_SECS=<seconds> if this is expected."
+      else
+        log_warning "⚠️  Semgrep failed to complete (exit ${exit_code}) — likely network/auth/rules issue, not findings."
+        log_warning "   Diagnose: SEMGREP_APP_TOKEN=<token> semgrep ci --code --dry-run"
+      fi
       echo "" >&2
       if [[ -t 0 ]]; then
         local push_anyway

--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,13 @@ fi
 # entry by bare name (see smartwatermelon/dotfiles#176).
 REPO_DIR="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if [[ ! -d "${REPO_DIR}/.git" ]]; then
+# `git rev-parse --git-dir`, not `[[ -d .git ]]`. A linked worktree's .git is a
+# FILE holding a `gitdir:` pointer, not a directory, so the -d test rejected a
+# perfectly valid worktree as "not a git repository"
+# (smartwatermelon/dotfiles#254). rev-parse resolves both forms and, unlike
+# `-e`, confirms the entry actually resolves to a repository rather than just
+# existing.
+if ! git -C "${REPO_DIR}" rev-parse --git-dir >/dev/null 2>&1; then
   _err "Not a git repository: ${REPO_DIR}"
   _err "This script must be run from the dotfiles repo root."
   exit 1


### PR DESCRIPTION
Closes the remaining open issues in this repo. Three commits, each verified
against a deliberately broken version of the thing it fixes — several of these
defects were tests that reported green while testing nothing, so a fix that
merely "passes" proves very little.

## 1. Linked worktrees (#254, #251)

`install.sh` guarded with `[[ -d "${REPO_DIR}/.git" ]]`. A linked worktree's
`.git` is a FILE holding a `gitdir:` pointer, so a legitimate worktree was
rejected as "not a git repository". Now uses `git rev-parse --git-dir`, which
resolves both shapes and — unlike `-e` — confirms the entry actually resolves
to a repository.

The pre-push hook ran `semgrep ci --code` with no wall-clock bound, so a slow
or unreachable backend blocked a push indefinitely instead of degrading. Added
`run_bounded`: GNU `timeout` when present, a watchdog subshell otherwise
(stock macOS ships no `timeout`). Expiry normalizes to 124 and is reported
distinctly, so a timeout is not diagnosed as an auth problem. Both
implementations are tested.

`test-pre-push-stale-ci.sh` mocked `gh` but not `semgrep`, so a test about
stale-CI detection was scanning source over the network. Now mocked.

## 2. Tests that passed without testing anything (#256, #250)

Case 3 of the gpush guard reported PASS while never reaching a detached HEAD.
Three defects stacked, and the third is not the one the issue predicted:

1. No hook isolation, so this repo's own global pre-commit hook refused the
   fixture's commit to `main`. With no commit, `rev-list` printed nothing and
   `git checkout --detach ""` failed. The `fatal:` lines were visible in test
   output all along and read as incidental noise.
2. `trap ... RETURN` in a `bash -c` top level (not a function) never fires, so
   the temp directory leaked every run.
3. **It still passed** because after sourcing `gpush-wrapper.sh` a bare `git`
   resolves to this repo's git *wrapper*, through which `symbolic-ref` returned
   empty. `gpush` prints `Refusing to run on ${branch:-detached HEAD}`, so it
   emitted the detached-HEAD text while HEAD was on `main` — and the grep
   matched. Confirmed by instrumenting the fixture: `symbolic-ref` reported
   `main` while gpush printed "detached HEAD".

Fixed by isolating the fixture and asserting preconditions rather than assuming
them. Case 2 had the same missing isolation and now asserts its state too.

## 3. Portability and version assumptions (#252, part of #247)

`config_fingerprint` used macOS-only `md5` with `|| echo "MISSING"`. Without
`md5`, every call returned the same constant, so `before == after` always held
and the control assertion always failed — the test aborted rather than tested.
Now uses POSIX `cksum`, and the unreadable branch emits a path-unique value so
a missing file cannot reintroduce the vacuous comparison.

`test-git-wrapper-init-hook.sh` depends on `GIT_CONFIG_COUNT`, which git < 2.31
silently ignores. That would not merely skip a check — it would let the test's
`cat >` write through a preserved symlink and clobber the tracked
`git/template/hooks/post-checkout` while reporting green. Added a version guard.

## Verification

- Full suite: 16/16 pass (14 baseline + 2 new tests), before and after each commit.
- Every new assertion was falsified against deliberately broken code. That
  caught a real flaw in one of my own tests: its guard grepped for
  `rev-parse --git-dir` unanchored and matched its own explanatory comment, so
  it passed against a reverted `install.sh`. Now anchored to the `if !` opener.
- `shellcheck -S info` clean on all changed files; no `disable` directives.
- Pre-push codebase reviewer dry-run run before each commit; all findings either
  fixed or resolved empirically.
- `core.hooksPath=""` vs `--unset` was settled by experiment, not assumption: an
  empty value runs no hooks at all, while `--unset` would fall back to the
  global hooks path and reintroduce the blocking hook.

## Deliberately not taken

Two #247 findings are wrong or inapplicable, and are explained in the commits
rather than silently dropped: the stale `.ralph/` mentions live in a document
that states it is a historical record kept unedited (and already notes the
rename), and the "missing Case 2" finding is factually incorrect — Cases 1, 2
and 3 are contiguous.

Three #247 items remain open and are genuine design decisions for you rather
than fixes for an agent to make unilaterally: tag-vs-SHA pinning of the
reusable workflows, and `tolerate_upgrade_failure` swallowing all formula
failures in non-interactive mode. Both are documented in-code as intentional
trade-offs. #247 is therefore marked "Advances", not "Closes".

Closes #250
Closes #251
Closes #252
Closes #254
Closes #256

https://claude.ai/code/session_01TshyoHK7Jkhi6Td6b3vBqk
