### PR TITLE
fix(tests): make the run_bounded extraction comment-safe and its failure explanatory

### DIFF
--- a/bash/tests/test-gh-wrapper-draft-off-org.sh
+++ b/bash/tests/test-gh-wrapper-draft-off-org.sh
@@ -102,25 +102,56 @@ fi
 off_org_clone="/tmp/gh-wrapper-draft-test-off-org-$$"
 in_org_clone="/tmp/gh-wrapper-draft-test-in-org-$$"
 mkdir -p "${off_org_clone}" "${in_org_clone}"
-trap 'rm -rf "${off_org_clone}" "${in_org_clone}"' EXIT
+# cwd_status_dir is created further down but named here, so an abort between
+# its mktemp and its explicit cleanup cannot leak it. The `:-` guard covers the
+# window before it is assigned. Leaked fixture dirs are the defect class this
+# suite has been clearing out (#255, #256).
+trap 'rm -rf "${off_org_clone}" "${in_org_clone}" "${cwd_status_dir:-}"' EXIT
 (cd "${off_org_clone}" && command git init -q && command git remote add origin git@github.com:someoutsideorg/foo.git)
 (cd "${in_org_clone}" && command git init -q && command git remote add origin git@github.com:smartwatermelon/dotfiles.git)
 
-cwd_fail_file="/tmp/gh-wrapper-draft-test-cwd-fail-$$"
-rm -f "${cwd_fail_file}"
-(
-  cd "${off_org_clone}"
-  assert_args "off-org cwd remote fallback" 1 pr create --title x
-  if [[ "${fail}" == "1" ]]; then touch "${cwd_fail_file}"; fi
-)
-(
-  cd "${in_org_clone}"
-  assert_args "in-org cwd remote fallback" 0 pr create --title x
-  if [[ "${fail}" == "1" ]]; then touch "${cwd_fail_file}"; fi
-)
-if [[ -f "${cwd_fail_file}" ]]; then
-  fail=1
-fi
-rm -f "${cwd_fail_file}"
+# `fail` is set inside subshells, so it cannot propagate back by assignment.
+# It travels through the filesystem instead — and the direction matters.
+#
+# Signalling FAILURE ("touch on failure") fails OPEN: this script runs under
+# `set -e`, so a subshell that dies before reaching its sentinel line — an
+# unexpected non-zero from `cd` or `assert_args` rather than a `fail=1` — writes
+# nothing, and the parent reads that silence as a pass
+# (smartwatermelon/dotfiles#247).
+#
+# Signalling COMPLETION instead fails CLOSED. Each subshell records its own
+# verdict only after it has run to the end, so an early exit leaves the file
+# absent and the parent treats a missing verdict as a failure. Silence can no
+# longer be mistaken for success — the defect class this suite has been
+# clearing out (see #256).
+cwd_status_dir="$(mktemp -d "${TMPDIR:-/tmp}/gh-wrapper-draft-cwd.XXXXXX")"
+
+run_cwd_case() {
+  local clone="$1" desc="$2" want="$3" tag="$4"
+  (
+    cd "${clone}" || exit 1
+    fail=0
+    assert_args "${desc}" "${want}" pr create --title x
+    # Reached only if the case ran to completion; the recorded value is this
+    # subshell's own verdict.
+    printf '%s\n' "${fail}" >"${cwd_status_dir}/${tag}"
+  )
+}
+
+run_cwd_case "${off_org_clone}" "off-org cwd remote fallback" 1 off-org
+run_cwd_case "${in_org_clone}" "in-org cwd remote fallback" 0 in-org
+
+for tag in off-org in-org; do
+  if [[ ! -f "${cwd_status_dir}/${tag}" ]]; then
+    echo "FAIL: ${tag} cwd case did not run to completion (aborted before recording a verdict)"
+    fail=1
+  else
+    cwd_verdict="$(cat "${cwd_status_dir}/${tag}")" || cwd_verdict="unreadable"
+    if [[ "${cwd_verdict}" != "0" ]]; then
+      fail=1
+    fi
+  fi
+done
+rm -rf "${cwd_status_dir}"
 
 exit "${fail}"

--- a/bash/tests/test-install-worktree-guard.sh
+++ b/bash/tests/test-install-worktree-guard.sh
@@ -110,6 +110,16 @@ fi
 _pass "fixture worktree has the .git-as-file shape"
 
 # The guard itself, applied to each shape.
+# Bare `git`, deliberately — install.sh calls bare `git` too, so this exercises
+# the same resolution path the guard actually takes rather than a stricter one.
+# The fixture setup above uses /usr/bin/git because it must build a specific
+# repository shape regardless of what is on PATH; the guard check must instead
+# mirror production.
+#
+# Verified that the two agree here: this repo's git wrapper special-cases only
+# `init` and otherwise delegates through `command git "$@"`, so bare `git` and
+# /usr/bin/git return the same verdict for `rev-parse --git-dir` on both a
+# normal checkout and a linked worktree (smartwatermelon/dotfiles#258).
 guard_accepts() {
   local dir="$1"
   git -C "${dir}" rev-parse --git-dir >/dev/null 2>&1

--- a/bash/tests/test-pre-push-scan-timeout.sh
+++ b/bash/tests/test-pre-push-scan-timeout.sh
@@ -49,28 +49,50 @@ _fail() {
 # The function's text is isolated first, parsed in a clean subshell, and then
 # reprinted by `declare -f` — so what this test drives is what bash parsed,
 # not what a regex guessed at.
-# awk brace-balances from the function header to its true close, so the slice
-# ends at run_bounded's own `}` regardless of indentation — unlike a
+# Brace-balance from the function header to its true close, so the slice ends at
+# run_bounded's own `}` regardless of indentation — unlike a
 # `sed '/start/,/^}/p'` range, which stops at the first column-0 `}` and would
-# truncate mid-function if a nested block ever closed there. The slice is then
-# handed to bash to PARSE, so what the cases drive is a function bash accepted,
-# not a region a regex guessed at. (Sourcing the hook itself is not an option:
-# it runs its checks at source time.)
+# truncate mid-function if a nested block ever closed there.
+#
+# Comments are stripped before counting. Counting raw characters treats a `{` in
+# a comment or URL as structure, which skews the depth and makes the slice
+# over-run into whatever follows the function
+# (smartwatermelon/dotfiles#260). Verified against a body carrying
+# `# see https://example.com/{path`, which over-ran before this and does not now.
+#
+# The stripping is only for the COUNT; the printed lines are the originals, so
+# the extracted body is byte-identical to the source.
+#
+# `sub(/#.*/, "")` also strips a `#` inside a quoted string, which would
+# under-count a brace that really is structure. That is the safe direction: it
+# can only end the slice early, and bash then fails to parse the truncation, so
+# the guards below report which stage failed rather than the test running on a
+# partial function. Verified by hiding an unbalanced `}` in a string inside
+# run_bounded: the test fails with an explicit message naming the extraction.
+# A shell-accurate tokenizer is not worth writing here. bash then parses it and
+# `declare -f` reprints it, so what the cases drive is a function bash accepted,
+# not a region awk guessed at.
 _raw_body="$(awk '
   /^run_bounded\(\)/ { collecting = 1 }
   collecting {
     print
-    n = gsub(/\{/, "{"); depth += n
-    n = gsub(/\}/, "}"); depth -= n
+    counted = $0
+    sub(/#.*/, "", counted)
+    n = gsub(/\{/, "{", counted); depth += n
+    n = gsub(/\}/, "}", counted); depth -= n
     if (depth == 0 && seen_open) { exit }
     if (depth > 0) { seen_open = 1 }
   }
 ' "${HOOK}")"
 
+# `|| RUNNER_SRC=""`, because a bare command-substitution assignment that exits
+# non-zero would abort the script under `set -e` — silently, before the
+# diagnostic guards below could say why. A truncated slice must produce an
+# explanation, not an empty exit 1.
 RUNNER_SRC="$(bash --norc --noprofile -c '
   eval "$1" || exit 1
   declare -f run_bounded
-' _ "${_raw_body}" 2>/dev/null)"
+' _ "${_raw_body}" 2>/dev/null)" || RUNNER_SRC=""
 
 if [[ -n "${RUNNER_SRC}" ]]; then
   _timeout_default="$(grep -E '^SEMGREP_TIMEOUT_SECS=' "${HOOK}" | head -1)" || _timeout_default=""

--- a/bash/tests/test-pre-push-scan-timeout.sh
+++ b/bash/tests/test-pre-push-scan-timeout.sh
@@ -184,8 +184,13 @@ for mode in timeout fallback; do
   else
     _fail "${label}: over-budget command exited ${rc}, expected 124"
   fi
-  if ((elapsed <= 10)); then
-    _pass "${label}: terminated near the budget (${elapsed}s), not at the command's own length"
+  # The assertion is "bounded", not "bounded precisely". The ceiling is well
+  # clear of the 3s budget plus SIGKILL escalation, but far below the 60s the
+  # command would run unbounded — so a loaded runner cannot flake it, while a
+  # genuinely unbounded run still fails. `SECONDS` has 1-second granularity,
+  # which the margin absorbs.
+  if ((elapsed <= 20)); then
+    _pass "${label}: terminated near the budget (${elapsed}s of a 60s command)"
   else
     _fail "${label}: took ${elapsed}s for a 3s budget — not actually bounded"
   fi
@@ -212,7 +217,10 @@ for mode in timeout fallback; do
   # waiting out the whole budget.
   case_out="$(run_case "${force}" 30 sleep 2)"
   read -r rc elapsed <<<"${case_out}"
-  if [[ "${rc}" == "0" ]] && ((elapsed < 15)); then
+  # The point is that the watchdog does not hold the budget open after the
+  # command finishes. Anything comfortably under 30s proves that; the margin is
+  # sized so shell overhead on a saturated runner cannot flake it.
+  if [[ "${rc}" == "0" ]] && ((elapsed < 25)); then
     _pass "${label}: returns when the command finishes (${elapsed}s of a 30s budget)"
   else
     _fail "${label}: exit ${rc} after ${elapsed}s — expected 0 in well under 30s"

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -237,8 +237,33 @@ run_bounded() {
       ((waited += 1))
     done
     kill -TERM "${cmd_pid}" 2>/dev/null || true
-    sleep 2
-    kill -KILL "${cmd_pid}" 2>/dev/null || true
+
+    # Escalate to SIGKILL only while the process is still ours to signal.
+    #
+    # A flat `sleep 2; kill -KILL` would signal a pid the parent's `wait` may
+    # already have reaped, and a reaped pid can be reassigned — so the SIGKILL
+    # could land on an unrelated process
+    # (smartwatermelon/dotfiles#258). Polling in short steps and re-checking
+    # liveness before escalating both shortens that window and makes the
+    # escalation conditional on the process still existing.
+    #
+    # This narrows the race rather than eliminating it: nothing in POSIX makes
+    # "check liveness, then signal" atomic. It cannot be closed from a shell
+    # without process groups or pidfds, and the residual window is now a few
+    # milliseconds on a path that runs once per push.
+    local grace=0
+    while ((grace < 20)); do
+      # `|| exit 0` is the SUCCESS path, not an error path: the command is
+      # already gone, so there is nothing left to escalate against and the
+      # watchdog has no further work. The counter uses `+= 1` rather than
+      # `++` because `((v++))` evaluates to 0 when v is 0 and would abort
+      # this subshell under the inherited `set -e`.
+      kill -0 "${cmd_pid}" 2>/dev/null || exit 0
+      sleep 0.1
+      ((grace += 1))
+    done
+    kill -0 "${cmd_pid}" 2>/dev/null && kill -KILL "${cmd_pid}" 2>/dev/null
+    exit 0
   ) &
   local watchdog_pid=$!
 


### PR DESCRIPTION
Closes #260. Stacked on #261.

## awk brace counter counted braces in comments

The counter treated every `{` as structure. Verified against a body carrying
`# see https://example.com/{path`: the depth skewed and the slice over-ran past
the function's own close into whatever followed it.

Comments are now stripped before counting, while the **printed** lines stay the
originals — so the extracted body is byte-identical to the source, and bash
still does the actual parsing.

The stripping also removes a `#` inside a quoted string, which can under-count a
brace that really is structure. That direction is safe: it can only end the slice
early, and bash then rejects the truncation. A shell-accurate tokenizer isn't
worth writing here.

## Checking that claim found a real bug in the test

I wrote "the guards fire loudly" and then checked it. They didn't. A truncated
slice failed with **no output at all** — exit 1 and nothing else.

`RUNNER_SRC="$(bash ...)"` is a bare command substitution, so under `set -e` a
non-zero inner bash aborted the script before the diagnostic guards below could
run. `|| RUNNER_SRC=""` lets them report which stage failed. Verified by hiding
an unbalanced `}` in a string inside `run_bounded`:

```
FAIL: could not extract run_bounded from .../git/hooks/pre-push
      (it may have been renamed or removed — the Semgrep scan would
       then be unbounded again, which is #251)
```

Silence is the failure mode this suite has spent several commits eliminating
(#256, #247). A guard that exits without saying why isn't much better than one
that passes without testing.

## Second item in #260

No code change needed — `OLD_SHA_2` was already corrected from 37 to 40
characters in #257, and the finding itself confirms the fix is right.

Full suite 16/16, shellcheck `-S info` clean, dry-run pre-push reviewer PASS with
no findings.

Closes #260

https://claude.ai/code/session_01TshyoHK7Jkhi6Td6b3vBqk
