### PR TITLE
fix(hooks): pass --kill-after to timeout, which otherwise never escalates

### DIFF
--- a/bash/tests/test-gh-wrapper-draft-off-org.sh
+++ b/bash/tests/test-gh-wrapper-draft-off-org.sh
@@ -106,7 +106,12 @@ mkdir -p "${off_org_clone}" "${in_org_clone}"
 # its mktemp and its explicit cleanup cannot leak it. The `:-` guard covers the
 # window before it is assigned. Leaked fixture dirs are the defect class this
 # suite has been clearing out (#255, #256).
-trap 'rm -rf "${off_org_clone}" "${in_org_clone}" "${cwd_status_dir:-}"' EXIT
+# `${cwd_status_dir:+...}` expands to nothing at all when the variable is unset,
+# rather than handing `rm -rf` an empty string. macOS `rm -rf ""` happens to be
+# a silent no-op (verified), but GNU coreutils is not obliged to agree, and a
+# spurious error here would land on top of whatever real failure triggered the
+# abort. This form is unambiguous on both.
+trap 'rm -rf "${off_org_clone}" "${in_org_clone}" ${cwd_status_dir:+"${cwd_status_dir}"}' EXIT
 (cd "${off_org_clone}" && command git init -q && command git remote add origin git@github.com:someoutsideorg/foo.git)
 (cd "${in_org_clone}" && command git init -q && command git remote add origin git@github.com:smartwatermelon/dotfiles.git)
 

--- a/bash/tests/test-pre-push-scan-timeout.sh
+++ b/bash/tests/test-pre-push-scan-timeout.sh
@@ -249,6 +249,59 @@ for mode in timeout fallback; do
   fi
 done
 
+# ---------------------------------------------------------------
+# The SIGKILL escalation branch
+# ---------------------------------------------------------------
+# The cases above all terminate on SIGTERM, so the grace loop exits early and
+# the `kill -KILL` line never runs. That left the escalation branch with no
+# coverage at all: a future edit could break it and every test would still pass
+# (smartwatermelon/dotfiles#262).
+#
+# A command that IGNORES SIGTERM forces the escalation. It must still be
+# terminated, and within the grace budget rather than running to its own length.
+echo "Case: run_bounded escalates to SIGKILL for a SIGTERM-ignoring command"
+
+IGNORER="${WORKDIR}/ignores-sigterm.sh"
+cat >"${IGNORER}" <<'IGNORER_EOF'
+#!/usr/bin/env bash
+# Survives SIGTERM; only SIGKILL can stop this.
+#
+# The `sleep` runs in the foreground, so killing this script tears it down with
+# it. Verified by sampling `pgrep -f "sleep 60"` across a full run: the count
+# rises during each case and returns to zero between them, with none left
+# behind at the end.
+trap '' TERM
+sleep 60
+IGNORER_EOF
+chmod +x "${IGNORER}"
+
+for mode in timeout fallback; do
+  force=0
+  label="GNU timeout"
+  if [[ "${mode}" == "fallback" ]]; then
+    force=1
+    label="watchdog fallback"
+  fi
+
+  case_out="$(run_case "${force}" 2 "${IGNORER}")"
+  read -r rc elapsed <<<"${case_out}"
+
+  # GNU timeout reports 124 on expiry; the fallback normalizes SIGKILL's 137 to
+  # 124 itself. Either way the caller must see the expiry code.
+  if [[ "${rc}" == "124" ]]; then
+    _pass "${label}: a SIGTERM-ignoring command is still reported as expired"
+  else
+    _fail "${label}: SIGTERM-ignoring command exited ${rc}, expected 124"
+  fi
+
+  # The escalation must actually land. Unterminated, the command runs 60s.
+  if ((elapsed <= 20)); then
+    _pass "${label}: escalation killed it in ${elapsed}s, not its full 60s"
+  else
+    _fail "${label}: took ${elapsed}s — the SIGKILL escalation did not land"
+  fi
+done
+
 echo
 if ((fail)); then
   echo "SOME CHECKS FAILED" >&2

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -216,8 +216,29 @@ run_bounded() {
   fi
 
   if [[ -n "${timeout_bin}" ]]; then
-    "${timeout_bin}" "${secs}" "$@"
-    return $?
+    # --kill-after is not optional. Plain `timeout N` sends only SIGTERM and
+    # then waits indefinitely for a command that ignores it — it still reports
+    # 124, so it CLAIMS to have bounded the run while actually blocking for the
+    # command's full length. Measured: `timeout 2` against a SIGTERM-ignoring
+    # command returned 124 after 60 seconds; with --kill-after it returned at 4
+    # (smartwatermelon/dotfiles#262). Without this the hook keeps exactly the
+    # hang #251 set out to remove, on any machine that has coreutils.
+    local timeout_status=0
+    # A SIGKILLed child makes the invoking shell print a "Killed: 9" job notice
+    # on its own stderr. That is cosmetic and only appears on the escalation
+    # path, which already logs an explicit timeout warning right after — and it
+    # cannot be suppressed from inside this function, since the notice comes
+    # from the shell reaping the job rather than from the command. Left alone
+    # rather than papered over with a subshell that does not actually stop it.
+    "${timeout_bin}" --kill-after="${SEMGREP_TIMEOUT_KILL_GRACE:-2}" "${secs}" "$@" \
+      || timeout_status=$?
+    # When --kill-after escalates, timeout exits 137 (SIGKILL) rather than 124.
+    # Both mean the same thing to the caller — the budget expired — so report
+    # one code, matching the fallback path below.
+    if ((timeout_status == 137 || timeout_status == 143)); then
+      return 124
+    fi
+    return "${timeout_status}"
   fi
 
   # Fallback watchdog: run the command in the background, kill it if it


### PR DESCRIPTION
Closes #262. Stacked on #263 — the last PR in the chain.

## Adding the requested test coverage found a real bug in the shipped code

#262 asked for coverage of the SIGKILL escalation branch, noting it was
unexercised. It was — and adding a case for it broke immediately, on the
**primary** path rather than my fallback.

Every existing case terminated on SIGTERM, so the grace loop always exited early
and `kill -KILL` never ran. A command that *ignores* SIGTERM forces that branch.
With it, the GNU `timeout` path took **61 seconds for a 2-second budget**.

Plain `timeout N` sends only SIGTERM, then waits indefinitely for a command that
ignores it. It still exits 124 — so it *claims* the run was bounded while
actually blocking for the command's full length. Measured:

| invocation | exit | elapsed |
|---|---|---|
| `timeout 2` | 124 | **60s** |
| `timeout --kill-after=2 2` | 137 | **4s** |

So the hook kept exactly the hang #251 set out to remove, on any machine with
coreutils installed — the common case, and the path most users take. The
watchdog fallback was correct the whole time; only the branch that normally runs
was broken.

Fixed with `--kill-after`, plus normalizing the resulting 137 to 124 so both
implementations report one expiry code. Re-verified across five scenarios on both
paths — over-budget, SIGTERM-ignoring, success, failure passthrough, under-budget
early return — which now agree on every one.

## Smaller items

`rm -rf ""` in the EXIT trap: now `${var:+"${var}"}`, so an abort before `mktemp`
expands to no argument at all. macOS treats `rm -rf ""` as a silent no-op
(verified), but GNU coreutils need not agree.

The reviewer's concern that the new fixture orphans its `sleep 60` **does not
occur**: sampling the process table across a full run shows the count rising per
case and returning to zero, none left at the end. Noted in the fixture so it
isn't re-raised.

A SIGKILLed child makes the invoking shell print a cosmetic "Killed: 9" notice.
It appears only on the escalation path, which already logs an explicit timeout
warning, and can't be suppressed from inside the function — the shell emits it
while reaping the job. Left alone rather than papered over with a subshell that
was tried and doesn't actually stop it.

Full suite 16/16, shellcheck `-S info` clean, dry-run reviewer PASS.

Closes #262

https://claude.ai/code/session_01TshyoHK7Jkhi6Td6b3vBqk
