### PR TITLE
fix(hooks): report expiry only when the watchdog is what killed the command

### DIFF
--- a/bash/tests/test-install-worktree-guard.sh
+++ b/bash/tests/test-install-worktree-guard.sh
@@ -26,12 +26,21 @@ REPO_ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 _tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/git-env-isolation.sh
 source "${_tests_dir}/lib/git-env-isolation.sh"
-isolate_git_env
 
 fail=0
 
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/install-worktree-test.XXXXXX")"
 trap 'rm -rf "${WORKDIR}"' EXIT
+
+# Pass WORKDIR as the ceiling, not just the bare call. This test asserts that the
+# guard REJECTS a non-repository directory, and without GIT_CEILING_DIRECTORIES a
+# git command run from a scratch dir walks up to whatever repository encloses it
+# — which would resolve, making that negative case pass vacuously
+# (smartwatermelon/dotfiles#264). WORKDIR lives under TMPDIR today, so nothing
+# encloses it in practice; the ceiling makes that a property of the test rather
+# than of where mktemp happened to put it. Verified: a scratch dir placed inside
+# a repo resolves to that repo's .git without a ceiling.
+isolate_git_env "${WORKDIR}"
 
 _pass() { echo "  PASS: $1"; }
 _fail() {

--- a/bash/tests/test-pre-push-scan-timeout.sh
+++ b/bash/tests/test-pre-push-scan-timeout.sh
@@ -302,6 +302,49 @@ for mode in timeout fallback; do
   fi
 done
 
+# ---------------------------------------------------------------
+# A signal death inside the budget is not an expiry
+# ---------------------------------------------------------------
+# The fallback used to relabel any 143/137 as 124, so a command killed by an
+# external SIGTERM well inside its budget was reported as a timeout
+# (smartwatermelon/dotfiles#266).
+#
+# The fixture signals ITSELF rather than the test hunting for the process with
+# pkill. Both `pkill -f "sleep N"` and `pkill -x -n sleep` were tried and are
+# unreliable here: -f also matches the driver shells, which carry the command in
+# their own argv, and -n races against the test's own helper sleeps. A
+# self-signalling fixture needs no process discovery at all, so the case cannot
+# flake on which process the pattern happened to match.
+echo "Case: an external signal inside the budget is not reported as expiry"
+
+SELF_SIGNALLER="${WORKDIR}/self-sigterm.sh"
+cat >"${SELF_SIGNALLER}" <<'SIGNALLER_EOF'
+#!/usr/bin/env bash
+# Dies by SIGTERM after 1s, well inside any budget this case uses. Stands in for
+# any external kill — an operator, an OOM reaper, a parent tearing down.
+sleep 1
+kill -TERM $$
+sleep 30
+SIGNALLER_EOF
+chmod +x "${SELF_SIGNALLER}"
+
+case_out="$(run_case 1 30 "${SELF_SIGNALLER}")"
+read -r rc elapsed <<<"${case_out}"
+
+if [[ "${rc}" == "143" ]]; then
+  _pass "watchdog fallback: a SIGTERM inside the budget reports 143, not the expiry code"
+elif [[ "${rc}" == "124" ]]; then
+  _fail "watchdog fallback: a signal death was mislabelled as an expiry (124)"
+else
+  _fail "watchdog fallback: signal death reported ${rc}, expected 143"
+fi
+
+if ((elapsed < 15)); then
+  _pass "watchdog fallback: returned on the signal (${elapsed}s), not at the 30s budget"
+else
+  _fail "watchdog fallback: took ${elapsed}s — did not return on the signal"
+fi
+
 echo
 if ((fail)); then
   echo "SOME CHECKS FAILED" >&2

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -244,6 +244,14 @@ run_bounded() {
   # Fallback watchdog: run the command in the background, kill it if it
   # outlives the budget. `wait` on a known pid yields the command's own exit
   # status, so a normal completion is reported untouched.
+  #
+  # The marker records that the watchdog — rather than anything else — is what
+  # killed the command, so the expiry code below is not inferred from the signal
+  # number alone.
+  local expiry_marker
+  expiry_marker="$(mktemp "${TMPDIR:-/tmp}/prepush-expiry.XXXXXX")"
+  rm -f "${expiry_marker}"
+
   "$@" &
   local cmd_pid=$!
 
@@ -257,6 +265,7 @@ run_bounded() {
       sleep 1
       ((waited += 1))
     done
+    : >"${expiry_marker}"
     kill -TERM "${cmd_pid}" 2>/dev/null || true
 
     # Escalate to SIGKILL only while the process is still ours to signal.
@@ -290,14 +299,27 @@ run_bounded() {
 
   local status=0
   wait "${cmd_pid}" 2>/dev/null || status=$?
+  # SIGTERM to the watchdog also takes down whatever `sleep` it is sitting in:
+  # that sleep is a foreground child of the subshell, not a background job, so
+  # it dies with its parent. Checked by sampling the process table across
+  # repeated calls — no `sleep` survives run_bounded's return
+  # (smartwatermelon/dotfiles#264).
   kill -TERM "${watchdog_pid}" 2>/dev/null || true
   wait "${watchdog_pid}" 2>/dev/null || true
 
-  # A killed command surfaces as 143 (SIGTERM) / 137 (SIGKILL); normalize to
-  # coreutils' 124 so callers have one expiry code to branch on.
-  if ((status == 143 || status == 137)); then
+  # Report expiry only when the WATCHDOG is what killed the command.
+  #
+  # Normalizing on the signal number alone would relabel any 143/137 as a
+  # timeout — including a command killed by an external SIGTERM well inside its
+  # budget, which is a signal death and not an expiry
+  # (smartwatermelon/dotfiles#266). The marker is written by the watchdog just
+  # before it signals, so its presence distinguishes "we timed this out" from
+  # "something else killed it".
+  if [[ -f "${expiry_marker}" ]] && ((status == 143 || status == 137)); then
+    rm -f "${expiry_marker}"
     return 124
   fi
+  rm -f "${expiry_marker}"
   return "${status}"
 }
 


### PR DESCRIPTION
Closes #264 and #266. Last PR in the stack.

## Expiry was inferred from the signal number alone (#266)

The fallback normalized any 143/137 to 124, so a command killed by an **external**
SIGTERM well inside its budget was reported as a timeout — an operator kill, an
OOM reaper, or a parent tearing down would all read as an expiry.

The watchdog now stamps a marker immediately before it signals, and the
normalization is gated on that marker. Verified: a command signalled at 1s of a
30s budget reports **143**, while a genuine expiry still reports **124**.
Falsified by reverting the gate, which makes the new case fail with "a signal
death was mislabelled as an expiry (124)".

### The test fixture signals itself

Worth noting because two obvious approaches don't work here. `pkill -f "sleep N"`
also matches the driver shells, which carry the command in their own argv — so it
killed the wrapper and the exit code was lost. `pkill -x -n sleep` raced against
the test's own helper sleeps and killed the wrong one. A self-signalling fixture
needs no process discovery at all, so the case can't flake on whichever process a
pattern happened to match.

## Isolation ceiling (#264)

`test-install-worktree-guard.sh` called `isolate_git_env` bare. That test asserts
the guard **rejects** a non-repository directory, and without
`GIT_CEILING_DIRECTORIES` a git command run from a scratch dir walks up to
whatever repository encloses it — which would resolve, making the negative case
pass vacuously.

WORKDIR lives under TMPDIR today so nothing encloses it in practice; passing the
ceiling makes that a property of the test rather than of where `mktemp` happened
to put it. Confirmed the failure mode is real: a scratch dir placed inside a repo
resolves to that repo's `.git` without a ceiling.

## Not reproduced

The reported watchdog `sleep` orphan doesn't occur. That sleep is a foreground
child of the subshell rather than a background job, so it dies with its parent.
Checked by sampling the process table across repeated calls — no `sleep` survives
`run_bounded`'s return. Noted in the hook so it isn't re-raised.

Full suite 16/16, shellcheck `-S info` clean, dry-run reviewer PASS with no
findings.

Closes #264
Closes #266

https://claude.ai/code/session_01TshyoHK7Jkhi6Td6b3vBqk
