### PR TITLE
fix(hooks): clean up the expiry marker with a RETURN trap

### DIFF
--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -248,9 +248,27 @@ run_bounded() {
   # The marker records that the watchdog — rather than anything else — is what
   # killed the command, so the expiry code below is not inferred from the signal
   # number alone.
+  # mktemp is used to RESERVE A UNIQUE PATH, not to create the file that is read
+  # later. The marker's meaning is its existence — the watchdog creates it with
+  # `: >` just before it signals, and the expiry check below tests for it — so
+  # the file mktemp creates is removed immediately, leaving the path free to
+  # carry that meaning. Without this the marker would already exist on every
+  # call and every result would look like an expiry.
+  #
+  # mktemp rather than a constructed name because it reserves the path against
+  # concurrent runs of this hook, which a "$$"-style name does not do reliably.
   local expiry_marker
   expiry_marker="$(mktemp "${TMPDIR:-/tmp}/prepush-expiry.XXXXXX")"
   rm -f "${expiry_marker}"
+
+  # RETURN genuinely fires here: run_bounded is a function, unlike the `bash -c`
+  # script top level where a RETURN trap silently never runs and leaked a
+  # directory per test run (smartwatermelon/dotfiles#256). Verified in a scratch
+  # function before relying on it.
+  #
+  # This covers every exit path, so a killed hook cannot leave the marker behind
+  # (smartwatermelon/dotfiles#268).
+  trap 'rm -f "${expiry_marker}"' RETURN
 
   "$@" &
   local cmd_pid=$!
@@ -315,11 +333,10 @@ run_bounded() {
   # (smartwatermelon/dotfiles#266). The marker is written by the watchdog just
   # before it signals, so its presence distinguishes "we timed this out" from
   # "something else killed it".
+  # Cleanup is the RETURN trap's job on every path below.
   if [[ -f "${expiry_marker}" ]] && ((status == 143 || status == 137)); then
-    rm -f "${expiry_marker}"
     return 124
   fi
-  rm -f "${expiry_marker}"
   return "${status}"
 }
 


### PR DESCRIPTION
Closes #268. Stacked on #269.

The expiry marker was created by `mktemp` and removed explicitly on each return
path, leaving a window in which a killed hook would leave the file behind.

`trap ... RETURN` closes it, and here it **genuinely fires**: `run_bounded` is a
function, unlike the `bash -c` script top level where a RETURN trap silently
never runs and leaked a directory per test run (#256). Verified in a scratch
function before relying on it, rather than assuming the two cases behave alike.
Three explicit `rm -f` calls collapse to one trap.

## The local reviewer flagged a line as dead code — it isn't

The pre-commit adversarial reviewer blocked this, calling the `rm -f` immediately
after `mktemp` "almost certainly a refactoring artifact." It's load-bearing, and
the comment now explains why.

`mktemp` here **reserves a path**; it does not create the file that's read later.
The marker's meaning is its *existence*, written by the watchdog with `: >` just
before it signals. Leaving mktemp's file in place would mean the marker already
exists on every call.

Demonstrated rather than argued — with that line removed:

| case | with `rm -f` | without |
|---|---|---|
| genuine expiry | 124 | 124 |
| signal inside budget | **143** | **124** ← the #266 bug, back |
| success | 0 | 0 |

So removing it reintroduces exactly the mislabelling #266 fixed. The reviewer
asked the right question ("does the watchdog *write* the marker, or rely on its
existence from mktemp?") and couldn't answer it from the diff; the answer is that
it writes, at `pre-push:277`.

Full suite 16/16, shellcheck `-S info` clean, both commit-time reviewers pass.

Closes #268

https://claude.ai/code/session_01TshyoHK7Jkhi6Td6b3vBqk
