### PR TITLE
fix(hooks): stop the timeout path conflating an external kill with an expiry

### DIFF
--- a/bash/tests/test-gh-wrapper-draft-off-org.sh
+++ b/bash/tests/test-gh-wrapper-draft-off-org.sh
@@ -106,7 +106,12 @@ mkdir -p "${off_org_clone}" "${in_org_clone}"
 # its mktemp and its explicit cleanup cannot leak it. The `:-` guard covers the
 # window before it is assigned. Leaked fixture dirs are the defect class this
 # suite has been clearing out (#255, #256).
-trap 'rm -rf "${off_org_clone}" "${in_org_clone}" "${cwd_status_dir:-}"' EXIT
+# `${cwd_status_dir:+...}` expands to nothing at all when the variable is unset,
+# rather than handing `rm -rf` an empty string. macOS `rm -rf ""` happens to be
+# a silent no-op (verified), but GNU coreutils is not obliged to agree, and a
+# spurious error here would land on top of whatever real failure triggered the
+# abort. This form is unambiguous on both.
+trap 'rm -rf "${off_org_clone}" "${in_org_clone}" ${cwd_status_dir:+"${cwd_status_dir}"}' EXIT
 (cd "${off_org_clone}" && command git init -q && command git remote add origin git@github.com:someoutsideorg/foo.git)
 (cd "${in_org_clone}" && command git init -q && command git remote add origin git@github.com:smartwatermelon/dotfiles.git)
 

--- a/bash/tests/test-gh-wrapper-draft-off-org.sh
+++ b/bash/tests/test-gh-wrapper-draft-off-org.sh
@@ -143,8 +143,18 @@ run_cwd_case() {
   )
 }
 
-run_cwd_case "${off_org_clone}" "off-org cwd remote fallback" 1 off-org
-run_cwd_case "${in_org_clone}" "in-org cwd remote fallback" 0 in-org
+# `|| true` so a subshell that dies mid-case does not abort this script under
+# `set -e`. Without it the script exits immediately with the subshell's status
+# and NO explanation — the missing-verdict check below never runs, so a broken
+# case looks like a bare non-zero exit rather than a named failure
+# (smartwatermelon/dotfiles#270).
+#
+# This does not weaken the fail-closed property: the verdict file is still only
+# written by a case that ran to completion, and a missing file is still treated
+# as a failure. It only ensures the failure is REPORTED instead of aborting
+# silently.
+run_cwd_case "${off_org_clone}" "off-org cwd remote fallback" 1 off-org || true
+run_cwd_case "${in_org_clone}" "in-org cwd remote fallback" 0 in-org || true
 
 for tag in off-org in-org; do
   if [[ ! -f "${cwd_status_dir}/${tag}" ]]; then

--- a/bash/tests/test-install-worktree-guard.sh
+++ b/bash/tests/test-install-worktree-guard.sh
@@ -26,12 +26,21 @@ REPO_ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 _tests_dir="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/git-env-isolation.sh
 source "${_tests_dir}/lib/git-env-isolation.sh"
-isolate_git_env
 
 fail=0
 
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/install-worktree-test.XXXXXX")"
 trap 'rm -rf "${WORKDIR}"' EXIT
+
+# Pass WORKDIR as the ceiling, not just the bare call. This test asserts that the
+# guard REJECTS a non-repository directory, and without GIT_CEILING_DIRECTORIES a
+# git command run from a scratch dir walks up to whatever repository encloses it
+# — which would resolve, making that negative case pass vacuously
+# (smartwatermelon/dotfiles#264). WORKDIR lives under TMPDIR today, so nothing
+# encloses it in practice; the ceiling makes that a property of the test rather
+# than of where mktemp happened to put it. Verified: a scratch dir placed inside
+# a repo resolves to that repo's .git without a ceiling.
+isolate_git_env "${WORKDIR}"
 
 _pass() { echo "  PASS: $1"; }
 _fail() {

--- a/bash/tests/test-pre-push-scan-timeout.sh
+++ b/bash/tests/test-pre-push-scan-timeout.sh
@@ -345,6 +345,54 @@ else
   _fail "watchdog fallback: took ${elapsed}s — did not return on the signal"
 fi
 
+# ---------------------------------------------------------------
+# run_bounded must survive its caller returning
+# ---------------------------------------------------------------
+# A `trap ... RETURN` set inside run_bounded is NOT scoped to run_bounded: it
+# stays armed and fires again when the CALLER returns, when the function's
+# `local` is out of scope and `set -u` aborts with "expiry_marker: unbound
+# variable". That shipped and turned CI red while every local run passed,
+# because this machine has coreutils `timeout` and never took the branch that
+# set the trap (smartwatermelon/dotfiles#268).
+#
+# The cases above all invoke run_bounded at the top level, so none of them would
+# have caught it. This one calls it from inside a function and then returns,
+# under `set -eu`, which is how the hook actually uses it.
+echo "Case: run_bounded does not corrupt its caller's scope"
+
+SCOPE_PROBE="${WORKDIR}/scope-probe.sh"
+cat >"${SCOPE_PROBE}" <<SCOPE_EOF
+set -euo pipefail
+source "${RUNNER_FILE}"
+outer() {
+  run_bounded 5 true
+  echo "inner-ok"
+}
+outer
+echo "caller-ok"
+SCOPE_EOF
+
+for mode in timeout fallback; do
+  label="GNU timeout"
+  probe_path="${PATH}"
+  if [[ "${mode}" == "fallback" ]]; then
+    label="watchdog fallback"
+    # Strip the directories carrying timeout/gtimeout, reproducing a stock macOS
+    # box — which is exactly what the CI runner is, and where this bug lived.
+    probe_path="/usr/bin:/bin"
+  fi
+
+  if scope_out="$(PATH="${probe_path}" "${TEST_BASH}" "${SCOPE_PROBE}" 2>&1)"; then
+    if [[ "${scope_out}" == *"caller-ok"* ]]; then
+      _pass "${label}: the caller returns normally after run_bounded"
+    else
+      _fail "${label}: caller did not complete — output: ${scope_out}"
+    fi
+  else
+    _fail "${label}: run_bounded aborted its caller — output: ${scope_out}"
+  fi
+done
+
 echo
 if ((fail)); then
   echo "SOME CHECKS FAILED" >&2

--- a/bash/tests/test-pre-push-scan-timeout.sh
+++ b/bash/tests/test-pre-push-scan-timeout.sh
@@ -249,6 +249,59 @@ for mode in timeout fallback; do
   fi
 done
 
+# ---------------------------------------------------------------
+# The SIGKILL escalation branch
+# ---------------------------------------------------------------
+# The cases above all terminate on SIGTERM, so the grace loop exits early and
+# the `kill -KILL` line never runs. That left the escalation branch with no
+# coverage at all: a future edit could break it and every test would still pass
+# (smartwatermelon/dotfiles#262).
+#
+# A command that IGNORES SIGTERM forces the escalation. It must still be
+# terminated, and within the grace budget rather than running to its own length.
+echo "Case: run_bounded escalates to SIGKILL for a SIGTERM-ignoring command"
+
+IGNORER="${WORKDIR}/ignores-sigterm.sh"
+cat >"${IGNORER}" <<'IGNORER_EOF'
+#!/usr/bin/env bash
+# Survives SIGTERM; only SIGKILL can stop this.
+#
+# The `sleep` runs in the foreground, so killing this script tears it down with
+# it. Verified by sampling `pgrep -f "sleep 60"` across a full run: the count
+# rises during each case and returns to zero between them, with none left
+# behind at the end.
+trap '' TERM
+sleep 60
+IGNORER_EOF
+chmod +x "${IGNORER}"
+
+for mode in timeout fallback; do
+  force=0
+  label="GNU timeout"
+  if [[ "${mode}" == "fallback" ]]; then
+    force=1
+    label="watchdog fallback"
+  fi
+
+  case_out="$(run_case "${force}" 2 "${IGNORER}")"
+  read -r rc elapsed <<<"${case_out}"
+
+  # GNU timeout reports 124 on expiry; the fallback normalizes SIGKILL's 137 to
+  # 124 itself. Either way the caller must see the expiry code.
+  if [[ "${rc}" == "124" ]]; then
+    _pass "${label}: a SIGTERM-ignoring command is still reported as expired"
+  else
+    _fail "${label}: SIGTERM-ignoring command exited ${rc}, expected 124"
+  fi
+
+  # The escalation must actually land. Unterminated, the command runs 60s.
+  if ((elapsed <= 20)); then
+    _pass "${label}: escalation killed it in ${elapsed}s, not its full 60s"
+  else
+    _fail "${label}: took ${elapsed}s — the SIGKILL escalation did not land"
+  fi
+done
+
 echo
 if ((fail)); then
   echo "SOME CHECKS FAILED" >&2

--- a/bash/tests/test-pre-push-scan-timeout.sh
+++ b/bash/tests/test-pre-push-scan-timeout.sh
@@ -302,6 +302,49 @@ for mode in timeout fallback; do
   fi
 done
 
+# ---------------------------------------------------------------
+# A signal death inside the budget is not an expiry
+# ---------------------------------------------------------------
+# The fallback used to relabel any 143/137 as 124, so a command killed by an
+# external SIGTERM well inside its budget was reported as a timeout
+# (smartwatermelon/dotfiles#266).
+#
+# The fixture signals ITSELF rather than the test hunting for the process with
+# pkill. Both `pkill -f "sleep N"` and `pkill -x -n sleep` were tried and are
+# unreliable here: -f also matches the driver shells, which carry the command in
+# their own argv, and -n races against the test's own helper sleeps. A
+# self-signalling fixture needs no process discovery at all, so the case cannot
+# flake on which process the pattern happened to match.
+echo "Case: an external signal inside the budget is not reported as expiry"
+
+SELF_SIGNALLER="${WORKDIR}/self-sigterm.sh"
+cat >"${SELF_SIGNALLER}" <<'SIGNALLER_EOF'
+#!/usr/bin/env bash
+# Dies by SIGTERM after 1s, well inside any budget this case uses. Stands in for
+# any external kill — an operator, an OOM reaper, a parent tearing down.
+sleep 1
+kill -TERM $$
+sleep 30
+SIGNALLER_EOF
+chmod +x "${SELF_SIGNALLER}"
+
+case_out="$(run_case 1 30 "${SELF_SIGNALLER}")"
+read -r rc elapsed <<<"${case_out}"
+
+if [[ "${rc}" == "143" ]]; then
+  _pass "watchdog fallback: a SIGTERM inside the budget reports 143, not the expiry code"
+elif [[ "${rc}" == "124" ]]; then
+  _fail "watchdog fallback: a signal death was mislabelled as an expiry (124)"
+else
+  _fail "watchdog fallback: signal death reported ${rc}, expected 143"
+fi
+
+if ((elapsed < 15)); then
+  _pass "watchdog fallback: returned on the signal (${elapsed}s), not at the 30s budget"
+else
+  _fail "watchdog fallback: took ${elapsed}s — did not return on the signal"
+fi
+
 echo
 if ((fail)); then
   echo "SOME CHECKS FAILED" >&2

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -216,8 +216,29 @@ run_bounded() {
   fi
 
   if [[ -n "${timeout_bin}" ]]; then
-    "${timeout_bin}" "${secs}" "$@"
-    return $?
+    # --kill-after is not optional. Plain `timeout N` sends only SIGTERM and
+    # then waits indefinitely for a command that ignores it — it still reports
+    # 124, so it CLAIMS to have bounded the run while actually blocking for the
+    # command's full length. Measured: `timeout 2` against a SIGTERM-ignoring
+    # command returned 124 after 60 seconds; with --kill-after it returned at 4
+    # (smartwatermelon/dotfiles#262). Without this the hook keeps exactly the
+    # hang #251 set out to remove, on any machine that has coreutils.
+    local timeout_status=0
+    # A SIGKILLed child makes the invoking shell print a "Killed: 9" job notice
+    # on its own stderr. That is cosmetic and only appears on the escalation
+    # path, which already logs an explicit timeout warning right after — and it
+    # cannot be suppressed from inside this function, since the notice comes
+    # from the shell reaping the job rather than from the command. Left alone
+    # rather than papered over with a subshell that does not actually stop it.
+    "${timeout_bin}" --kill-after="${SEMGREP_TIMEOUT_KILL_GRACE:-2}" "${secs}" "$@" \
+      || timeout_status=$?
+    # When --kill-after escalates, timeout exits 137 (SIGKILL) rather than 124.
+    # Both mean the same thing to the caller — the budget expired — so report
+    # one code, matching the fallback path below.
+    if ((timeout_status == 137 || timeout_status == 143)); then
+      return 124
+    fi
+    return "${timeout_status}"
   fi
 
   # Fallback watchdog: run the command in the background, kill it if it

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -244,6 +244,14 @@ run_bounded() {
   # Fallback watchdog: run the command in the background, kill it if it
   # outlives the budget. `wait` on a known pid yields the command's own exit
   # status, so a normal completion is reported untouched.
+  #
+  # The marker records that the watchdog — rather than anything else — is what
+  # killed the command, so the expiry code below is not inferred from the signal
+  # number alone.
+  local expiry_marker
+  expiry_marker="$(mktemp "${TMPDIR:-/tmp}/prepush-expiry.XXXXXX")"
+  rm -f "${expiry_marker}"
+
   "$@" &
   local cmd_pid=$!
 
@@ -257,6 +265,7 @@ run_bounded() {
       sleep 1
       ((waited += 1))
     done
+    : >"${expiry_marker}"
     kill -TERM "${cmd_pid}" 2>/dev/null || true
 
     # Escalate to SIGKILL only while the process is still ours to signal.
@@ -290,14 +299,27 @@ run_bounded() {
 
   local status=0
   wait "${cmd_pid}" 2>/dev/null || status=$?
+  # SIGTERM to the watchdog also takes down whatever `sleep` it is sitting in:
+  # that sleep is a foreground child of the subshell, not a background job, so
+  # it dies with its parent. Checked by sampling the process table across
+  # repeated calls — no `sleep` survives run_bounded's return
+  # (smartwatermelon/dotfiles#264).
   kill -TERM "${watchdog_pid}" 2>/dev/null || true
   wait "${watchdog_pid}" 2>/dev/null || true
 
-  # A killed command surfaces as 143 (SIGTERM) / 137 (SIGKILL); normalize to
-  # coreutils' 124 so callers have one expiry code to branch on.
-  if ((status == 143 || status == 137)); then
+  # Report expiry only when the WATCHDOG is what killed the command.
+  #
+  # Normalizing on the signal number alone would relabel any 143/137 as a
+  # timeout — including a command killed by an external SIGTERM well inside its
+  # budget, which is a signal death and not an expiry
+  # (smartwatermelon/dotfiles#266). The marker is written by the watchdog just
+  # before it signals, so its presence distinguishes "we timed this out" from
+  # "something else killed it".
+  if [[ -f "${expiry_marker}" ]] && ((status == 143 || status == 137)); then
+    rm -f "${expiry_marker}"
     return 124
   fi
+  rm -f "${expiry_marker}"
   return "${status}"
 }
 

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -232,10 +232,25 @@ run_bounded() {
     # rather than papered over with a subshell that does not actually stop it.
     "${timeout_bin}" --kill-after="${SEMGREP_TIMEOUT_KILL_GRACE:-2}" "${secs}" "$@" \
       || timeout_status=$?
-    # When --kill-after escalates, timeout exits 137 (SIGKILL) rather than 124.
-    # Both mean the same thing to the caller — the budget expired — so report
-    # one code, matching the fallback path below.
-    if ((timeout_status == 137 || timeout_status == 143)); then
+    # 137 ONLY, not 143. GNU timeout already distinguishes these itself, so
+    # mapping both would throw away information it went to the trouble of
+    # providing (smartwatermelon/dotfiles#270). Measured against GNU coreutils
+    # timeout, which is what `brew install coreutils` provides and what this
+    # hook's macOS environment has; the codes below follow coreutils' documented
+    # convention (128+signal, 124 for expiry) rather than being specific to this
+    # machine. A non-GNU `timeout` is not expected on the supported platform, and
+    # if one appeared, a mismatched code lands in the generic branch — which
+    # prompts interactively and blocks in strict mode, so it degrades safely
+    # rather than passing a scan off as clean.
+    #
+    #   124 — its own expiry, SIGTERM sufficed
+    #   137 — its own expiry, escalated via --kill-after
+    #   143 — the timeout BINARY was killed from outside, inside its budget
+    #
+    # So 137 is an expiry and folds into 124 for one caller-facing code, while
+    # 143 is a signal death that must stay 143. Collapsing it would reintroduce
+    # on this path exactly the mislabelling #266 fixed on the fallback.
+    if ((timeout_status == 137)); then
       return 124
     fi
     return "${timeout_status}"
@@ -251,6 +266,19 @@ run_bounded() {
   local expiry_marker
   expiry_marker="$(mktemp "${TMPDIR:-/tmp}/prepush-expiry.XXXXXX")"
   rm -f "${expiry_marker}"
+
+  # Cleanup is explicit on each return path below, NOT a `trap ... RETURN`.
+  #
+  # A RETURN trap set inside a function is not scoped to that function: it stays
+  # armed and fires again when the CALLER returns, by which point this `local`
+  # is out of scope and `set -u` aborts the hook with "expiry_marker: unbound
+  # variable". That reached CI as a red bash-tests run — invisible locally,
+  # where coreutils `timeout` exists so this branch never executes
+  # (smartwatermelon/dotfiles#268 attempted the trap; this reverts it).
+  #
+  # The window #268 wanted closed is narrow and the residue is harmless: an
+  # empty file under TMPDIR with a recognizable prefix, which the OS collects.
+  # Trading a real crash for that is not a good exchange.
 
   "$@" &
   local cmd_pid=$!
@@ -315,11 +343,15 @@ run_bounded() {
   # (smartwatermelon/dotfiles#266). The marker is written by the watchdog just
   # before it signals, so its presence distinguishes "we timed this out" from
   # "something else killed it".
-  if [[ -f "${expiry_marker}" ]] && ((status == 143 || status == 137)); then
-    rm -f "${expiry_marker}"
-    return 124
+  local expired=0
+  if [[ -f "${expiry_marker}" ]]; then
+    expired=1
   fi
   rm -f "${expiry_marker}"
+
+  if ((expired)) && ((status == 143 || status == 137)); then
+    return 124
+  fi
   return "${status}"
 }
 


### PR DESCRIPTION
Closes #270. Stacked on #271.

## The expiry gate was only half-applied

#266 gated the expiry normalization on the **fallback** path but left the
**timeout-binary** path mapping both 137 and 143 to 124 — the same defect, on the
branch that actually runs whenever coreutils is installed.

GNU `timeout` already distinguishes these, so collapsing them discarded
information it provides. Measured all three directly:

| exit | meaning |
|---|---|
| 124 | its own expiry, SIGTERM sufficed |
| 137 | its own expiry, escalated via `--kill-after` |
| 143 | the `timeout` **binary** was killed from outside, inside its budget |

137 is an expiry and still folds into 124 for one caller-facing code; 143 is a
signal death and now stays 143. Both paths now agree across five cases: expiry,
expiry-via-SIGKILL, command signalled inside budget, success, failure passthrough.

On portability: these follow coreutils' documented convention (128+signal, 124
for expiry) rather than being specific to this machine. A non-GNU `timeout` isn't
expected on the supported platform, and a mismatched code lands in the generic
branch — which prompts interactively and blocks in strict mode, so it degrades
safely rather than passing a scan off as clean.

## Second finding is wrong, but pointed at something real

#270 claims an `assert_args` internal error still writes a verdict file. It
doesn't — under `set -e` the subshell aborts before the `printf`, so no verdict is
recorded and the parent fails closed. Verified by making `assert_args` return
non-zero.

Checking it did surface a different weakness. The **unguarded** call meant `set
-e` killed the whole script with the subshell's status, so the parent's
missing-verdict check never ran: a broken case appeared as a bare `exit 3` with no
explanation. Adding `|| true` at the two call sites lets the check run — the same
sabotage now reports both cases by name and exits 1.

This doesn't weaken fail-closed: a verdict file is still only written by a case
that ran to completion, and a missing one is still a failure. It only makes the
failure *reported* rather than silent.

Full suite 16/16, shellcheck `-S info` clean, dry-run reviewer PASS.

Closes #270

https://claude.ai/code/session_01TshyoHK7Jkhi6Td6b3vBqk
