### PR TITLE
fix(hooks): report when pre-push is edited while it is running

### DIFF
--- a/bash/tests/test-hook-mutation-warning.sh
+++ b/bash/tests/test-hook-mutation-warning.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#shellcheck shell=bash
+# Standalone verification that git/hooks/pre-push notices when its own file is
+# rewritten while it is running.
+# Run directly: bash bash/tests/test-hook-mutation-warning.sh
+#
+# Bash does not read a script into memory before running it: it reads a chunk,
+# executes it, then returns to the FILE for the next chunk by byte offset. This
+# hook is deployed as a symlink into a live working tree, so editing that file —
+# or any checkout/rebase/reset that rewrites it — can make bash resume at a
+# stale offset and report an error citing a line whose content does not match
+# the message (smartwatermelon/dotfiles#274).
+#
+# The hook does not prevent that; it reports it, so the operator can tell a
+# spurious failure from a real one. This test covers the reporting.
+set -uo pipefail
+unset CDPATH
+
+REPO_ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="${REPO_ROOT}/git/hooks/pre-push"
+
+fail=0
+
+_pass() { echo "  PASS: $1"; }
+_fail() {
+  echo "  FAIL: $1" >&2
+  fail=1
+}
+
+# ---------------------------------------------------------------
+# Case 1: the detection is wired up
+# ---------------------------------------------------------------
+echo "Case: the mutation detector is installed and survives nested traps"
+
+if grep -q '_warn_if_hook_mutated' "${HOOK}"; then
+  _pass "the detector function is present"
+else
+  _fail "no _warn_if_hook_mutated in the hook (this is #274's reporting)"
+fi
+
+# The stamp must follow the symlink. Stamping "$0" would watch the symlink
+# itself, whose mtime does not change when its target is rewritten — so the
+# detector would never fire in the deployed configuration.
+if grep -q 'readlink -f' "${HOOK}"; then
+  _pass "the stamp resolves the symlink target"
+else
+  _fail "the stamp does not resolve the symlink — it would never fire when deployed"
+fi
+
+# Every EXIT trap must keep the detector. A bare `trap - EXIT` or a replacement
+# trap would silently drop it for the rest of the run, which is exactly the
+# window where #274 was observed.
+bare_clears="$(grep -cE "^\s*trap - EXIT\s*$" "${HOOK}" || true)"
+if ((bare_clears == 0)); then
+  _pass "no bare 'trap - EXIT' drops the detector"
+else
+  _fail "${bare_clears} bare 'trap - EXIT' would disable the detector mid-run"
+fi
+
+# Count every trap that installs a handler on EXIT (with or without ERR), and
+# require each to mention the detector. The two patterns must describe the same
+# set, or the comparison is meaningless — hence the shared prefix.
+exit_traps="$(grep -cE "^[[:space:]]*trap '[^']*' (ERR )?EXIT" "${HOOK}" || true)"
+detector_traps="$(grep -cE "^[[:space:]]*trap '[^']*_warn_if_hook_mutated[^']*' (ERR )?EXIT" "${HOOK}" || true)"
+if ((exit_traps > 0)) && ((exit_traps == detector_traps)); then
+  _pass "all ${exit_traps} EXIT trap(s) retain the detector"
+else
+  _fail "${exit_traps} EXIT trap(s) but only ${detector_traps} retain the detector"
+fi
+
+# ---------------------------------------------------------------
+# Case 2: behavioral — it fires on mutation, and only on mutation
+# ---------------------------------------------------------------
+# Exercised on a copy of the real hook, so the wiring under test is the shipped
+# wiring rather than a restatement of it.
+echo "Case: the warning fires on a mid-run rewrite, and not otherwise"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/hook-mutation-test.XXXXXX")"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+WARN_RE='EDITED WHILE IT WAS RUNNING'
+
+# The hook runs Semgrep and AI reviews, which take minutes. Neither is needed to
+# exercise the trap wiring, so the copy is truncated to the detector plus a
+# short sleep — the window in which a rewrite lands.
+build_probe() {
+  local out="$1"
+  # Take everything up to and including the top-level trap, then stop.
+  sed -n '1,/^trap .\_warn_if_hook_mutated. ERR EXIT$/p' "${HOOK}" >"${out}"
+  {
+    echo 'echo probe-running'
+    echo 'sleep 1'
+    echo 'echo probe-done'
+  } >>"${out}"
+}
+
+run_probe() {
+  local path="$1" out="$2" mutate="$3"
+  bash "${path}" >"${out}" 2>&1 &
+  local pid=$!
+  sleep 0.4
+  if [[ "${mutate}" == "mutate" ]]; then
+    printf '\n# appended mid-run\n' >>"${path}"
+  fi
+  wait "${pid}" 2>/dev/null || true
+}
+
+build_probe "${WORKDIR}/quiet.sh"
+run_probe "${WORKDIR}/quiet.sh" "${WORKDIR}/quiet.log" no
+
+build_probe "${WORKDIR}/noisy.sh"
+run_probe "${WORKDIR}/noisy.sh" "${WORKDIR}/noisy.log" mutate
+
+quiet_hits="$(grep -cE "${WARN_RE}" "${WORKDIR}/quiet.log" || true)"
+noisy_hits="$(grep -cE "${WARN_RE}" "${WORKDIR}/noisy.log" || true)"
+
+# The negative case first: a detector that always fires is as useless as one
+# that never does.
+if ((quiet_hits == 0)); then
+  _pass "an untouched run stays silent (no false positive)"
+else
+  _fail "an untouched run warned ${quiet_hits} time(s) — false positive"
+fi
+
+if ((noisy_hits == 1)); then
+  _pass "a rewritten run warns exactly once"
+elif ((noisy_hits == 0)); then
+  _fail "a rewritten run did NOT warn — the detector is not working"
+else
+  _fail "a rewritten run warned ${noisy_hits} times — the once-only guard failed"
+fi
+
+echo
+if ((fail)); then
+  echo "SOME CHECKS FAILED" >&2
+  exit 1
+fi
+echo "test-hook-mutation-warning: all cases passed"

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -2,6 +2,70 @@
 set -euo pipefail
 
 # =========================================================
+# SELF-MUTATION DETECTION
+# =========================================================
+# Bash does not read a script into memory before running it: it reads a chunk,
+# executes it, then returns to the FILE for the next chunk, tracking its place
+# by byte offset. This hook is deployed as a symlink into a live working tree
+# (~/.config/git/hooks/pre-push -> the dotfiles checkout), so editing that file
+# — or any checkout/rebase/reset that rewrites it — moves bytes under a shell
+# that is still reading. Bash then resumes at a stale offset in new content and
+# lands mid-line, reporting errors that cite a line whose content does not match
+# the message (smartwatermelon/dotfiles#274):
+#
+#   line 490: ==================: command not found
+#   line 412: syntax error near unexpected token `('
+#
+# The first is a comment divider whose "# " prefix fell outside the resumed
+# offset. Such an error is not a defect in this hook and not a problem with the
+# code being pushed — the push aborts cleanly and an unchanged retry succeeds.
+#
+# This does not PREVENT the corruption. Wrapping the body in a brace group would
+# (bash parses the whole block before executing any of it), but that idiom
+# belongs to scripts piped over a network — `curl … | bash` — not to a local
+# file, no other hook here uses it, and the repo's shell formatter reindents
+# everything inside the braces, turning a three-line change into a 644-line
+# reformat. The failure only occurs while the hook file is actively being
+# rewritten, so naming it clearly is worth more than engineering it away.
+#
+# Stamp the RESOLVED target rather than "$0": the deployed path is a symlink,
+# whose own mtime does not change when the file it points at is rewritten.
+_HOOK_REAL_PATH="$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
+_hook_stamp() {
+  # mtime:size — cheap, and enough to catch any rewrite that shifts offsets.
+  stat -f '%m:%z' "${_HOOK_REAL_PATH}" 2>/dev/null || echo "unknown"
+}
+_HOOK_STAMP_START="$(_hook_stamp)"
+_HOOK_MUTATION_REPORTED=0
+
+_warn_if_hook_mutated() {
+  # Fires from both ERR and EXIT so it is reported whether the corruption
+  # surfaces as a failed command or as a clean-looking early finish; the guard
+  # keeps it to one message.
+  [[ "${_HOOK_MUTATION_REPORTED}" == "1" ]] && return 0
+  local now
+  now="$(_hook_stamp)"
+  [[ "${now}" == "${_HOOK_STAMP_START}" ]] && return 0
+  _HOOK_MUTATION_REPORTED=1
+
+  echo "" >&2
+  echo "⚠️  [PRE-PUSH] THIS HOOK WAS EDITED WHILE IT WAS RUNNING." >&2
+  echo "" >&2
+  echo "    ${_HOOK_REAL_PATH}" >&2
+  echo "    changed mid-run (${_HOOK_STAMP_START} -> ${now})." >&2
+  echo "" >&2
+  echo "    Bash reads a script incrementally, so it may have resumed at a" >&2
+  echo "    stale byte offset. Any syntax error above that cites a line whose" >&2
+  echo "    content does not match the message is THIS, not your code and not" >&2
+  echo "    a real finding (smartwatermelon/dotfiles#274)." >&2
+  echo "" >&2
+  echo "    Nothing is lost. Re-run the push once the file has settled." >&2
+  echo "    Do NOT reach for STRICT_PREPUSH=0 on account of this." >&2
+  echo "" >&2
+}
+trap '_warn_if_hook_mutated' ERR EXIT
+
+# =========================================================
 # COLOR OUTPUT AND LOGGING FUNCTIONS
 # =========================================================
 
@@ -498,7 +562,10 @@ run_reviews() {
   local fulldiff_log codebase_log
   fulldiff_log=$(mktemp)
   codebase_log=$(mktemp)
-  trap 'rm -f "${fulldiff_log:-}" "${codebase_log:-}"' EXIT
+  # Chain the mutation warning rather than replacing it: a bare EXIT trap here
+  # would drop the detection installed at the top of this file for the rest of
+  # the run, which is exactly the window where #274 was observed.
+  trap 'rm -f "${fulldiff_log:-}" "${codebase_log:-}"; _warn_if_hook_mutated' EXIT
 
   (echo "${full_diff}" | "${REVIEW_SCRIPT}" --mode=full-diff >"${fulldiff_log}" 2>&1) &
   local fulldiff_pid=$!
@@ -522,7 +589,8 @@ run_reviews() {
   # linger as a process-scoped handler referencing now-out-of-scope
   # locals once this function returns (it's only meaningful for
   # early-exit paths still inside this function's execution).
-  trap - EXIT
+  # Restore the top-level detection rather than clearing to default.
+  trap '_warn_if_hook_mutated' EXIT
 
   # Evaluate results
   local has_failure=false


### PR DESCRIPTION
Closes #274.

## What the bug is

Bash doesn't read a script into memory before running it. It reads a chunk, runs
it, then goes back to the **file** for the next chunk — tracking its place by
byte offset.

This hook is deployed as a symlink into a live working tree
(`~/.config/git/hooks/pre-push` → the dotfiles checkout). So editing that file —
or any `checkout`/`rebase`/`reset` that rewrites it — moves bytes under a shell
that's still reading. Bash resumes at a stale offset, lands mid-line, and reports
an error citing a line whose content doesn't match the message:

```
line 490: ==================: command not found
```

That's a comment divider whose `# ` prefix fell outside the resumed offset.
Reproduced directly by rewriting a running script with a shorter earlier line.

## What this does — report, not prevent

Stamps the hook file's mtime+size at start, and warns loudly if it changed:

```
⚠️  [PRE-PUSH] THIS HOOK WAS EDITED WHILE IT WAS RUNNING.

    /Users/.../git/hooks/pre-push
    changed mid-run (1787765751:33716 -> 1787765752:32572).

    Bash reads a script incrementally, so it may have resumed at a
    stale byte offset. Any syntax error above that cites a line whose
    content does not match the message is THIS, not your code and not
    a real finding (smartwatermelon/dotfiles#274).

    Nothing is lost. Re-run the push once the file has settled.
    Do NOT reach for STRICT_PREPUSH=0 on account of this.
```

That last line matters: the reporter noted a spurious "Review found issues" was
easy to misread as a real finding, and reaching for `STRICT_PREPUSH=0` on a false
block is the actual risk.

## Why not prevent it

Wrapping the body in `{ ... }` **does** prevent it — bash parses the whole block
before executing any of it, and I verified that on this hook (unwrapped: 1
corruption error under mid-run rewrite; wrapped: 0).

I backed it out anyway:

- The idiom belongs to scripts piped over a network (`curl … | bash`), not a
  local file read from disk.
- **None of the other seven hooks here use it**, and no shipped script in this
  repo does. `pre-push` would be the lone exception.
- The repo's own `shell-lint-fix` reindents everything inside the braces —
  a three-line change commits as a **644-line reformat**, resetting `git blame`
  on the whole hook.

It also treats a *deployment* problem as a *code* problem: the root cause is that
the deployed hook is a symlink into a live tree. Wrapping one file leaves the
other seven exposed. The failure only occurs while the hook is actively being
rewritten, the push aborts cleanly, and a retry succeeds — so naming it clearly
beats engineering it away. If it ever becomes a real nuisance, the deployment
model is the thing to revisit.

## Two details that would have made this a no-op

- **The stamp resolves the symlink target, not `$0`.** The deployed path is a
  symlink whose own mtime doesn't change when its target is rewritten — stamping
  `$0` would never fire in the exact configuration that has the problem.
- **The two EXIT traps in `run_reviews()` now chain the detector.** A bare
  `trap - EXIT` there dropped detection for the rest of the run — precisely the
  window where the reported failures occurred.

## On the reported diagnosis

The report proposed stdin theft: background subshells inheriting the hook's stdin
and eating script bytes. That mechanism is **ruled out** —
`protected_branch_check()` drains stdin to EOF at lines 83–107, and
`run_reviews()` spawns its subshells several hundred lines later, so stdin is
already exhausted. The line-325 subshell is the `run_bounded` watchdog, which
never reads stdin.

The report was explicit that its mechanism was a hypothesis, and everything it
documented factually checks out — the line/content mismatch, zero `</dev/null`
redirections, clean `bash -n`, all four prompts guarded by `[[ -t 0 ]]`. The
symptom is real; only the cause differs.

## Testing

Test runs in ~2s against a truncated copy of the real hook, so it exercises the
shipped traps rather than a restatement of them (the full hook runs Semgrep and
AI reviews — minutes, and not needed to test a trap). It asserts the **silent**
case first: a detector that always fires is as useless as one that never does.

Falsified both ways — restoring the bare `trap - EXIT`, and stamping `$0` — each
fails the guard that exists for it.

Full suite 17/17, shellcheck `-S info` clean, dry-run reviewer PASS with no
findings. Two deletions total, both intentional trap changes; no reformat.

Closes #274

https://claude.ai/code/session_01TshyoHK7Jkhi6Td6b3vBqk
