### PR TITLE
refactor(pre-push): drop --mode=codebase from the push path

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -167,7 +167,7 @@ and check whether any reported findings' line ranges overlap your diff.
 
 **Why**: Ensures CI workflows use same linting rules as local development
 
-**Also runs AI review**: on non-main branches with a diff against `main`, the hook runs `~/.claude/hooks/run-review.sh` in `--mode=full-diff` and `--mode=codebase`. The codebase pass **files its non-blocking findings as GitHub issues in whatever repo you are pushing from** — this hook is global via `core.hooksPath`, so that is not limited to claude-config. To read those findings before they are filed, dry-run the same script with `gh` stubbed: see `claude-config/docs/CHECKLISTS.md` -> "Pre-Push Review Dry-Run" (also reachable as `~/.claude/docs/CHECKLISTS.md`). The reviewer and its procedure live in claude-config; if `run-review.sh` moves, the docs move with it.
+**Also runs AI review**: on non-main branches with a diff against `main`, the hook runs `~/.claude/hooks/run-review.sh` in `--mode=full-diff`. That pass reports its findings to stderr and gates the push on its exit code; it **files no GitHub issues**. `--mode=codebase` used to run here in parallel and was the only thing on the push path that filed issues. It was removed from the push path — see `dev-env/docs/plans/2026-08-26-review-pipeline-redesign-design.md` §1 — because a whole-codebase scan hunts pre-existing defects, which do not appear between pushes. The mode itself remains in `run-review.sh` for weekly and on-demand use. The reviewer lives in claude-config; if `run-review.sh` moves, the docs move with it.
 
 ### post-checkout
 

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -511,12 +511,18 @@ run_static_analysis() {
 run_static_analysis
 
 # =========================================================
-# FULL-DIFF + CODEBASE REVIEW (parallel)
+# FULL-DIFF REVIEW
 # =========================================================
-# Runs two reviews in parallel on complete main...HEAD diff:
+# Runs one review on the complete main...HEAD diff:
 #   --mode=full-diff: diff-only cross-file integration check
-#   --mode=codebase:  whole-codebase review with tool access
-# Both must pass for push to succeed.
+# It must pass for the push to succeed.
+#
+# --mode=codebase used to run here in parallel. It was removed from the push
+# path (dev-env/docs/plans/2026-08-26-review-pipeline-redesign-design.md §1):
+# a whole-codebase scan hunts PRE-EXISTING defects, which do not appear between
+# pushes, so per-push cadence bought nothing while costing a second Sonnet call
+# on the identical diff and a non-converging stream of auto-filed issues. The
+# mode still exists in run-review.sh for weekly and on-demand use.
 run_reviews() {
   local current_branch
   current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
@@ -543,48 +549,36 @@ run_reviews() {
   local diff_lines
   diff_lines=$(echo "${full_diff}" | wc -l | tr -d ' ')
 
-  # Runs a whole-codebase review that FILES its non-blocking findings as GitHub
-  # issues, in whatever repo you are pushing from (this hook is global via
-  # core.hooksPath). To read those findings before they are filed, dry-run this
-  # same script with `gh` stubbed first: see claude-config/docs/CHECKLISTS.md ->
-  # "Pre-Push Review Dry-Run". That procedure is authored alongside the reviewer,
-  # not alongside this hook — if run-review.sh ever moves, the docs move with it.
+  # The surviving --mode=full-diff review files nothing: every path through
+  # run-review.sh's full-diff block exits before reaching the sole
+  # create_nonblocking_issues call site, which lives in the codebase block.
+  # No push from this hook creates a GitHub issue, so the dry-run procedure
+  # that used to be referenced here no longer applies to the push path.
   local REVIEW_SCRIPT="${HOME}/.claude/hooks/run-review.sh"
   if [[ ! -x "${REVIEW_SCRIPT}" ]]; then
     log_warning "run-review.sh not found — skipping reviews"
     return 0
   fi
 
-  log "Running full-diff + codebase review in parallel (${diff_lines} lines)"
+  log "Running full-diff review (${diff_lines} lines)"
 
-  # Run both reviews in parallel
-  local fulldiff_exit=0 codebase_exit=0
-  local fulldiff_log codebase_log
+  local fulldiff_exit=0
+  local fulldiff_log
   fulldiff_log=$(mktemp)
-  codebase_log=$(mktemp)
   # Chain the mutation warning rather than replacing it: a bare EXIT trap here
   # would drop the detection installed at the top of this file for the rest of
   # the run, which is exactly the window where #274 was observed.
-  trap 'rm -f "${fulldiff_log:-}" "${codebase_log:-}"; _warn_if_hook_mutated' EXIT
+  trap 'rm -f "${fulldiff_log:-}"; _warn_if_hook_mutated' EXIT
 
   (echo "${full_diff}" | "${REVIEW_SCRIPT}" --mode=full-diff >"${fulldiff_log}" 2>&1) &
   local fulldiff_pid=$!
 
-  (echo "${full_diff}" | "${REVIEW_SCRIPT}" --mode=codebase >"${codebase_log}" 2>&1) &
-  local codebase_pid=$!
-
-  # Wait for both
   wait "${fulldiff_pid}" || fulldiff_exit=$?
-  wait "${codebase_pid}" || codebase_exit=$?
 
-  # Show output from both
   if [[ -s "${fulldiff_log}" ]]; then
     cat "${fulldiff_log}" >&2
   fi
-  if [[ -s "${codebase_log}" ]]; then
-    cat "${codebase_log}" >&2
-  fi
-  rm -f "${fulldiff_log}" "${codebase_log}"
+  rm -f "${fulldiff_log}"
   # Explicit cleanup above already ran; unset the trap so it doesn't
   # linger as a process-scoped handler referencing now-out-of-scope
   # locals once this function returns (it's only meaningful for
@@ -597,10 +591,6 @@ run_reviews() {
   if [[ ${fulldiff_exit} -ne 0 ]]; then
     has_failure=true
     log_warning "Full-diff review found issues"
-  fi
-  if [[ ${codebase_exit} -ne 0 ]]; then
-    has_failure=true
-    log_warning "Codebase review found issues"
   fi
 
   if [[ "${has_failure}" == true ]]; then
@@ -630,7 +620,7 @@ run_reviews() {
       return 0
     fi
   else
-    log_success "Full-diff + codebase review passed"
+    log_success "Full-diff review passed"
   fi
 }
 run_reviews


### PR DESCRIPTION
## What

Removes the `--mode=codebase` invocation from `git/hooks/pre-push`. It was the
second of two parallel `run-review.sh` calls in `run_reviews()`. The
`--mode=full-diff` call is untouched and still gates the push on its exit code.

`--mode=codebase` remains fully functional in `run-review.sh`. Only its per-push
trigger is removed.

## Why

The fix-then-re-review loop on the whole-codebase scan does not converge, and the
cause is structural rather than a matter of prompt quality:

- **Unbounded search space.** The mode hunts *pre-existing* defects across the
  whole repository. A diff is finite; a repository's imperfections are not. Each
  run samples a fresh subset of an effectively unbounded pool, so the series
  cannot converge regardless of how the prompt is tuned.
- **Pre-existing defects do not appear between pushes.** Per-push cadence buys
  nothing a slower cadence would not, while costing a second Sonnet call on the
  *identical* diff plus a false-positive tax — only 12.5% of a classified sample
  (n=40) were real correctness or security findings.
- **The duplication is intra-run.** Median gap between near-duplicate filings is
  72 seconds — one pass emitting the same finding two or three times.
- **Prompt-tuning is exhausted.** Fourteen consecutive suppression-gate commits
  on the reviewer; claude-config#434 validated at 0 findings and still produced
  new issues on its next run.

This also removes every auto-filed GitHub issue from the push path.
`run-review.sh`'s sole `create_nonblocking_issues` call site is inside the
codebase block, and every path through the full-diff block exits before reaching
it. That fact is verified in the diff, not assumed.

Coverage measurement found 55% of the mode's genuine findings have no successor
layer, so the capability is kept and moves to weekly plus on-demand rather than
being deleted.

Design: `dev-env/docs/plans/2026-08-26-review-pipeline-redesign-design.md` (§1)

## Verification

- `shellcheck -S info git/hooks/pre-push` — clean, zero `# shellcheck disable`
  directives in the file.
- `bash -n` — syntax OK.
- Repo test suite on push: **17 passed, 0 failed**, including
  `test-pre-push-scan-timeout.sh` and `test-hook-mutation-warning.sh`, which
  exercise this file.
- Pre-push codebase reviewer dry-run (`--no-file`): PASS.

**Full-diff regression check, validated against a known-bad control.** The risk
here is silently breaking the surviving review, so a clean result needed proving.
A harness extracts `run_reviews()` from the hook under test, stubs
`REVIEW_SCRIPT` with a script that records its args and returns a controllable
exit code, and drives it against a throwaway repo with a real `main...HEAD`
divergence.

Control first — a sabotaged copy with the full-diff call *also* deleted:

```
HOOK_EXIT=0
--- stub invocations ---
(stub never invoked)
[ok] Full-diff review passed      <- false pass, stub was set to exit 1
```

The harness catches that regression, so it has discriminating power. The actual
change:

| Stub exit | Hook exit | Stub invoked with |
|---|---|---|
| 1 (review fails) | **1** — push blocked | `--mode=full-diff` (once) |
| 0 (review passes) | 0 | `--mode=full-diff` (once) |

`--mode=codebase` is never invoked. The `_warn_if_hook_mutated` chaining fires in
every case, and a before/after `TMPDIR` count shows **0 leaked temp files**, so
`fulldiff_log` cleanup still works.

## Also

`git/README.md` documented the codebase pass as filing GitHub issues on every
push. That is no longer true of any push-path review, so it is corrected here
rather than left as a stale claim.

## Note

`git push -u` reported `could not write config file .git/config: Operation not
permitted`. The branch pushed fine; only the local upstream tracking ref failed
to write. Cause is the macOS `uchg` immutable flag on `.git/config` — apparently
a deliberate lock, given this repo's test suite has previously blanked
`core.hooksPath` by writing to that file. Left alone, not worked around.

https://claude.ai/code/session_01TkKEWX1afF71kRYfFDq11i
